### PR TITLE
Add explicit conda env dependency on pyiron-data

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -11,6 +11,7 @@ dependencies:
 - numpy =1.26.0
 - pyiron_atomistics =0.3.4
 - pyiron_base =0.6.7
+- pyiron-data =0.0.24
 - python-graphviz =0.20.1
 - toposort =1.10
 - typeguard =4.1.5

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - numpy =1.26.0
   - pyiron_atomistics =0.3.4
   - pyiron_base =0.6.7
+  - pyiron-data =0.0.24
   - python-graphviz =0.20.1
   - toposort =1.10
   - typeguard =4.1.5

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -13,6 +13,7 @@ dependencies:
 - numpy =1.26.0
 - pyiron_atomistics =0.3.4
 - pyiron_base =0.6.7
+- pyiron-data =0.0.24
 - python-graphviz =0.20.1
 - toposort =1.10
 - typeguard =4.1.5


### PR DESCRIPTION
This is a necessary dependency for atomistics to work, so it will wind up in the env in the long run anyhow (at least until the node libraries are pulled out of the repo), but its appearance as an _explicit_ dependency is just until it correctly appears as an upstream requirement in pyiron_atomistics. Until then I need this so tests don't break meaninglessly.