### PR TITLE
Handle actions itself in the dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
 updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
 - package-ecosystem: pip
   directory: "/"
   schedule:


### PR DESCRIPTION
I just saw the update of action version itself in https://github.com/dependabot/demo and I think this is a nice idea to do! 