### PR TITLE
Allow trivial re-assignment

### DIFF
--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -281,12 +281,16 @@ class Composite(Node, ABC):
                 f"Only new node instances may be added, but got {type(node)}."
             )
         self._ensure_node_has_no_other_parent(node)
-        label = self._get_unique_label(node.label if label is None else label)
-        self._ensure_node_is_not_duplicated(node, label)
 
-        self.nodes[label] = node
-        node.label = label
-        node.parent = self
+        if not (label in self.nodes.keys() and self.nodes[label] is node):
+            # Otherwise you're just passing the same node to the same key!
+
+            label = self._get_unique_label(node.label if label is None else label)
+            self._ensure_node_is_not_duplicated(node, label)
+
+            self.nodes[label] = node
+            node.label = label
+            node.parent = self
         return node
 
     def _get_unique_label(self, label):

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -9,6 +9,11 @@ from pyiron_workflow.workflow import Workflow
 
 
 class TestTopology(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        ensure_tests_in_python_path()
+        super().setUpClass()
+
     def test_manually_constructed_cyclic_graph(self):
         """
         Check that cyclic graphs run.
@@ -78,7 +83,6 @@ class TestTopology(unittest.TestCase):
         )
 
     def test_for_loop(self):
-        ensure_tests_in_python_path()
         Workflow.register("demo", "static.demo_nodes")
 
         n = 5
@@ -182,8 +186,6 @@ class TestTopology(unittest.TestCase):
 
         C.f. `pyiron_workflow.function._wrapper_factory` for more detail.
         """
-
-        ensure_tests_in_python_path()
         wf = Workflow("depickle")
         wf.create.register("demo", "static.demo_nodes")
         wf.before_pickling = wf.create.demo.OptionallyAdd(1)

--- a/tests/unit/test_interfaces.py
+++ b/tests/unit/test_interfaces.py
@@ -13,6 +13,7 @@ class TestCreator(TestCase):
     def setUpClass(cls) -> None:
         cls.creator = Creator()
         ensure_tests_in_python_path()
+        super().setUpClass()
 
     def test_registration(self):
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -52,6 +52,21 @@ class TestWorkflow(unittest.TestCase):
             ]
         )
 
+        with self.subTest("Make sure trivial re-assignment has no impact"):
+            original_foo = wf.foo
+            n_nodes = len(wf.nodes)
+            wf.foo = original_foo
+            self.assertIs(
+                original_foo,
+                wf.foo,
+                msg="Reassigning a node to the same name should have no impact",
+            )
+            self.assertEqual(
+                n_nodes,
+                len(wf.nodes),
+                msg="Reassigning a node to the same name should have no impact",
+            )
+
         with self.subTest("Make sure strict naming causes a bunch of attribute errors"):
             wf.strict_naming = True
             # Validate name preservation

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -5,6 +5,7 @@ import unittest
 
 from bidict import ValueDuplicationError
 
+from pyiron_workflow._tests import ensure_tests_in_python_path
 from pyiron_workflow.channels import NotData
 from pyiron_workflow.files import DirectoryObject
 from pyiron_workflow.util import DotDict
@@ -18,6 +19,10 @@ def plus_one(x=0):
 
 @unittest.skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
 class TestWorkflow(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        ensure_tests_in_python_path()
+        super().setUpClass()
 
     def test_node_addition(self):
         wf = Workflow("my_workflow")


### PR DESCRIPTION
Something silly like `wf.my_node = wf.my_node` used to throw an exception. This is dumb, but sensible things like `wf.user_input = wf.create.standard.UserInput()` used to do the same thing by virtue of the `create` method adding the node already.

Closes #52 

(Ignore the crappy branch name, I just forgot to check out a clean branch before doing the work and accidentally pushed onto the old merged-and-deleted one)