### PR TITLE
Expose dict values as list

### DIFF
--- a/pyiron_workflow/io.py
+++ b/pyiron_workflow/io.py
@@ -171,6 +171,10 @@ class DataIO(IO, ABC):
     def to_value_dict(self):
         return {label: channel.value for label, channel in self.channel_dict.items()}
 
+    def to_list(self):
+        """A list of channel values (order not guaranteed)"""
+        return list(channel.value for channel in self.channel_dict.values())
+
     @property
     def ready(self):
         return all([c.ready for c in self])

--- a/pyiron_workflow/util.py
+++ b/pyiron_workflow/util.py
@@ -20,6 +20,10 @@ class DotDict(dict):
         for k, v in state.items():
             self.__dict__[k] = v
 
+    def to_list(self):
+        """A list of values (order not guaranteed)"""
+        return list(self.values())
+
 
 class SeabornColors:
     """

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -139,7 +139,7 @@ class TestDataIO(TestCase):
         )
 
 @skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
-class TestDataIO(TestCase):
+class TestSignalIO(TestCase):
     def setUp(self) -> None:
         node = DummyNode()
 

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -2,7 +2,7 @@ from unittest import TestCase, skipUnless
 from sys import version_info
 
 from pyiron_workflow.channels import (
-    InputData, InputSignal, OutputData, OutputSignal
+    InputData, InputSignal, OutputData, OutputSignal, ChannelConnectionError
 )
 from pyiron_workflow.io import Inputs, Outputs, Signals
 
@@ -65,11 +65,15 @@ class TestDataIO(TestCase):
             )
 
     def test_connection(self):
-        self.input.x = self.input.y
+        with self.assertRaises(
+            ChannelConnectionError,
+            msg="Shouldn't be allowed to connect two inputs"
+        ):
+            self.input.x = self.input.y
         self.assertEqual(
             0,
             len(self.input.x.connections),
-            msg="Shouldn't be allowed to connect two inputs, but only passes warning"
+            msg="Sanity check that the above error-raising connection never got made"
         )
 
         self.input.x = self.output.a
@@ -79,8 +83,8 @@ class TestDataIO(TestCase):
             msg="Should be able to create connections by assignment"
         )
 
-        self.input.x = 7
-        self.assertEqual(self.input.x.value, 7)
+        self.input.x = 7.
+        self.assertEqual(self.input.x.value, 7.)
 
         self.input.y = self.output.a
         disconnected = self.input.disconnect()

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -23,8 +23,8 @@ class TestDataIO(TestCase):
     def setUp(self) -> None:
         node = DummyNode()
         self.inputs = [
-            InputData(label="x", node=node, default=0, type_hint=float),
-            InputData(label="y", node=node, default=1, type_hint=float)
+            InputData(label="x", node=node, default=0., type_hint=float),
+            InputData(label="y", node=node, default=1., type_hint=float)
         ]
         outputs = [
             OutputData(label="a", node=node, type_hint=float),
@@ -136,6 +136,15 @@ class TestDataIO(TestCase):
             self.input.x.connections[0],
             msg="The IO connection found should be the same object as the channel "
                 "connection"
+        )
+
+    def test_to_list(self):
+        self.assertListEqual(
+            [0., 1.],
+            self.input.to_list(),
+            msg="Expected a shortcut to channel values. Order is explicitly not "
+                "guaranteed in the docstring, but it would be nice to appear in the "
+                "order the channels are added here"
         )
 
 @skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -12,3 +12,5 @@ class TestUtil(TestCase):
         self.assertEqual(dd['foo'], dd.foo, msg="Dot access should be equivalent.")
         dd.bar = "towel"
         self.assertEqual("towel", dd["bar"], msg="Dot assignment should be equivalent.")
+
+        self.assertListEqual(dd.to_list(), [42, "towel"])


### PR DESCRIPTION
Just adds `to_list()` methods to `DotDict` and `DataIO` so the dictionaries can be case to value lists. The order is explicitly not guaranteed, but it winds up being the order items are added to the underlying dict.

As requested in #38.

Closes #40.