### PR TITLE
Refactor macros

### DIFF
--- a/pyiron_workflow/atomistics_library/macronodes.py
+++ b/pyiron_workflow/atomistics_library/macronodes.py
@@ -10,7 +10,6 @@ from pyiron_workflow.atomistics_library.tasknodes import (
 
 
 def atomistics_meta_macro(task_generator_node_class, macro_name) -> type[Macro]:
-
     def generic_macro(wf: Macro) -> None:
         wf.tasks = task_generator_node_class()
         wf.structures = generate_structures(instance=wf.tasks)
@@ -18,11 +17,13 @@ def atomistics_meta_macro(task_generator_node_class, macro_name) -> type[Macro]:
         wf.fit = analyse_structures(instance=wf.tasks, output_dict=wf.calc)
         inputs_map = {
             # Dynamically expose _all_ task generator input directly on the macro
-            "tasks__" + s: s for s in wf.tasks.inputs.labels
+            "tasks__" + s: s
+            for s in wf.tasks.inputs.labels
         }
         inputs_map["calc__calculator"] = "calculator"
         wf.inputs_map = inputs_map
         wf.outputs_map = {"fit__result_dict": "result_dict"}
+
     generic_macro.__name__ = macro_name
 
     return macro_node()(generic_macro)
@@ -34,7 +35,8 @@ elastic_matrix = atomistics_meta_macro(
 
 
 energy_volume_curve = atomistics_meta_macro(
-    get_evcurve_task_generator, "energy_volume_curve",
+    get_evcurve_task_generator,
+    "energy_volume_curve",
 )
 
 phonons = atomistics_meta_macro(get_phonons_task_generator, "phonons")

--- a/pyiron_workflow/atomistics_library/macronodes.py
+++ b/pyiron_workflow/atomistics_library/macronodes.py
@@ -1,5 +1,4 @@
 from pyiron_workflow.macro import Macro, macro_node
-from pyiron_workflow.function import single_value_node
 from pyiron_workflow.atomistics_library.calculatornodes import calc_with_calculator
 from pyiron_workflow.atomistics_library.tasknodes import (
     get_elastic_matrix_task_generator,
@@ -41,84 +40,8 @@ energy_volume_curve = atomistics_meta_macro(
 phonons = atomistics_meta_macro(get_phonons_task_generator, "phonons")
 
 
-
-
-
-@single_value_node("instance")
-def get_instance(instance):
-    return instance
-
-
-@macro_node()
-def internal_macro(wf: Macro) -> None:
-    wf.get_instance = get_instance()
-    wf.generate_structures = generate_structures(instance=wf.get_instance)
-    wf.calc_with_calculator = calc_with_calculator(task_dict=wf.generate_structures)
-    wf.fit = analyse_structures(
-        instance=wf.get_instance, output_dict=wf.calc_with_calculator
-    )
-    wf.inputs_map = {
-        "get_instance__instance": "instance",
-        "calc_with_calculator__calculator": "calculator",
-    }
-    wf.outputs_map = {"fit__fit_dict": "fit_dict"}
-
-
-@macro_node()
-def get_energy_volume_curve(wf: Macro) -> None:
-    wf.get_task_generator = get_evcurve_task_generator()
-    wf.internal = internal_macro(instance=wf.get_task_generator)
-    wf.inputs_map = {
-        "get_task_generator__structure": "structure",
-        "get_task_generator__num_points": "num_points",
-        "get_task_generator__fit_type": "fit_type",
-        "get_task_generator__fit_order": "fit_order",
-        "get_task_generator__vol_range": "vol_range",
-        "get_task_generator__axes": "axes",
-        "get_task_generator__strains": "strains",
-        "internal__calculator": "calculator",
-    }
-    wf.outputs_map = {"internal__fit_dict": "fit_dict"}
-
-
-@macro_node()
-def get_elastic_matrix(wf: Macro) -> None:
-    wf.get_task_generator = get_elastic_matrix_task_generator()
-    wf.internal = internal_macro(instance=wf.get_task_generator)
-    wf.inputs_map = {
-        "get_task_generator__structure": "structure",
-        "get_task_generator__num_of_point": "num_of_point",
-        "get_task_generator__eps_range": "eps_range",
-        "get_task_generator__sqrt_eta": "sqrt_eta",
-        "get_task_generator__fit_order": "fit_order",
-        "internal__calculator": "calculator",
-    }
-    wf.outputs_map = {"internal__fit_dict": "fit_dict"}
-
-
-@macro_node()
-def get_phonons(wf: Macro) -> None:
-    wf.get_task_generator = get_phonons_task_generator()
-    wf.internal = internal_macro(instance=wf.get_task_generator)
-    wf.inputs_map = {
-        "get_task_generator__structure": "structure",
-        "get_task_generator__interaction_range": "interaction_range",
-        "get_task_generator__factor": "factor",
-        "get_task_generator__displacement": "displacement",
-        "get_task_generator__dos_mesh": "dos_mesh",
-        "get_task_generator__primitive_matrix": "primitive_matrix",
-        "get_task_generator__number_of_snapshots": "number_of_snapshots",
-        "internal__calculator": "calculator",
-    }
-    wf.outputs_map = {"internal__fit_dict": "fit_dict"}
-
-
 nodes = [
     elastic_matrix,
     energy_volume_curve,
     phonons,
-    get_energy_volume_curve,
-    get_elastic_matrix,
-    get_phonons,
-
 ]


### PR DESCRIPTION
Old: define a generic macro shared by all atomistics workflows leveraging task generators, then define a set of macros each of which instantiates the task generator node and the generic macro node, then connects them and manually re-maps all the task generator input to be available at the macro level.

New: Create a meta-workflow that takes the task generator node as input and returns a macro class in which all the task generator IO has been dynamically re-mapped to be available at the macro level; instantiate this meta-macro once per task generator to get a set of macros.


There is absolutely nothing wrong with the "old" version, it's a perfectly legitimate and legal way to construct a set of macros! Further, the biggest advantage of the "new" way -- that the task generator input is dynamically remapped -- could also be used right in the "old" way. Using a "meta-macro" is purely stylistic and my personal preference.

@jan-janssen, it's your node package so I think it's fair if you use whatever one you prefer. However, if you chose to stick with the implementation on the base branch, I would still suggest to leverage the same dynamic remapping just to shorten the node definitions.


```python
from pyiron_workflow import Workflow

Workflow.register("macros", "pyiron_workflow.atomistics_library.macronodes")
Workflow.register("calculators", "pyiron_workflow.atomistics_library.calculatornodes")
Workflow.register("tasks", "pyiron_workflow.atomistics_library.tasknodes")

wf = Workflow("ev")
wf.bulk = wf.create.tasks.GetBulk("Al")
wf.calc = wf.create.calculators.GetEmt()
# wf.old_ev_curve = wf.create.macros.GetEnergyVolumeCurve(
#     structure=wf.bulk,
#     calculator=wf.calc,
# )
wf.new_ev_curve = wf.create.macros.EnergyVolumeCurve(
    structure=wf.bulk,
    calculator=wf.calc,
)
out = wf()

# out.old_ev_curve__internal__fit__result_dict["poly_fit"] - out.new_ev_curve__result_dict["poly_fit"]
```

The commented out stuff works on the first commit of this PR, where both old and new exist at once. The output is just an array of zeros, as expected and desired.

I didn't do the same sort of thorough test for the other two, but I did make sure that they instantiated OK and had nice clean IO:

```python
p = Workflow.create.macros.Phonons()
p.inputs.labels, p.outputs.labels
```

```
(['structure',
  'interaction_range',
  'factor',
  'displacement',
  'dos_mesh',
  'primitive_matrix',
  'number_of_snapshots',
  'calculator'],
 ['result_dict'])
```

and 

```python
l = Workflow.create.macros.ElasticMatrix()
l.inputs.labels, l.outputs.labels
```

```
(['structure',
  'num_points',
  'fit_type',
  'fit_order',
  'vol_range',
  'axes',
  'strains',
  'calculator'],
 ['internal__fit__result_dict'])
```