### PR TITLE
Allow replacing nodes

### DIFF
--- a/notebooks/workflow_example.ipynb
+++ b/notebooks/workflow_example.ipynb
@@ -634,8 +634,8 @@
     {
      "data": {
       "text/plain": [
-       "array([0.23888392, 0.24728969, 0.2937081 , 0.66902714, 0.47716927,\n",
-       "       0.12469378, 0.36244931, 0.01119268, 0.26370445, 0.84121862])"
+       "array([0.98830723, 0.76898713, 0.05580742, 0.70040889, 0.59265983,\n",
+       "       0.56839124, 0.48762346, 0.90402605, 0.86155979, 0.68738559])"
       ]
      },
      "execution_count": 22,
@@ -644,7 +644,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAAApy0lEQVR4nO3df1Tc1Z3/8dcwBCZmYVxCA6NBgtkYIaxahgUhzXr8EZro0ub07ErXTWLcZFdSrWJWd+VkVyTHc1jb6mq7Qo0mummi5fij3eYspc45u1oi3WVDyDmluNU1dCHJIAdoB1oL6PD5/pHCN5OBhM8E5maY5+Oczx9zuZ+Z95x74ry89/O5H4dlWZYAAAAMSTBdAAAAiG+EEQAAYBRhBAAAGEUYAQAARhFGAACAUYQRAABgFGEEAAAYRRgBAABGJZouYDYmJiZ0+vRppaSkyOFwmC4HAADMgmVZGhkZ0RVXXKGEhJnnP2IijJw+fVpZWVmmywAAABHo7e3V8uXLZ/x7TISRlJQUSWe+TGpqquFqAADAbAwPDysrK2vqd3wmMRFGJpdmUlNTCSMAAMSYC11iwQWsAADAKMIIAAAwijACAACMIowAAACjCCMAAMAowggAADCKMAIAAIwijAAAAKNiYtMzAHMnOGGprXtI/SOjWpbiUlFOmpwJPPMJgDmEESCONHf6VXu4S/7A6FSbx+1STXmeNuR7DFYGIJ6xTAPEieZOv3YePBYSRCSpLzCqnQePqbnTb6gyAPGOMALEgeCEpdrDXbKm+dtkW+3hLgUnpusBAPOLMALEgbbuobAZkbNZkvyBUbV1D0WvKAD4HcIIEAf6R2YOIpH0A4C5RBgB4sCyFNec9gOAuUQYAeJAUU6aPG6XZrqB16Ezd9UU5aRFsywAkEQYAeKCM8GhmvI8SQoLJJOva8rz2G8EgBGEESBObMj3qGFzgTLdoUsxmW6XGjYXsM8IAGPY9AyIIxvyPVqfl8kOrAAuKYQRIM44ExwqWbnUdBkAMIVlGgAAYBRhBAAAGEUYAQAARhFGAACAUYQRAABgFGEEAAAYFVEYqa+vV05Ojlwul7xer1paWs7b/7nnnlNubq4WL16s1atX68CBAxEVCwAAFh7b+4w0NjaqqqpK9fX1Wrt2rZ5//nlt3LhRXV1duuqqq8L6NzQ0qLq6Wi+88IL+6I/+SG1tbfqrv/or/f7v/77Ky8vn5EsAAIDY5bAsy7JzQnFxsQoKCtTQ0DDVlpubq02bNqmuri6sf2lpqdauXauvf/3rU21VVVU6evSojhw5MqvPHB4eltvtViAQUGpqqp1yAQCAIbP9/ba1TDM+Pq729naVlZWFtJeVlam1tXXac8bGxuRyhT4LY/HixWpra9Mnn3wy4znDw8MhBwAAWJhshZGBgQEFg0FlZGSEtGdkZKivr2/acz7/+c/rxRdfVHt7uyzL0tGjR7V//3598sknGhgYmPacuro6ud3uqSMrK8tOmQAAIIZEdAGrwxH6UC3LssLaJv3DP/yDNm7cqBtvvFGLFi3SF7/4RW3btk2S5HQ6pz2nurpagUBg6ujt7Y2kTAAAEANshZH09HQ5nc6wWZD+/v6w2ZJJixcv1v79+/Xxxx/rF7/4hXp6erRixQqlpKQoPT192nOSk5OVmpoacgAAgIXJVhhJSkqS1+uVz+cLaff5fCotLT3vuYsWLdLy5cvldDr13e9+V3/yJ3+ihARz25wEJyz95MNB/evxU/rJh4MKTti6jhcAAMwR27f27tq1S1u2bFFhYaFKSkq0d+9e9fT0qLKyUtKZJZZTp05N7SXy/vvvq62tTcXFxfrlL3+pp59+Wp2dnfqXf/mXuf0mNjR3+lV7uEv+wOhUm8ftUk15njbke4zVBQBAPLIdRioqKjQ4OKg9e/bI7/crPz9fTU1Nys7OliT5/X719PRM9Q8Gg3rqqaf085//XIsWLdLNN9+s1tZWrVixYs6+hB3NnX7tPHhM586D9AVGtfPgMTVsLiCQAAAQRbb3GTFhrvYZCU5Y+tyT/x4yI3I2h6RMt0tH/u4WOROmvyAXAADMzrzsMxLr2rqHZgwikmRJ8gdG1dY9FL2iAACIc3EVRvpHZg4ikfQDAAAXL67CyLIU14U72egHAAAuXlyFkaKcNHncLs10NYhDZ+6qKcpJi2ZZAADEtbgKI84Eh2rK8yQpLJBMvq4pz+PiVQAAoiiuwogkbcj3qGFzgTLdoUsxmW4Xt/UCAGCA7X1GFoIN+R6tz8tUW/eQ+kdGtSzlzNIMMyIAAERfXIYR6cySTcnKpabLAAAg7sXdMg0AALi0EEYAAIBRhBEAAGAUYQQAABhFGAEAAEbF7d00QDQEJyxuIQeACyCMAPOkudOv2sNdIU+K9rhdqinPY3M9ADgLyzTAPGju9GvnwWMhQUSS+gKj2nnwmJo7/YYqA4BLD2EEmGPBCUu1h7tkTfO3ybbaw10KTkzXAwDiD2EEmGNt3UNhMyJnsyT5A6Nq6x6KXlEAcAkjjABzrH9k5iASST8AWOgII8AcW5biunAnG/0AYKEjjABzrCgnTR63SzPdwOvQmbtqinLSolkWAFyyCCPAHHMmOFRTnidJYYFk8nVNeR77jQDA7xBGgHmwId+jhs0FynSHLsVkul1q2FzAPiMAcBY2PQPmyYZ8j9bnZbIDKwBcAGEEmEfOBIdKVi41XQYAXNJYpgEAAEYRRgAAgFGEEQAAYBRhBAAAGEUYAQAARhFGAACAURGFkfr6euXk5Mjlcsnr9aqlpeW8/Q8dOqTrr79el112mTwej+655x4NDg5GVDAAAFhYbIeRxsZGVVVVaffu3ero6NC6deu0ceNG9fT0TNv/yJEj2rp1q7Zv366f/exneu211/Tf//3f2rFjx0UXDwAAYp/tMPL0009r+/bt2rFjh3Jzc/XMM88oKytLDQ0N0/b/z//8T61YsUIPPPCAcnJy9LnPfU733nuvjh49etHFAwCA2GcrjIyPj6u9vV1lZWUh7WVlZWptbZ32nNLSUp08eVJNTU2yLEsfffSRXn/9dd1xxx0zfs7Y2JiGh4dDDgAAsDDZCiMDAwMKBoPKyMgIac/IyFBfX9+055SWlurQoUOqqKhQUlKSMjMzdfnll+tb3/rWjJ9TV1cnt9s9dWRlZdkpEwAAxJCILmB1OEIf9GVZVljbpK6uLj3wwAN67LHH1N7erubmZnV3d6uysnLG96+urlYgEJg6ent7IykTAADEAFsPyktPT5fT6QybBenv7w+bLZlUV1entWvX6pFHHpEkXXfddVqyZInWrVunJ554Qh5P+KPUk5OTlZycbKc0AAAQo2zNjCQlJcnr9crn84W0+3w+lZaWTnvOxx9/rISE0I9xOp2SzsyoAACA+GZ7mWbXrl168cUXtX//fr333nt66KGH1NPTM7XsUl1dra1bt071Ly8v15tvvqmGhgadOHFC7777rh544AEVFRXpiiuumLtvAgAAYpKtZRpJqqio0ODgoPbs2SO/36/8/Hw1NTUpOztbkuT3+0P2HNm2bZtGRkb0z//8z/qbv/kbXX755brlllv05JNPzt23AAAAMcthxcBayfDwsNxutwKBgFJTU02XAwAAZmG2v988mwYAABhFGAEAAEYRRgAAgFGEEQAAYBRhBAAAGEUYAQAARhFGAACAUYQRAABgFGEEAAAYRRgBAABGEUYAAIBRhBEAAGAUYQQAABhFGAEAAEYRRgAAgFGEEQAAYBRhBAAAGEUYAQAARhFGAACAUYQRAABgFGEEAAAYRRgBAABGEUYAAIBRhBEAAGAUYQQAABhFGAEAAEYRRgAAgFGEEQAAYBRhBAAAGEUYAQAARhFGAACAUYQRAABgVERhpL6+Xjk5OXK5XPJ6vWppaZmx77Zt2+RwOMKONWvWRFw0AABYOGyHkcbGRlVVVWn37t3q6OjQunXrtHHjRvX09Ezb/9lnn5Xf7586ent7lZaWpj/7sz+76OIBAEDsc1iWZdk5obi4WAUFBWpoaJhqy83N1aZNm1RXV3fB87///e/rS1/6krq7u5WdnT2rzxweHpbb7VYgEFBqaqqdcgEAgCGz/f22NTMyPj6u9vZ2lZWVhbSXlZWptbV1Vu+xb98+3XbbbecNImNjYxoeHg45AADAwmQrjAwMDCgYDCojIyOkPSMjQ319fRc83+/364c//KF27Nhx3n51dXVyu91TR1ZWlp0yAQBADInoAlaHwxHy2rKssLbpvPzyy7r88su1adOm8/arrq5WIBCYOnp7eyMpEwAAxIBEO53T09PldDrDZkH6+/vDZkvOZVmW9u/fry1btigpKem8fZOTk5WcnGynNAAAEKNszYwkJSXJ6/XK5/OFtPt8PpWWlp733HfeeUf/+7//q+3bt9uvEnMmOGHpJx8O6l+Pn9JPPhxUcMLW9csAAMw5WzMjkrRr1y5t2bJFhYWFKikp0d69e9XT06PKykpJZ5ZYTp06pQMHDoSct2/fPhUXFys/P39uKodtzZ1+1R7ukj8wOtXmcbtUU56nDfkeg5UBAOKZ7TBSUVGhwcFB7dmzR36/X/n5+Wpqapq6O8bv94ftORIIBPTGG2/o2WefnZuqYVtzp187Dx7TufMgfYFR7Tx4TA2bCwgkAAAjbO8zYgL7jFyc4ISlzz357yEzImdzSMp0u3Tk726RM+HCFyIDADAb87LPCGJTW/fQjEFEkixJ/sCo2rqHolcUAAC/QxiJA/0jMweRSPoBADCXCCNxYFmKa077AQAwlwgjcaAoJ00et0szXQ3i0Jm7aopy0qJZFgAAkggjccGZ4FBNeZ4khQWSydc15XlcvAoAMIIwEic25HvUsLlAme7QpZhMt4vbegEARtneZwSxa0O+R+vzMtXWPaT+kVEtSzmzNMOMCADAJMJInHEmOFSycqnpMgAAmMIyDQAAMIowAgAAjCKMAAAAowgjAADAKMIIAAAwijACAACMIowAAACjCCMAAMAowggAADCKMAIAAIwijAAAAKMIIwAAwCjCCAAAMIowAgAAjCKMAAAAowgjAADAKMIIAAAwijACAACMIowAAACjCCMAAMAowggAADCKMAIAAIwijAAAAKMIIwAAwKiIwkh9fb1ycnLkcrnk9XrV0tJy3v5jY2PavXu3srOzlZycrJUrV2r//v0RFQwAABaWRLsnNDY2qqqqSvX19Vq7dq2ef/55bdy4UV1dXbrqqqumPefOO+/URx99pH379ukP/uAP1N/fr08//fSiiwcAALHPYVmWZeeE4uJiFRQUqKGhYaotNzdXmzZtUl1dXVj/5uZmffnLX9aJEyeUlpYWUZHDw8Nyu90KBAJKTU2N6D0AAEB0zfb329Yyzfj4uNrb21VWVhbSXlZWptbW1mnP+cEPfqDCwkJ97Wtf05VXXqlrrrlGDz/8sH7729/O+DljY2MaHh4OOQAAwMJka5lmYGBAwWBQGRkZIe0ZGRnq6+ub9pwTJ07oyJEjcrlc+t73vqeBgQF95Stf0dDQ0IzXjdTV1am2ttZOaQAAIEZFdAGrw+EIeW1ZVljbpImJCTkcDh06dEhFRUW6/fbb9fTTT+vll1+ecXakurpagUBg6ujt7Y2kTAAAEANszYykp6fL6XSGzYL09/eHzZZM8ng8uvLKK+V2u6facnNzZVmWTp48qVWrVoWdk5ycrOTkZDulAQCAGGVrZiQpKUler1c+ny+k3efzqbS0dNpz1q5dq9OnT+vXv/71VNv777+vhIQELV++PIKSAQDAQmJ7mWbXrl168cUXtX//fr333nt66KGH1NPTo8rKSklnlli2bt061f+uu+7S0qVLdc8996irq0s//vGP9cgjj+gv//IvtXjx4rn7JgAAICbZ3mekoqJCg4OD2rNnj/x+v/Lz89XU1KTs7GxJkt/vV09Pz1T/3/u935PP59NXv/pVFRYWaunSpbrzzjv1xBNPzN23AAAAMcv2PiMmsM8IAACxZ172GQEAAJhrhBEAAGAUYQQAABhFGAEAAEYRRgAAgFGEEQAAYJTtfUaAWBScsNTWPaT+kVEtS3GpKCdNzoTpn6cEAIguwggWvOZOv2oPd8kfGJ1q87hdqinP04Z8j8HKAAASyzRY4Jo7/dp58FhIEJGkvsCodh48puZOv6HKAACTCCNYsIITlmoPd2m6LYYn22oPdyk4cclvQgwACxphBAtWW/dQ2IzI2SxJ/sCo2rqHolcUACAMYQQLVv/IzEEkkn4AgPlBGMGCtSzFNaf9AADzgzCCBasoJ00et0sz3cDr0Jm7aopy0qJZFgDgHIQRLFjOBIdqyvMkKSyQTL6uKc9jvxEAMIwwggVtQ75HDZsLlOkOXYrJdLvUsLmAfUYA4BLApmdY8Dbke7Q+L5MdWAHgEkUYQVxwJjhUsnKp6TIAANNgmQYAABhFGAEAAEYRRgAAgFGEEQAAYBRhBAAAGMXdNAAAxKnghHVJbHtAGAEAIA41d/pVe7gr5OnmHrdLNeV5Ud8QkmUaAADiTHOnXzsPHgsJIpLUFxjVzoPH1Nzpj2o9hBEAAOJIcMJS7eEuWdP8bbKt9nCXghPT9ZgfhBEAAOJIW/dQ2IzI2SxJ/sCo2rqHolYTYQQAgDjSPzJzEImk31wgjAAAEEeWpbgu3MlGv7lAGAEAII4U5aTJ43Zppht4HTpzV01RTlrUaooojNTX1ysnJ0cul0ter1ctLS0z9n377bflcDjCjv/5n/+JuGgAABAZZ4JDNeV5khQWSCZf15TnRXW/EdthpLGxUVVVVdq9e7c6Ojq0bt06bdy4UT09Pec97+c//7n8fv/UsWrVqoiLBgAAkduQ71HD5gJlukOXYjLdLjVsLoj6PiMOy7Js3btTXFysgoICNTQ0TLXl5uZq06ZNqqurC+v/9ttv6+abb9Yvf/lLXX755REVOTw8LLfbrUAgoNTU1IjeAwAAhJrvHVhn+/tta2ZkfHxc7e3tKisrC2kvKytTa2vrec/97Gc/K4/Ho1tvvVX/8R//YedjAQDAPHAmOFSycqm+eMOVKlm51MhW8JLN7eAHBgYUDAaVkZER0p6RkaG+vr5pz/F4PNq7d6+8Xq/Gxsb0ne98R7feeqvefvtt/fEf//G054yNjWlsbGzq9fDwsJ0yAQBADIno2TQOR2hysiwrrG3S6tWrtXr16qnXJSUl6u3t1Te+8Y0Zw0hdXZ1qa2sjKQ0AAMQYW8s06enpcjqdYbMg/f39YbMl53PjjTfqgw8+mPHv1dXVCgQCU0dvb6+dMgEAQAyxFUaSkpLk9Xrl8/lC2n0+n0pLS2f9Ph0dHfJ4Zr5SNzk5WampqSEHAABYmGwv0+zatUtbtmxRYWGhSkpKtHfvXvX09KiyslLSmVmNU6dO6cCBA5KkZ555RitWrNCaNWs0Pj6ugwcP6o033tAbb7wxt98EAADEJNthpKKiQoODg9qzZ4/8fr/y8/PV1NSk7OxsSZLf7w/Zc2R8fFwPP/ywTp06pcWLF2vNmjX6t3/7N91+++1z9y0AAEDMsr3PiAnsMwIAQOyZl31GAAAA5hphBAAAGEUYAQAARhFGAACAUYQRAABgFGEEAAAYRRgBAABGEUYAAIBRhBEAAGAUYQQAABhFGAEAAEYRRgAAgFGEEQAAYBRhBAAAGEUYAQAARhFGAACAUYQRAABgFGEEAAAYRRgBAABGEUYAAIBRhBEAAGAUYQQAABhFGAEAAEYRRgAAgFGEEQAAYFSi6QIAIFqCE5bauofUPzKqZSkuFeWkyZngMF0WEPcIIwDiQnOnX7WHu+QPjE61edwu1ZTnaUO+x2BlAFimAbDgNXf6tfPgsZAgIkl9gVHtPHhMzZ1+Q5UBkAgjABa44ISl2sNdsqb522Rb7eEuBSem6wEgGggjABa0tu6hsBmRs1mS/IFRtXUPRa8oACEIIwAWtP6RmYNIJP0AzD3CCIAFbVmKa077AZh7EYWR+vp65eTkyOVyyev1qqWlZVbnvfvuu0pMTNQNN9wQyccCgG1FOWnyuF2a6QZeh87cVVOUkxbNsgCcxXYYaWxsVFVVlXbv3q2Ojg6tW7dOGzduVE9Pz3nPCwQC2rp1q2699daIiwUAu5wJDtWU50lSWCCZfF1Tnsd+I4BBDsuybF1CXlxcrIKCAjU0NEy15ebmatOmTaqrq5vxvC9/+ctatWqVnE6nvv/97+v48eOz/szh4WG53W4FAgGlpqbaKRcAJLHPCGDCbH+/bW16Nj4+rvb2dj366KMh7WVlZWptbZ3xvJdeekkffvihDh48qCeeeOKCnzM2NqaxsbGp18PDw3bKBIAwG/I9Wp+XyQ6swCXIVhgZGBhQMBhURkZGSHtGRob6+vqmPeeDDz7Qo48+qpaWFiUmzu7j6urqVFtba6c0ALggZ4JDJSuXmi4DwDkiuoDV4Qj9PwnLssLaJCkYDOquu+5SbW2trrnmmlm/f3V1tQKBwNTR29sbSZkAACAG2JoZSU9Pl9PpDJsF6e/vD5stkaSRkREdPXpUHR0duv/++yVJExMTsixLiYmJeuutt3TLLbeEnZecnKzk5GQ7pQEAgBhla2YkKSlJXq9XPp8vpN3n86m0tDSsf2pqqn7605/q+PHjU0dlZaVWr16t48ePq7i4+OKqBwAAMc/2U3t37dqlLVu2qLCwUCUlJdq7d696enpUWVkp6cwSy6lTp3TgwAElJCQoPz8/5Pxly5bJ5XKFtQMAgPhkO4xUVFRocHBQe/bskd/vV35+vpqampSdnS1J8vv9F9xzBAAAYJLtfUZMYJ8RAABiz2x/v3k2DQAAMIowAgAAjCKMAAAAowgjAADAKMIIAAAwijACAACMIowAAACjCCMAAMAowggAADCKMAIAAIwijAAAAKMIIwAAwCjCCAAAMIowAgAAjCKMAAAAowgjAADAKMIIAAAwijACAACMIowAAACjCCMAAMAowggAADAq0XQBAABIUnDCUlv3kPpHRrUsxaWinDQ5Exymy0IUEEYAAMY1d/pVe7hL/sDoVJvH7VJNeZ425HsMVoZoYJkGAGBUc6dfOw8eCwkiktQXGNXOg8fU3Ok3VBmihTACADAmOGGp9nCXrGn+NtlWe7hLwYnpemChIIwAAIxp6x4KmxE5myXJHxhVW/dQ9IpC1BFGAADG9I/MHEQi6YfYRBgBABizLMU1p/0QmwgjAABjinLS5HG7NNMNvA6duaumKCctmmUhyggjAABjnAkO1ZTnSVJYIJl8XVOex34jCxxhBABg1IZ8jxo2FyjTHboUk+l2qWFzAfuMxAE2PQMAGLch36P1eZnswBqnIpoZqa+vV05Ojlwul7xer1paWmbse+TIEa1du1ZLly7V4sWLde211+qf/umfIi4YALAwORMcKlm5VF+84UqVrFxKEIkjtmdGGhsbVVVVpfr6eq1du1bPP/+8Nm7cqK6uLl111VVh/ZcsWaL7779f1113nZYsWaIjR47o3nvv1ZIlS/TXf/3Xc/IlAABA7HJYlmVrW7vi4mIVFBSooaFhqi03N1ebNm1SXV3drN7jS1/6kpYsWaLvfOc7s+o/PDwst9utQCCg1NRUO+UCAABDZvv7bWuZZnx8XO3t7SorKwtpLysrU2tr66zeo6OjQ62trbrppptm7DM2Nqbh4eGQAwAALEy2wsjAwICCwaAyMjJC2jMyMtTX13fec5cvX67k5GQVFhbqvvvu044dO2bsW1dXJ7fbPXVkZWXZKRMAAMSQiC5gdThCLyqyLCus7VwtLS06evSovv3tb+uZZ57Rq6++OmPf6upqBQKBqaO3tzeSMgEAQAywdQFrenq6nE5n2CxIf39/2GzJuXJyciRJf/iHf6iPPvpIjz/+uP78z/982r7JyclKTk62UxoAAIhRtmZGkpKS5PV65fP5Qtp9Pp9KS0tn/T6WZWlsbMzORwMAgAXK9q29u3bt0pYtW1RYWKiSkhLt3btXPT09qqyslHRmieXUqVM6cOCAJOm5557TVVddpWuvvVbSmX1HvvGNb+irX/3qHH4NAAAQq2yHkYqKCg0ODmrPnj3y+/3Kz89XU1OTsrOzJUl+v189PT1T/ScmJlRdXa3u7m4lJiZq5cqV+sd//Efde++9c/ctAABAzLK9z4gJ7DMCAEDsmZd9RgAAAOYaYQQAABhFGAEAAEYRRgAAgFGEEQAAYBRhBAAAGEUYAQAARhFGAACAUYQRAABglO3t4IF4Epyw1NY9pP6RUS1LcakoJ03OBIfpsgBgQSGMADNo7vSr9nCX/IHRqTaP26Wa8jxtyPcYrAwAFhaWaYBpNHf6tfPgsZAgIkl9gVHtPHhMzZ1+Q5UBwMJDGAHOEZywVHu4S9M9QXKyrfZwl4ITl/wzJgEgJhBGgHO0dQ+FzYiczZLkD4yqrXsoekUBwAJGGAHO0T8ycxCJpB8A4PwII8A5lqW45rQfAOD8CCPAOYpy0uRxuzTTDbwOnbmrpignLZplAcCCRRgBzuFMcKimPE+SwgLJ5Oua8jz2GwGAOUIYAaaxId+jhs0FynSHLsVkul1q2FzAPiMAMIfY9AyYwYZ8j9bnZbIDKwDMM8IIcB7OBIdKVi41XQYALGgs0wAAAKMIIwAAwCjCCAAAMIowAgAAjCKMAAAAowgjAADAKMIIAAAwijACAACMIowAAACjCCMAAMAowggAADAqojBSX1+vnJwcuVwueb1etbS0zNj3zTff1Pr16/WZz3xGqampKikp0Y9+9KOICwYAAAuL7TDS2Nioqqoq7d69Wx0dHVq3bp02btyonp6eafv/+Mc/1vr169XU1KT29nbdfPPNKi8vV0dHx0UXDwAAYp/DsizLzgnFxcUqKChQQ0PDVFtubq42bdqkurq6Wb3HmjVrVFFRoccee2xW/YeHh+V2uxUIBJSammqnXAAAYMhsf79tzYyMj4+rvb1dZWVlIe1lZWVqbW2d1XtMTExoZGREaWlpM/YZGxvT8PBwyAEAABYmW2FkYGBAwWBQGRkZIe0ZGRnq6+ub1Xs89dRT+s1vfqM777xzxj51dXVyu91TR1ZWlp0yAQBADInoAlaHwxHy2rKssLbpvPrqq3r88cfV2NioZcuWzdivurpagUBg6ujt7Y2kTAAAEAMS7XROT0+X0+kMmwXp7+8Pmy05V2Njo7Zv367XXntNt91223n7JicnKzk52U5pAAAgRtmaGUlKSpLX65XP5wtp9/l8Ki0tnfG8V199Vdu2bdMrr7yiO+64I7JKAQDAgmRrZkSSdu3apS1btqiwsFAlJSXau3evenp6VFlZKenMEsupU6d04MABSWeCyNatW/Xss8/qxhtvnJpVWbx4sdxu9xx+FQAAEItsh5GKigoNDg5qz5498vv9ys/PV1NTk7KzsyVJfr8/ZM+R559/Xp9++qnuu+8+3XfffVPtd999t15++eWL/wYAACCm2d5nxAT2GQEAIPbMyz4jAAAAc40wAgAAjCKMAAAAowgjAADAKMIIAAAwijACAACMIowAAACjCCMAAMAo2zuwAgtFcMJSW/eQ+kdGtSzFpaKcNDkTLvz0aQDA3CKMIC41d/pVe7hL/sDoVJvH7VJNeZ425HsMVgYA8YdlGsSd5k6/dh48FhJEJKkvMKqdB4+pudNvqDIAiE+EEcSV4ISl2sNdmu6BTJNttYe7FJy45B/ZBAALBmEEcaWteyhsRuRsliR/YFRt3UPRKwoA4hxhBHGlf2TmIBJJPwDAxSOMIK4sS3HNaT8AwMUjjCCuFOWkyeN2aaYbeB06c1dNUU5aNMsCgLhGGEFccSY4VFOeJ0lhgWTydU15HvuNAEAUEUYQdzbke9SwuUCZ7tClmEy3Sw2bC9hnBACijE3PEJc25Hu0Pi+THVgB4BJAGEHcciY4VLJyqekyACDusUwDAACMIowAAACjCCMAAMAowggAADCKMAIAAIwijAAAAKMIIwAAwCjCCAAAMIowAgAAjIqJHVgty5IkDQ8PG64EAADM1uTv9uTv+ExiIoyMjIxIkrKysgxXAgAA7BoZGZHb7Z7x7w7rQnHlEjAxMaHTp08rJSVFDof9B5kNDw8rKytLvb29Sk1NnYcKMdcYs9jDmMUWxiv2xOKYWZalkZERXXHFFUpImPnKkJiYGUlISNDy5csv+n1SU1NjZgBxBmMWexiz2MJ4xZ5YG7PzzYhM4gJWAABgFGEEAAAYFRdhJDk5WTU1NUpOTjZdCmaJMYs9jFlsYbxiz0Ies5i4gBUAACxccTEzAgAALl2EEQAAYBRhBAAAGEUYAQAARi2YMFJfX6+cnBy5XC55vV61tLSct/8777wjr9crl8ulq6++Wt/+9rejVCkm2RmzN998U+vXr9dnPvMZpaamqqSkRD/60Y+iWC3s/hub9O677yoxMVE33HDD/BaIMHbHbGxsTLt371Z2draSk5O1cuVK7d+/P0rVQrI/ZocOHdL111+vyy67TB6PR/fcc48GBwejVO0cshaA7373u9aiRYusF154werq6rIefPBBa8mSJdb//d//Tdv/xIkT1mWXXWY9+OCDVldXl/XCCy9YixYtsl5//fUoVx6/7I7Zgw8+aD355JNWW1ub9f7771vV1dXWokWLrGPHjkW58vhkd7wm/epXv7Kuvvpqq6yszLr++uujUywsy4pszL7whS9YxcXFls/ns7q7u63/+q//st59990oVh3f7I5ZS0uLlZCQYD377LPWiRMnrJaWFmvNmjXWpk2bolz5xVsQYaSoqMiqrKwMabv22mutRx99dNr+f/u3f2tde+21IW333nuvdeONN85bjQhld8ymk5eXZ9XW1s51aZhGpONVUVFh/f3f/71VU1NDGIkyu2P2wx/+0HK73dbg4GA0ysM07I7Z17/+devqq68OafvmN79pLV++fN5qnC8xv0wzPj6u9vZ2lZWVhbSXlZWptbV12nN+8pOfhPX//Oc/r6NHj+qTTz6Zt1pxRiRjdq6JiQmNjIwoLS1tPkrEWSIdr5deekkffvihampq5rtEnCOSMfvBD36gwsJCfe1rX9OVV16pa665Rg8//LB++9vfRqPkuBfJmJWWlurkyZNqamqSZVn66KOP9Prrr+uOO+6IRslzKiYelHc+AwMDCgaDysjICGnPyMhQX1/ftOf09fVN2//TTz/VwMCAPB7PvNWLyMbsXE899ZR+85vf6M4775yPEnGWSMbrgw8+0KOPPqqWlhYlJsb8f2ZiTiRjduLECR05ckQul0vf+973NDAwoK985SsaGhriupEoiGTMSktLdejQIVVUVGh0dFSffvqpvvCFL+hb3/pWNEqeUzE/MzLJ4XCEvLYsK6ztQv2na8f8sTtmk1599VU9/vjjamxs1LJly+arPJxjtuMVDAZ11113qba2Vtdcc020ysM07Pwbm5iYkMPh0KFDh1RUVKTbb79dTz/9tF5++WVmR6LIzph1dXXpgQce0GOPPab29nY1Nzeru7tblZWV0Sh1TsX8/7Kkp6fL6XSGJcf+/v6whDkpMzNz2v6JiYlaunTpvNWKMyIZs0mNjY3avn27XnvtNd12223zWSZ+x+54jYyM6OjRo+ro6ND9998v6cwPnWVZSkxM1FtvvaVbbrklKrXHq0j+jXk8Hl155ZUhj3vPzc2VZVk6efKkVq1aNa81x7tIxqyurk5r167VI488Ikm67rrrtGTJEq1bt05PPPFETM3yx/zMSFJSkrxer3w+X0i7z+dTaWnptOeUlJSE9X/rrbdUWFioRYsWzVutOCOSMZPOzIhs27ZNr7zySkyuicYqu+OVmpqqn/70pzp+/PjUUVlZqdWrV+v48eMqLi6OVulxK5J/Y2vXrtXp06f161//eqrt/fffV0JCgpYvXz6v9SKyMfv444+VkBD6M+50OiX9/9n+mGHqytm5NHk71L59+6yuri6rqqrKWrJkifWLX/zCsizLevTRR60tW7ZM9Z+8tfehhx6yurq6rH379nFrb5TZHbNXXnnFSkxMtJ577jnL7/dPHb/61a9MfYW4Yne8zsXdNNFnd8xGRkas5cuXW3/6p39q/exnP7Peeecda9WqVdaOHTtMfYW4Y3fMXnrpJSsxMdGqr6+3PvzwQ+vIkSNWYWGhVVRUZOorRGxBhBHLsqznnnvOys7OtpKSkqyCggLrnXfemfrb3Xffbd10000h/d9++23rs5/9rJWUlGStWLHCamhoiHLFsDNmN910kyUp7Lj77rujX3icsvtv7GyEETPsjtl7771n3XbbbdbixYut5cuXW7t27bI+/vjjKFcd3+yO2Te/+U0rLy/PWrx4seXxeKy/+Iu/sE6ePBnlqi+ew7JibS4HAAAsJDF/zQgAAIhthBEAAGAUYQQAABhFGAEAAEYRRgAAgFGEEQAAYBRhBAAAGEUYAQAARhFGAACAUYQRAABgFGEEAAAYRRgBAABG/T8nSJ5zOJcZ9gAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAg20lEQVR4nO3de2zV9f3H8ddpS3uU0WMK0h6g1sJAWxvRlhRbRtycVNDUH8kWahyiDhOLc9ymC4zFWmLW6CZxXlqdcskCssbrJOkq/WODcpkMaBPxkGigsyCnNm3j6fFSkPbz+4Nf+/PQFnsOp+fTc87zkZyQ8+nne877nG9oX+f7+X7fx2GMMQIAALAkwXYBAAAgvhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFiVZLuAkejr69OZM2c0YcIEORwO2+UAAIARMMbI7/drypQpSkgY/vhHVISRM2fOKDMz03YZAAAgBKdOndK0adOG/XlUhJEJEyZIuvBiUlNTLVcDAABGoru7W5mZmQN/x4cTFWGkf2kmNTWVMAIAQJT5vlMsOIEVAABYRRgBAABWEUYAAIBVhBEAAGBV0GFk7969Ki0t1ZQpU+RwOPTuu+9+7zZ79uxRQUGBnE6npk+frpdffjmUWgEAQAwKOox89dVXmj17tl588cURzW9padGdd96p+fPnq6mpSb/73e+0cuVKvfXWW0EXCwAAYk/Ql/YuWrRIixYtGvH8l19+Wddcc42ee+45SVJOTo4OHz6sP/3pT/rZz34W7NMDAIAYM+rnjBw8eFAlJSUBY3fccYcOHz6sb7/9dshtzp49q+7u7oAbAACITaMeRtra2pSenh4wlp6ervPnz6ujo2PIbaqqquRyuQZutIIHACD8evuMDp7o1N+bP9PBE53q7TNW6ohIB9aLO68ZY4Yc77d+/XqtXbt24H5/O1kAABAe9ce8qtzlkdfXMzDmdjlVUZqrhXnuiNYy6kdGMjIy1NbWFjDW3t6upKQkTZw4cchtUlJSBlq/0wIeAIDwqj/m1YrtRwOCiCS1+Xq0YvtR1R/zRrSeUQ8jRUVFamhoCBjbvXu35syZo3Hjxo320wMAgO/o7TOq3OXRUAsy/WOVuzwRXbIJOox8+eWXam5uVnNzs6QLl+42NzertbVV0oUllmXLlg3MLy8v16effqq1a9fq+PHj2rJlizZv3qzHHnssPK8AAACM2KGWrkFHRL7LSPL6enSopStiNQV9zsjhw4f1k5/8ZOB+/7kd999/v7Zt2yav1zsQTCQpOztbdXV1WrNmjV566SVNmTJFzz//PJf1AgBgQbt/+CASyrxwCDqM/PjHPx44AXUo27ZtGzR266236ujRo8E+FQAACLPJE5xhnRcOfDcNAABxpDA7TW6XU0Nfzyo5dOGqmsLstIjVRBgBACCOJCY4VFGaK0mDAkn//YrSXCUmDBdXwo8wAgBAnFmY51bN0nxluAKXYjJcTtUszY94n5GIND0DAABjy8I8txbkZuhQS5fa/T2aPOHC0kwkj4j0I4wAABCnEhMcKpoxdAPSSGKZBgAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYlWS7AAAAYlVvn9Ghli61+3s0eYJThdlpSkxw2C5rzCGMAAAwCuqPeVW5yyOvr2dgzO1yqqI0Vwvz3BYrG3tYpgEAIMzqj3m1YvvRgCAiSW2+Hq3YflT1x7yWKhubCCMAAIRRb59R5S6PzBA/6x+r3OVRb99QM+ITYQQAgDA61NI16IjIdxlJXl+PDrV0Ra6oMY4wAgBAGLX7hw8iocyLB4QRAADCaPIEZ1jnxQPCCAAAYVSYnSa3y6nhLuB16MJVNYXZaZEsa0wjjAAAEEaJCQ5VlOZK0qBA0n+/ojSXfiPfQRgBACDMFua5VbM0XxmuwKWYDJdTNUvz6TNyEZqeAQAwChbmubUgN4MOrCNAGAEQ92jZjdGSmOBQ0YyJtssY8wgjAOIaLbsB+zhnBEDcomU3MDYQRgDEJVp2A2MHYQRAXKJlNzB2EEYAxCVadgNjR0hhpLq6WtnZ2XI6nSooKFBjY+Ml5+/YsUOzZ8/WlVdeKbfbrQcffFCdnZ0hFQwA4UDLbmDsCDqM1NbWavXq1dqwYYOampo0f/58LVq0SK2trUPO37dvn5YtW6bly5fro48+0htvvKH//Oc/euihhy67eAAIFS27gbEj6DCyadMmLV++XA899JBycnL03HPPKTMzUzU1NUPO//e//61rr71WK1euVHZ2tn70ox/p4Ycf1uHDhy+7eAAIFS27gbEjqDBy7tw5HTlyRCUlJQHjJSUlOnDgwJDbFBcX6/Tp06qrq5MxRp9//rnefPNN3XXXXcM+z9mzZ9Xd3R1wA4Bwo2U3MDYE1fSso6NDvb29Sk9PDxhPT09XW1vbkNsUFxdrx44dKisrU09Pj86fP6+7775bL7zwwrDPU1VVpcrKymBKA4CQ0LIbsC+kE1gdjsD/pMaYQWP9PB6PVq5cqSeeeEJHjhxRfX29WlpaVF5ePuzjr1+/Xj6fb+B26tSpUMoEgBHpb9n9PzdNVdGMiQQRIMKCOjIyadIkJSYmDjoK0t7ePuhoSb+qqirNmzdPjz/+uCTpxhtv1Pjx4zV//nw99dRTcrsHHwZNSUlRSkpKMKUBAIAoFdSRkeTkZBUUFKihoSFgvKGhQcXFxUNu8/XXXyshIfBpEhMTJV04ogIAAOJb0Ms0a9eu1WuvvaYtW7bo+PHjWrNmjVpbWweWXdavX69ly5YNzC8tLdXbb7+tmpoanTx5Uvv379fKlStVWFioKVOmhO+VAACAqBT0t/aWlZWps7NTGzdulNfrVV5enurq6pSVlSVJ8nq9AT1HHnjgAfn9fr344ov6zW9+o6uuukq33Xabnn766fC9CgAALlNvn+FEZkscJgrWSrq7u+VyueTz+ZSammq7HABAjKk/5lXlLk/A9xW5XU5VlOZyifdlGOnfb76bBgAQ1+qPebVi+9FBX5zY5uvRiu1HVX/Ma6my+EEYAQDErd4+o8pdHg21RNA/VrnLo96+Mb+IENUIIwCAuHWopWvQEZHvMpK8vh4daumKXFFxiDACAIhb7f7hg0go8xAawggAIG5NnuD8/klBzENoCCMAgLhVmJ0mt8s56Jub+zl04aqawuy0SJYVdwgjAIC4lZjgUEVpriQNCiT99ytKc+k3MsoIIwCAuLYwz62apfnKcAUuxWS4nKpZmk+fkQgIugMrAACxZmGeWwtyM+jAaglhBAAAXViyKZox0XYZcYllGgAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVSGFkerqamVnZ8vpdKqgoECNjY2XnH/27Flt2LBBWVlZSklJ0YwZM7Rly5aQCgYAALElKdgNamtrtXr1alVXV2vevHl65ZVXtGjRInk8Hl1zzTVDbrNkyRJ9/vnn2rx5s374wx+qvb1d58+fv+ziAQBA9HMYY0wwG8ydO1f5+fmqqakZGMvJydHixYtVVVU1aH59fb3uuecenTx5UmlpaSEV2d3dLZfLJZ/Pp9TU1JAeAwAARNZI/34HtUxz7tw5HTlyRCUlJQHjJSUlOnDgwJDbvPfee5ozZ46eeeYZTZ06VbNmzdJjjz2mb775ZtjnOXv2rLq7uwNuAAAgNgW1TNPR0aHe3l6lp6cHjKenp6utrW3IbU6ePKl9+/bJ6XTqnXfeUUdHhx555BF1dXUNe95IVVWVKisrgykNAABEqZBOYHU4HAH3jTGDxvr19fXJ4XBox44dKiws1J133qlNmzZp27Ztwx4dWb9+vXw+38Dt1KlToZQJAACiQFBHRiZNmqTExMRBR0Ha29sHHS3p53a7NXXqVLlcroGxnJwcGWN0+vRpzZw5c9A2KSkpSklJCaY0AAAQpYI6MpKcnKyCggI1NDQEjDc0NKi4uHjIbebNm6czZ87oyy+/HBj7+OOPlZCQoGnTpoVQMgAAiCVBL9OsXbtWr732mrZs2aLjx49rzZo1am1tVXl5uaQLSyzLli0bmH/vvfdq4sSJevDBB+XxeLR37149/vjj+uUvf6krrrgifK8EAABEpaD7jJSVlamzs1MbN26U1+tVXl6e6urqlJWVJUnyer1qbW0dmP+DH/xADQ0N+vWvf605c+Zo4sSJWrJkiZ566qnwvQoAABC1gu4zYgN9RgAAiD6j0mcEAAAg3AgjAADAKsIIAACwijACAACsIowAAACrgr60FwDGut4+o0MtXWr392jyBKcKs9OUmDD0V1YAsI8wAiCm1B/zqnKXR15fz8CY2+VURWmuFua5LVYGYDgs0wCIGfXHvFqx/WhAEJGkNl+PVmw/qvpjXkuVAbgUwgiAmNDbZ1S5y6Ohujj2j1Xu8qi3b8z3eQTiDmEEQEw41NI16IjIdxlJXl+PDrV0Ra4oACNCGAEQE9r9wweRUOYBiBzCCICYMHmCM6zzAEQOYQRATCjMTpPb5dRwF/A6dOGqmsLstEiWBWAECCMAYkJigkMVpbmSNCiQ9N+vKM2l3wgwBhFGAMSMhXlu1SzNV4YrcCkmw+VUzdJ8+owAYxRNzwDElIV5bi3IzaADKxBFCCMAYk5igkNFMybaLgPACLFMAwAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKtCCiPV1dXKzs6W0+lUQUGBGhsbR7Td/v37lZSUpJtuuimUpwUAADEo6DBSW1ur1atXa8OGDWpqatL8+fO1aNEitba2XnI7n8+nZcuW6ac//WnIxQIAgNjjMMaYYDaYO3eu8vPzVVNTMzCWk5OjxYsXq6qqatjt7rnnHs2cOVOJiYl699131dzcPOLn7O7ulsvlks/nU2pqajDlAgAAS0b69zuoIyPnzp3TkSNHVFJSEjBeUlKiAwcODLvd1q1bdeLECVVUVIzoec6ePavu7u6AGwAAiE1BhZGOjg719vYqPT09YDw9PV1tbW1DbvPJJ59o3bp12rFjh5KSkkb0PFVVVXK5XAO3zMzMYMoEAABRJKQTWB0OR8B9Y8ygMUnq7e3Vvffeq8rKSs2aNWvEj79+/Xr5fL6B26lTp0IpEwAARIGRHar4P5MmTVJiYuKgoyDt7e2DjpZIkt/v1+HDh9XU1KRHH31UktTX1ydjjJKSkrR7927ddtttg7ZLSUlRSkpKMKUBAIAoFdSRkeTkZBUUFKihoSFgvKGhQcXFxYPmp6am6sMPP1Rzc/PArby8XNddd52am5s1d+7cy6seAABEvaCOjEjS2rVrdd9992nOnDkqKirSX/7yF7W2tqq8vFzShSWWzz77TH/961+VkJCgvLy8gO0nT54sp9M5aBwAAMSnoMNIWVmZOjs7tXHjRnm9XuXl5amurk5ZWVmSJK/X+709RwAAAPoF3WfEBvqMAAAQfUalzwgAAEC4EUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGBVSGGkurpa2dnZcjqdKigoUGNj47Bz3377bS1YsEBXX321UlNTVVRUpPfffz/kggEAl9bbZ3TwRKf+3vyZDp7oVG+fsV0ScElJwW5QW1ur1atXq7q6WvPmzdMrr7yiRYsWyePx6Jprrhk0f+/evVqwYIH+8Ic/6KqrrtLWrVtVWlqqDz74QDfffHNYXgQA4IL6Y15V7vLI6+sZGHO7nKoozdXCPLfFyoDhOYwxQUXmuXPnKj8/XzU1NQNjOTk5Wrx4saqqqkb0GDfccIPKysr0xBNPjGh+d3e3XC6XfD6fUlNTgykXAOJG/TGvVmw/qot/qTv+79+apfkEEkTUSP9+B7VMc+7cOR05ckQlJSUB4yUlJTpw4MCIHqOvr09+v19paWnDzjl79qy6u7sDbgCA4fX2GVXu8gwKIpIGxip3eViywZgUVBjp6OhQb2+v0tPTA8bT09PV1tY2osd49tln9dVXX2nJkiXDzqmqqpLL5Rq4ZWZmBlMmAMSdQy1dAUszFzOSvL4eHWrpilxRwAiFdAKrw+EIuG+MGTQ2lJ07d+rJJ59UbW2tJk+ePOy89evXy+fzDdxOnToVSpkAEDfa/cMHkVDmAZEU1AmskyZNUmJi4qCjIO3t7YOOllystrZWy5cv1xtvvKHbb7/9knNTUlKUkpISTGkAENcmT3CGdR4QSUEdGUlOTlZBQYEaGhoCxhsaGlRcXDzsdjt37tQDDzyg119/XXfddVdolQIAhlWYnSa3y6nhjlE7dOGqmsLs4c/XA2wJeplm7dq1eu2117RlyxYdP35ca9asUWtrq8rLyyVdWGJZtmzZwPydO3dq2bJlevbZZ3XLLbeora1NbW1t8vl84XsVABDnEhMcqijNlaRBgaT/fkVprhITvn9JHYi0oMNIWVmZnnvuOW3cuFE33XST9u7dq7q6OmVlZUmSvF6vWltbB+a/8sorOn/+vH71q1/J7XYP3FatWhW+VwEA0MI8t2qW5ivDFbgUk+FyclkvxrSg+4zYQJ8RABi53j6jQy1davf3aPKEC0szkT4iMhZqgH0j/fsddAdWAMDYlpjgUNGMidaeny6wCBZflAcACJv+LrAX9zxp8/Voxfajqj/mtVQZxjLCCAAgLOgCi1ARRgAAYUEXWISKMAIACAu6wCJUhBEAQFjQBRahIowAAMKCLrAIFWEEABAWdIFFqAgjAICwoQssQkHTMwBAWC3Mc2tBbgYdWDFihBEAQNjZ7gKL6MIyDQAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCq+KA9ASHr7DN/KCiAsCCMAglZ/zKvKXR55fT0DY26XUxWluVqY57ZYGYBoxDINgKDUH/NqxfajAUFEktp8PVqx/ajqj3ktVQYgWhFGAIxYb59R5S6PzBA/6x+r3OVRb99QMwBgaIQRACN2qKVr0BGR7zKSvL4eHWrpilxRAKIeYQTAiLX7hw8iocwDAIkwAiAIkyc4wzoPACTCCIAgFGanye1yargLeB26cFVNYXZaJMsCEOUIIwBGLDHBoYrSXEkaFEj671eU5tJvBEBQCCMAgrIwz62apfnKcAUuxWS4nKpZmk+fkQjq7TM6eKJTf2/+TAdPdHIVE6IWTc8ABG1hnlsLcjPowGoRjecQSxzGmDEfpbu7u+VyueTz+ZSamhqWx6SVNYBo1d947uJf3v2/wThChbFipH+/4/LICJ8oAESr72s859CFxnMLcjP4gIWoEXfnjNDKGkA0o/EcYlFchRFaWQOIdjSeQyyKqzDCJwoA0Y7Gc4hFcRVG+EQBINrReA6xKK7CCJ8oAEQ7Gs8hFsVVGOETBYBYQOM5xJq4urS3/xPFiu1H5ZACTmTlEwWAaELjOcSSuGx6Rp8RAABGH03PLoFPFAAAjB1xGUakC0s2RTMm2i4DAIC4F1cnsAIAgLGHMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwKio6sPZ/fU53d7flSgAAwEj1/93+vq/Bi4ow4vf7JUmZmZmWKwEAAMHy+/1yuVzD/jwqvrW3r69PZ86c0YQJE+Rw8GV2o627u1uZmZk6depUWL4lGcFjH9jHPrCL99++cOwDY4z8fr+mTJmihIThzwyJiiMjCQkJmjZtmu0y4k5qaiq/BCxjH9jHPrCL99++y90Hlzoi0o8TWAEAgFWEEQAAYBVhBIOkpKSooqJCKSkptkuJW+wD+9gHdvH+2xfJfRAVJ7ACAIDYxZERAABgFWEEAABYRRgBAABWEUYAAIBVhJE4VV1drezsbDmdThUUFKixsXHYuW+//bYWLFigq6++WqmpqSoqKtL7778fwWpjUzD74Lv279+vpKQk3XTTTaNbYIwL9v0/e/asNmzYoKysLKWkpGjGjBnasmVLhKqNTcHugx07dmj27Nm68sor5Xa79eCDD6qzszNC1caWvXv3qrS0VFOmTJHD4dC77777vdvs2bNHBQUFcjqdmj59ul5++eXwFWQQd/72t7+ZcePGmVdffdV4PB6zatUqM378ePPpp58OOX/VqlXm6aefNocOHTIff/yxWb9+vRk3bpw5evRohCuPHcHug35ffPGFmT59uikpKTGzZ8+OTLExKJT3/+677zZz5841DQ0NpqWlxXzwwQdm//79Eaw6tgS7DxobG01CQoL585//bE6ePGkaGxvNDTfcYBYvXhzhymNDXV2d2bBhg3nrrbeMJPPOO+9ccv7JkyfNlVdeaVatWmU8Ho959dVXzbhx48ybb74ZlnoII3GosLDQlJeXB4xdf/31Zt26dSN+jNzcXFNZWRnu0uJGqPugrKzM/P73vzcVFRWEkcsQ7Pv/j3/8w7hcLtPZ2RmJ8uJCsPvgj3/8o5k+fXrA2PPPP2+mTZs2ajXGi5GEkd/+9rfm+uuvDxh7+OGHzS233BKWGlimiTPnzp3TkSNHVFJSEjBeUlKiAwcOjOgx+vr65Pf7lZaWNholxrxQ98HWrVt14sQJVVRUjHaJMS2U9/+9997TnDlz9Mwzz2jq1KmaNWuWHnvsMX3zzTeRKDnmhLIPiouLdfr0adXV1ckYo88//1xvvvmm7rrrrkiUHPcOHjw4aH/dcccdOnz4sL799tvLfvyo+KI8hE9HR4d6e3uVnp4eMJ6enq62trYRPcazzz6rr776SkuWLBmNEmNeKPvgk08+0bp169TY2KikJP7bXo5Q3v+TJ09q3759cjqdeuedd9TR0aFHHnlEXV1dnDcSglD2QXFxsXbs2KGysjL19PTo/Pnzuvvuu/XCCy9EouS419bWNuT+On/+vDo6OuR2uy/r8TkyEqccDkfAfWPMoLGh7Ny5U08++aRqa2s1efLk0SovLox0H/T29uree+9VZWWlZs2aFanyYl4w/wf6+vrkcDi0Y8cOFRYW6s4779SmTZu0bds2jo5chmD2gcfj0cqVK/XEE0/oyJEjqq+vV0tLi8rLyyNRKjT0/hpqPBR8xIozkyZNUmJi4qBPH+3t7YNS78Vqa2u1fPlyvfHGG7r99ttHs8yYFuw+8Pv9Onz4sJqamvToo49KuvDH0RijpKQk7d69W7fddltEao8FofwfcLvdmjp1asBXoefk5MgYo9OnT2vmzJmjWnOsCWUfVFVVad68eXr88cclSTfeeKPGjx+v+fPn66mnnrrsT+a4tIyMjCH3V1JSkiZOnHjZj8+RkTiTnJysgoICNTQ0BIw3NDSouLh42O127typBx54QK+//jprtJcp2H2QmpqqDz/8UM3NzQO38vJyXXfddWpubtbcuXMjVXpMCOX/wLx583TmzBl9+eWXA2Mff/yxEhISNG3atFGtNxaFsg++/vprJSQE/slKTEyU9P+f0DF6ioqKBu2v3bt3a86cORo3btzlP0FYToNFVOm/pG7z5s3G4/GY1atXm/Hjx5v//ve/xhhj1q1bZ+67776B+a+//rpJSkoyL730kvF6vQO3L774wtZLiHrB7oOLcTXN5Qn2/ff7/WbatGnm5z//ufnoo4/Mnj17zMyZM81DDz1k6yVEvWD3wdatW01SUpKprq42J06cMPv27TNz5swxhYWFtl5CVPP7/aapqck0NTUZSWbTpk2mqalp4NLqi9///kt716xZYzwej9m8eTOX9uLyvfTSSyYrK8skJyeb/Px8s2fPnoGf3X///ebWW28duH/rrbcaSYNu999/f+QLjyHB7IOLEUYuX7Dv//Hjx83tt99urrjiCjNt2jSzdu1a8/XXX0e46tgS7D54/vnnTW5urrniiiuM2+02v/jFL8zp06cjXHVs+Oc//3nJ3+tDvf//+te/zM0332ySk5PNtddea2pqasJWj8MYjm8BAAB7OGcEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABg1f8C2I7ZC9TwoakAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -1199,7 +1199,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x13ebbfad0>"
+       "<graphviz.graphs.Digraph at 0x13ead51d0>"
       ]
      },
      "execution_count": 28,
