### PR TITLE
Draw channel links

### DIFF
--- a/pyiron_workflow/draw.py
+++ b/pyiron_workflow/draw.py
@@ -323,9 +323,9 @@ class Node(WorkflowGraphvizMap):
                         color=self._channel_bicolor(output_channel, input_channel),
                     )
 
-        # Loop to check for macro input --> internal node input connections
+        # Connect channels that are by-reference copies of each other
+        # i.e. for Workflow IO to child IO
         self._connect_matching(self.inputs.channels, internal_inputs)
-        # Loop to check for macro input --> internal node input connections
         self._connect_matching(internal_outputs, self.outputs.channels)
 
     def _connect_matching(self, sources: list[_Channel], destinations: list[_Channel]):

--- a/pyiron_workflow/draw.py
+++ b/pyiron_workflow/draw.py
@@ -328,6 +328,11 @@ class Node(WorkflowGraphvizMap):
         self._connect_matching(self.inputs.channels, internal_inputs)
         self._connect_matching(internal_outputs, self.outputs.channels)
 
+        # Connect channels that are value-linked
+        # i.e. for Macro IO to child IO
+        self._connect_linked(self.inputs.channels, internal_inputs)
+        self._connect_linked(internal_outputs, self.outputs.channels)
+
     def _connect_matching(self, sources: list[_Channel], destinations: list[_Channel]):
         """
         Draw an edge between two graph channels whose workflow channels are the same
@@ -339,6 +344,23 @@ class Node(WorkflowGraphvizMap):
                         source.name,
                         destination.name,
                         color=self._channel_bicolor(source, destination),
+                    )
+
+    def _connect_linked(self, sources: list[_Channel], destinations: list[_Channel]):
+        """
+        Draw an edge between two graph channels values are linked
+        """
+        for source in sources:
+            for destination in destinations:
+                if (
+                    hasattr(source.channel, "value_receiver")
+                    and source.channel.value_receiver is destination.channel
+                ):
+                    self.graph.edge(
+                        source.name,
+                        destination.name,
+                        color=self._channel_bicolor(source, destination),
+                        style="dashed",
                     )
 
     def build_node_name(self, suffix=""):


### PR DESCRIPTION
Workflows still create IO by reference, but now Macros create their own IO by value and use `DataChannel.value_receiver` to keep values synced with children. Here, we draw these links in the `.draw()` method.

Closes #56.

Result:
```python
from pyiron_workflow import Workflow

@Workflow.wrap_as.single_value_node("y")
def add1(x):
    return x + 1

@Workflow.wrap_as.macro_node()
def add2(macro):
    macro.one = add1()
    macro.two = add1(x=macro.one)
    macro.inputs_map = {"one__x": "x"}
    macro.outputs_map = {"two__y": "y"}
    
wf = Workflow("to_draw")
wf.nup = add1(x=0)
wf.m = add2(x=wf.nup)
wf.ndown = add1(x=wf.m.outputs.y)

wf.draw(depth=2)
```
![drawn_links](https://github.com/pyiron/pyiron_workflow/assets/20283329/eeda2ac3-29f0-4525-937f-0d53809cf22e)

