### PR TITLE
Can run right away

### DIFF
--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -104,6 +104,7 @@ class Composite(Node, ABC):
         label: str,
         *args,
         parent: Optional[Composite] = None,
+        run_after_init: bool = False,
         strict_naming: bool = True,
         inputs_map: Optional[dict | bidict] = None,
         outputs_map: Optional[dict | bidict] = None,

--- a/pyiron_workflow/function.py
+++ b/pyiron_workflow/function.py
@@ -296,6 +296,7 @@ class Function(Node):
         *args,
         label: Optional[str] = None,
         parent: Optional[Composite] = None,
+        run_after_init: bool = False,
         output_labels: Optional[str | list[str] | tuple[str]] = None,
         **kwargs,
     ):
@@ -568,24 +569,6 @@ class SingleValue(Function, HasChannel):
     - The entire node can be used in place of its output value for connections, e.g.
         `some_node.input.some_channel = my_svn_instance`.
     """
-
-    def __init__(
-        self,
-        node_function: callable,
-        *args,
-        label: Optional[str] = None,
-        parent: Optional[Workflow] = None,
-        output_labels: Optional[str | list[str] | tuple[str]] = None,
-        **kwargs,
-    ):
-        super().__init__(
-            node_function,
-            *args,
-            label=label,
-            parent=parent,
-            output_labels=output_labels,
-            **kwargs,
-        )
 
     def _get_output_labels(self, output_labels: str | list[str] | tuple[str] | None):
         output_labels = super()._get_output_labels(output_labels)

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -175,6 +175,7 @@ class Macro(Composite):
         graph_creator: callable[[Macro], None],
         label: Optional[str] = None,
         parent: Optional[Composite] = None,
+        run_after_init: bool = False,
         strict_naming: bool = True,
         inputs_map: Optional[dict | bidict] = None,
         outputs_map: Optional[dict | bidict] = None,

--- a/pyiron_workflow/util.py
+++ b/pyiron_workflow/util.py
@@ -1,3 +1,5 @@
+from abc import ABCMeta
+
 from pyiron_base import state
 
 logger = state.logger
@@ -59,3 +61,8 @@ class HasPost(type):
         if post := getattr(cls, "__post__", False):
             post(instance, *args, **kwargs)
         return instance
+
+
+class AbstractHasPost(HasPost, ABCMeta):
+    # Just for resolving metaclass conflic for ABC classes that have post
+    pass

--- a/pyiron_workflow/util.py
+++ b/pyiron_workflow/util.py
@@ -43,3 +43,19 @@ class SeabornColors:
     cyan = "#17becf"
     white = "#ffffff"
     black = "#000000"
+
+
+class HasPost(type):
+    """
+    A metaclass for adding a `__post__` method which has a compatible signature with
+    `__init__` (and indeed receives all its input), but is guaranteed to be called
+    only _after_ `__init__` is totally finished.
+
+    Based on @jsbueno's reply in [this discussion](https://discuss.python.org/t/add-a-post-method-equivalent-to-the-new-method-but-called-after-init/5449/11)
+    """
+
+    def __call__(cls, *args, **kwargs):
+        instance = super().__call__(*args, **kwargs)
+        if post := getattr(cls, "__post__", False):
+            post(instance, *args, **kwargs)
+        return instance

--- a/pyiron_workflow/workflow.py
+++ b/pyiron_workflow/workflow.py
@@ -182,6 +182,7 @@ class Workflow(Composite):
         self,
         label: str,
         *nodes: Node,
+        run_after_init: bool = False,
         strict_naming: bool = True,
         inputs_map: Optional[dict | bidict] = None,
         outputs_map: Optional[dict | bidict] = None,

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -14,3 +14,35 @@ class TestUtil(TestCase):
         self.assertEqual("towel", dd["bar"], msg="Dot assignment should be equivalent.")
 
         self.assertListEqual(dd.to_list(), [42, "towel"])
+
+    def test_has_post_metaclass(self):
+        class Foo(metaclass=util.HasPost):
+            def __init__(self, x=0):
+                self.x = x
+                self.y = x
+                self.z = x
+                self.x += 1
+
+            @property
+            def data(self):
+                return self.x, self.y, self.z
+
+        class Bar(Foo):
+            def __init__(self, x=0, extra=1):
+                super().__init__(x)
+
+            def __post__(self, *args, extra=1, **kwargs):
+                self.z = self.x + extra
+
+        self.assertTupleEqual(
+            (1, 0, 0),
+            Foo().data,
+            msg="It should be fine to have this metaclass but not define post"
+        )
+
+        self.assertTupleEqual(
+            (1, 0, 2),
+            Bar().data,
+            msg="Metaclass should be inherited, able to use input, and happen _after_ "
+                "__init__"
+        )


### PR DESCRIPTION
Introduces a new metaclass that adds a `__post__` method to classes which is invoked after `__init__` and with the same input. This is leveraged to allow `Node` and its children to run at the end of instantiation (defaults to false, don't run).

Closes #42 