@@ -1230,7 +1230,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9dbe327786644b2ca0ea31216fc48bc9",
+       "model_id": "5276705f13934382a5419737139590e7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1257,7 +1257,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x14a0d7a10>"
+       "<matplotlib.collections.PathCollection at 0x14a31ccd0>"
       ]
      },
      "execution_count": 29,
@@ -1509,7 +1509,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x14a511090>"
+       "<graphviz.graphs.Digraph at 0x14a40c590>"
       ]
      },
      "execution_count": 30,
@@ -2928,7 +2928,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x14a5c7710>"
+       "<graphviz.graphs.Digraph at 0x14a3e2550>"
       ]
      },
      "execution_count": 36,
@@ -2987,6 +2987,103 @@
    ],
    "source": [
     "out = wf(element=\"Mg\", phase1=\"fcc\", phase2=\"hcp\", lattice_guess1=3, lattice_guess2=3)\n",
+    "print(f\"{wf.inputs.element.value}: E({wf.inputs.phase2.value}) - E({wf.inputs.phase1.value}) = {out.compare__de:.2f} eV/atom\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7985d84f-b842-4a8d-95d5-eca3d19a78c8",
+   "metadata": {},
+   "source": [
+    "We can also replace entire node in a workflow or macro with a new node, booting the old one out and inserting the new one including all its connections. Because the connections are recreated, the replacement node _must_ have compatible IO to the node being replaced.\n",
+    "\n",
+    "There are several syntacic approaches for doing this, including invoking replacement methods from the workflow (or macro) or from the node being replaced, or a new (compatible!) class can be assigned directly to an existing node. We'll use the last approach, which makes a new instance of the supplied class and replaces the target node with it.\n",
+    "\n",
+    "Let's replace the calculation type for phase 1 -- let's switch it from a `CalcMin` to a `CalcStatic`; both of these take a `job` as input and give `structure` and `energy` as output, so we won't have any trouble connecting our new node in lieue of the old one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "4cdffdca-48d3-4486-9045-48102c7e5f31",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:110: UserWarning: The channel job was not connected to job, andthus could not disconnect from it.\n",
+      "  warn(\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:110: UserWarning: The channel energy_pot was not connected to energy1, andthus could not disconnect from it.\n",
+      "  warn(\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:110: UserWarning: The channel run was not connected to ran, andthus could not disconnect from it.\n",
+      "  warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "wf.min_phase1.calc = Macro.create.atomistics.CalcStatic"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dd7d2f9-313d-4e38-b467-823c48d0afa0",
+   "metadata": {},
+   "source": [
+    "Since we're no longer allowing our first phase to relax while the second phase still can, we would expect the second phase to have a much lower energy than the first one. If our lattice guess for the first phase is bad enough, this could even switch the preferred phase!\n",
+    "\n",
+    "Look at Al's fcc-hcp energy difference using this new workflow. We'll always let hcp relax, but freeze the fcc cell so we can see the impact of a good and bad lattice guess."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "ed4a3a22-fc3a-44c9-9d4f-c65bc1288889",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The job JUSTAJOBNAME was saved and received the ID: 9558\n",
+      "The job JUSTAJOBNAME was saved and received the ID: 9558\n",
+      "Al: E(hcp) - E(fcc) = -5.57 eV/atom\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Bad guess\n",
+    "out = wf(element=\"Al\", phase1=\"fcc\", phase2=\"hcp\", lattice_guess1=3, lattice_guess2=3)\n",
+    "print(f\"{wf.inputs.element.value}: E({wf.inputs.phase2.value}) - E({wf.inputs.phase1.value}) = {out.compare__de:.2f} eV/atom\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "5a985cbf-c308-4369-9223-b8a37edb8ab1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:110: UserWarning: The channel run was not connected to ran, andthus could not disconnect from it.\n",
+      "  warn(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The job JUSTAJOBNAME was saved and received the ID: 9558\n",
+      "The job JUSTAJOBNAME was saved and received the ID: 9558\n",
+      "Al: E(hcp) - E(fcc) = 0.03 eV/atom\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Good guess\n",
+    "out = wf(element=\"Al\", phase1=\"fcc\", phase2=\"hcp\", lattice_guess1=4.05, lattice_guess2=3)\n",
     "print(f\"{wf.inputs.element.value}: E({wf.inputs.phase2.value}) - E({wf.inputs.phase1.value}) = {out.compare__de:.2f} eV/atom\")"
    ]
   },
@@ -3052,7 +3149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 42,
    "id": "0b373764-b389-4c24-8086-f3d33a4f7fd7",
    "metadata": {},
    "outputs": [
@@ -3066,7 +3163,7 @@
        " 17.230249999999995]"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3103,7 +3200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 43,
    "id": "0dd04b4c-e3e7-4072-ad34-58f2c1e4f596",
    "metadata": {},
    "outputs": [
@@ -3162,7 +3259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 44,
    "id": "2dfb967b-41ac-4463-b606-3e315e617f2a",
    "metadata": {},
    "outputs": [
@@ -3186,7 +3283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 45,
    "id": "2e87f858-b327-4f6b-9237-c8a557f29aeb",
    "metadata": {},
    "outputs": [
@@ -3194,11 +3291,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.732 > 0.2\n",
-      "0.628 > 0.2\n",
-      "0.220 > 0.2\n",
-      "0.102 <= 0.2\n",
-      "Finally 0.102\n"
+      "0.710 > 0.2\n",
+      "0.757 > 0.2\n",
+      "0.651 > 0.2\n",
+      "0.821 > 0.2\n",
+      "0.677 > 0.2\n",
+      "0.189 <= 0.2\n",
+      "Finally 0.189\n"
      ]
     }
    ],

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -375,7 +375,7 @@ class Composite(Node, ABC):
         del self.nodes[node.label]
         return disconnected
 
-    def replace(self, owned_node: Node | str, replacement: Node):
+    def replace(self, owned_node: Node | str, replacement: Node | type[Node]):
         """
         Replaces a node currently owned with a new node instance.
         The replacement must not belong to any other parent or have any connections.
@@ -391,13 +391,6 @@ class Composite(Node, ABC):
         Returns:
             (Node): The node that got removed
         """
-        if replacement.parent is not None:
-            raise ValueError(
-                f"Replacement node must have no parent, but got {replacement.parent}"
-            )
-        if replacement.connected:
-            raise ValueError("Replacement node must not have any connections")
-
         if isinstance(owned_node, str):
             owned_node = self.nodes[owned_node]
 
@@ -405,6 +398,22 @@ class Composite(Node, ABC):
             raise ValueError(
                 f"The node being replaced should be a child of this composite, but "
                 f"another parent was found: {owned_node.parent}"
+            )
+
+        if isinstance(replacement, Node):
+            if replacement.parent is not None:
+                raise ValueError(
+                    f"Replacement node must have no parent, but got "
+                    f"{replacement.parent}"
+                )
+            if replacement.connected:
+                raise ValueError("Replacement node must not have any connections")
+        elif issubclass(replacement, Node):
+            replacement = replacement(label=owned_node.label)
+        else:
+            raise TypeError(
+                f"Expected replacement node to be a node instance or node subclass, but "
+                f"got {replacement}"
             )
 
         replacement.copy_connections(owned_node)

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -358,14 +358,22 @@ class Composite(Node, ABC):
             )
             del self.nodes[node.label]
 
-    def remove(self, node: Node | str):
-        if isinstance(node, Node):
-            node.parent = None
-            disconnected = node.disconnect()
-            del self.nodes[node.label]
-            return disconnected
-        else:
-            del self.nodes[node]
+    def remove(self, node: Node | str) -> list[tuple[Channel, Channel]]:
+        """
+        Remove a node from the `nodes` collection, disconnecting it and setting its
+        `parent` to None.
+
+        Args:
+            node (Node|str): The node (or its label) to remove.
+
+        Returns:
+            [list[tuple[Channel, Channel]]]: Any connections that node had.
+        """
+        node = self.nodes[node] if isinstance(node, str) else node
+        node.parent = None
+        disconnected = node.disconnect()
+        del self.nodes[node.label]
+        return disconnected
 
     def __setattr__(self, key: str, node: Node):
         if isinstance(node, Node) and key != "parent":

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -372,6 +372,8 @@ class Composite(Node, ABC):
         node = self.nodes[node] if isinstance(node, str) else node
         node.parent = None
         disconnected = node.disconnect()
+        if node in self.starting_nodes:
+            self.starting_nodes.remove(node)
         del self.nodes[node.label]
         return disconnected
 

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -426,6 +426,13 @@ class Composite(Node, ABC):
     def __setattr__(self, key: str, node: Node):
         if isinstance(node, Node) and key != "parent":
             self.add(node, label=key)
+        elif (
+            isinstance(node, type)
+            and issubclass(node, Node)
+            and key in self.nodes.keys()
+        ):
+            # When a class is assigned to an existing node, try a replacement
+            self.replace(key, node)
         else:
             super().__setattr__(key, node)
 

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -361,8 +361,9 @@ class Composite(Node, ABC):
     def remove(self, node: Node | str):
         if isinstance(node, Node):
             node.parent = None
-            node.disconnect()
+            disconnected = node.disconnect()
             del self.nodes[node.label]
+            return disconnected
         else:
             del self.nodes[node]
 

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -422,8 +422,11 @@ class Composite(Node, ABC):
 
         replacement.copy_connections(owned_node)
         replacement.label = owned_node.label
+        is_starting_node = owned_node in self.starting_nodes
         self.remove(owned_node)
         self.add(replacement)
+        if is_starting_node:
+            self.starting_nodes.append(replacement)
 
     def __setattr__(self, key: str, node: Node):
         if isinstance(node, Node) and key != "parent":

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -386,7 +386,9 @@ class Composite(Node, ABC):
 
         Args:
             owned_node (Node|str): The node to replace or its label.
-            replacement (Node): The node to replace it with.
+            replacement (Node | type[Node]): The node or class to replace it with. (If
+                a class is passed, it has all the same requirements on IO compatibility
+                and simply gets instantiated.)
 
         Returns:
             (Node): The node that got removed

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -114,7 +114,7 @@ class Macro(Composite):
         ...     macro.b = macro.create.SingleValue(add_one, x=0)
         ...     macro.c = macro.create.SingleValue(add_one, x=0)
         >>>
-        >>> m = Macro(modified_start_macro)
+        >>> m = Macro(modified_flow_macro)
         >>> m.outputs.to_value_dict()
         >>> m(a__x=1, b__x=2, c__x=3)
         {'a__result': 2, 'b__result': 3, 'c__result': 4}

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -135,6 +135,27 @@ class Macro(Composite):
         Manually controlling execution flow is necessary for cyclic graphs (cf. the
         while loop meta-node), but best to avoid when possible as it's easy to miss
         intended connections in complex graphs.
+
+        We can also modify an existing macro at runtime by replacing nodes within it, as
+        long as the replacement has fully compatible IO. There are three syntacic ways
+        to do this. Let's explore these by going back to our `add_three_macro` and
+        replacing each of its children with a node that adds 2 instead of 1.
+        >>> @Macro.wrap_as.single_value_node()
+        ... def add_two(x):
+        ...     result = x + 2
+        ...     return result
+        >>>
+        >>> adds_six_macro = Macro(add_three_macro)
+        >>> # With the replace method
+        >>> # (replacement target can be specified by label or instance,
+        >>> # the replacing node can be specified by instance or class)
+        >>> adds_six_macro.replace(adds_six_macro.one, add_two())
+        >>> # With the replace_with method
+        >>> adds_six_macro.two.replace_with(add_two())
+        >>> # And by assignment of a compatible class to an occupied node label
+        >>> adds_six_macro.three = add_two
+        >>> adds_six_macro(inp=1)
+        {'three__result': 7}
     """
 
     def __init__(

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -468,10 +468,10 @@ class Node(HasToDict, ABC):
                 (self.signals.input, other.signals.input),
                 (self.signals.output, other.signals.output),
             ]:
-                for channel in other_panel:
+                for key, channel in other_panel.items():
                     for target in channel.connections:
-                        my_panel[channel.label].connect(target)
-                        new_connections.append((my_panel[channel.label], target))
+                        my_panel[key].connect(target)
+                        new_connections.append((my_panel[key], target))
         except Exception as e:
             # If you run into trouble, unwind what you've done
             for connection in new_connections:

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -478,3 +478,20 @@ class Node(HasToDict, ABC):
                 connection[0].disconnect(connection[1])
             raise e
 
+    def replace_with(self, other: Node | type[Node]):
+        """
+        If this node has a parent, invokes `self.parent.replace(self, other)` to swap
+        out this node for the other node in the parent graph.
+
+        The replacement must have fully compatible IO, i.e. its IO must be a superset of
+        this node's IO with all the same labels and type hints (although the latter is
+        not strictly enforced and will only cause trouble if there is an incompatibility
+        that causes trouble in the process of copying over connections)
+
+        Args:
+            other (Node|type[Node]): The replacement.
+        """
+        if self.parent is not None:
+            self.parent.replace(self, other)
+        else:
+            warnings.warn(f"Could not replace {self.label}, as it has no parent.")

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -287,11 +287,23 @@ class TestMacro(unittest.TestCase):
             with self.assertRaises(ValueError):
                 macro.replace(another_macro, to_replace)
 
-        with self.subTest("Should be possible to replace by label too"):
-            macro.replace("two", to_replace)
+        with self.subTest(
+            "Should be possible to replace with a class instead of an instance"
+        ):
+            add_one_class = macro.wrap_as.single_value_node()(add_one)
+            self.assertTrue(issubclass(add_one_class, SingleValue), msg="Sanity check")
+            macro.replace(macro.two, add_one_class)
             self.assertEqual(
                 macro(one__x=0).three__result,
                 3,
+                msg="Should be possible to replace with a class instead of an instance"
+            )
+
+        with self.subTest("Should be possible to replace by label too"):
+            macro.replace("two", replacement)
+            self.assertEqual(
+                macro(one__x=0).three__result,
+                5,
                 msg="Original node should be back in place now"
             )
 

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -287,6 +287,13 @@ class TestMacro(unittest.TestCase):
                 msg="Should be possible to replace by label"
             )
 
+            macro.two.replace_with(adds_one_node)
+            self.assertEqual(
+                macro(one__x=0).three__result,
+                3,
+                msg="Nodes should have syntactic sugar for invoking replacement"
+            )
+
         with self.subTest("Verify failure cases"):
             another_macro = Macro(add_three_macro)
             another_node = Macro(

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -294,6 +294,17 @@ class TestMacro(unittest.TestCase):
                 msg="Nodes should have syntactic sugar for invoking replacement"
             )
 
+            @Macro.wrap_as.function_node()
+            def add_two(x):
+                result = x + 2
+                return result
+            macro.two = add_two
+            self.assertEqual(
+                macro(one__x=0).three__result,
+                4,
+                msg="Composite should allow replacement when a class is assigned"
+            )
+
         with self.subTest("Verify failure cases"):
             another_macro = Macro(add_three_macro)
             another_node = Macro(
@@ -325,6 +336,18 @@ class TestMacro(unittest.TestCase):
                 msg="Should fail if the node being replaced isn't a child"
             ):
                 macro.replace(another_node, an_ok_replacement)
+
+            @Macro.wrap_as.function_node()
+            def add_two_incompatible_io(not_x):
+                result_is_not_my_name = not_x + 2
+                return result_is_not_my_name
+
+            with self.assertRaises(
+                AttributeError,
+                msg="Replacing via class assignment should fail if the class has "
+                    "incompatible IO"
+            ):
+                macro.two = add_two_incompatible_io
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -317,6 +317,11 @@ class TestMacro(unittest.TestCase):
                 [new_starter],
                 msg="Replacement should be reflected in the starting nodes"
             )
+            self.assertIs(
+                macro.inputs.one__x,
+                new_starter.inputs.x,
+                msg="Replacement should be reflected in composite IO"
+            )
 
         with self.subTest("Verify failure cases"):
             another_macro = Macro(add_three_macro)

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -305,6 +305,19 @@ class TestMacro(unittest.TestCase):
                 msg="Composite should allow replacement when a class is assigned"
             )
 
+            self.assertListEqual(
+                macro.starting_nodes,
+                [macro.one],
+                msg="Sanity check"
+            )
+            new_starter = add_two()
+            macro.one.replace_with(new_starter)
+            self.assertListEqual(
+                macro.starting_nodes,
+                [new_starter],
+                msg="Replacement should be reflected in the starting nodes"
+            )
+
         with self.subTest("Verify failure cases"):
             another_macro = Macro(add_three_macro)
             another_node = Macro(

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -66,6 +66,26 @@ class TestWorkflow(unittest.TestCase):
             with self.assertRaises(AttributeError):
                 Workflow.create.Function(plus_one, label="boa", parent=wf)
 
+    def test_node_removal(self):
+        wf = Workflow("my_workflow")
+        wf.owned = Workflow.create.Function(plus_one)
+        node = Workflow.create.Function(plus_one)
+        wf.foo = node
+        # Add it to starting nodes manually, otherwise it's only there at run time
+        wf.starting_nodes = [wf.foo]
+        # Connect it inside the workflow
+        wf.foo.inputs.x = wf.owned.outputs.y
+
+        wf.remove(node)
+        self.assertIsNone(node.parent, msg="Removal should de-parent")
+        self.assertFalse(node.connected, msg="Removal should disconnect")
+        self.assertListEqual(
+            wf.starting_nodes,
+            [],
+            msg="Removal should also remove from starting nodes"
+        )
+
+
     def test_node_packages(self):
         wf = Workflow("my_workflow")
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -93,10 +93,15 @@ class TestWorkflow(unittest.TestCase):
         with self.assertRaises(ValueError):
             # Can't belong to two workflows at once
             wf2.add(node2)
-        wf1.remove(node2)
+        disconnections = wf1.remove(node2)
+        self.assertFalse(node2.connected, msg="Removal should first disconnect")
+        self.assertListEqual(
+            disconnections,
+            [(node2.inputs.x, wf1.node1.outputs.y)],
+            msg="Disconnections should be returned by removal"
+        )
         wf2.add(node2)
         self.assertEqual(node2.parent, wf2)
-        self.assertFalse(node2.connected)
 
     def test_workflow_io(self):
         wf = Workflow("wf")

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -103,6 +103,19 @@ class TestWorkflow(unittest.TestCase):
         wf2.add(node2)
         self.assertEqual(node2.parent, wf2)
 
+        node1 = wf1.node1
+        disconnections = wf1.remove(node1.label)
+        self.assertEqual(
+            node1.parent,
+            None,
+            msg="Should be able to remove nodes by label as well as by object"
+        )
+        self.assertListEqual(
+            [],
+            disconnections,
+            msg="node1 should have no connections left"
+        )
+
     def test_workflow_io(self):
         wf = Workflow("wf")
         wf.create.Function(plus_one, label="n1")


### PR DESCRIPTION
`Composite` instances can now replace one of their children with another node instance or class, as long as that node has no parent or connections and has compatible IO (this PR introduces a tool for coping connections from one node to the other)

Resolves a couple of the TODOs on #7.

```python
from pyiron_workflow import Workflow

@Workflow.wrap_as.single_value_node()
def add_one(x):
    result = x + 1
    return result

@Workflow.wrap_as.macro_node()
def add_three_macro(macro):
    macro.one = add_one()
    macro.two = add_one(x=macro.one)
    macro.three = add_one(x=macro.two)
    
    macro.inputs_map = {"one__x": "x"}
    macro.outputs_map = {"three__result": "result"}

macro = add_three_macro()

replacement = add_three_macro()

print(macro(x=0).result)  # 1 + 1 + 1 = 3
>>> 3

macro.replace(macro.two, replacement)
# Alternate syntaxes support using labels and classes:
# macro.replace("two", replacement)
# macro.replace(macro.two, add_three_macro)
# macro.two.replace_with(replacement)
# macro.two.replace_with(add_three_macro)
# macro.two = add_three_macro  # Some real sugar!
print(macro(x=0).result)  # 1 + (1 + 1 + 1) + 1 = 5
>>> 5
```