### PR TITLE
Stop version checking tests

### DIFF
--- a/tests/benchmark/test_benchmark.py
+++ b/tests/benchmark/test_benchmark.py
@@ -1,6 +1,6 @@
-import unittest
+from unittest import TestCase
 
 
-class TestNothing(unittest.TestCase):
+class TestNothing(TestCase):
     def test_nothing(self):
         self.assertTrue(True)

--- a/tests/benchmark/test_benchmark.py
+++ b/tests/benchmark/test_benchmark.py
@@ -1,6 +1,10 @@
-from unittest import TestCase
+import unittest
 
 
-class TestNothing(TestCase):
+class TestNothing(unittest.TestCase):
     def test_nothing(self):
         self.assertTrue(True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/integration/test_parallel_speedup.py
+++ b/tests/integration/test_parallel_speedup.py
@@ -1,11 +1,8 @@
-
-
 from time import perf_counter, sleep
 import unittest
 
 from pyiron_workflow import Workflow
 from pyiron_workflow.channels import NotData
-
 
 
 class TestParallelSpeedup(unittest.TestCase):

--- a/tests/integration/test_parallel_speedup.py
+++ b/tests/integration/test_parallel_speedup.py
@@ -1,13 +1,13 @@
 
-from sys import version_info
+
 from time import perf_counter, sleep
-from unittest import TestCase, skipUnless
+from unittest import TestCase
 
 from pyiron_workflow import Workflow
 from pyiron_workflow.channels import NotData
 
 
-@skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestParallelSpeedup(TestCase):
     def test_speedup(self):
         @Workflow.wrap_as.single_value_node()

--- a/tests/integration/test_parallel_speedup.py
+++ b/tests/integration/test_parallel_speedup.py
@@ -1,14 +1,14 @@
 
 
 from time import perf_counter, sleep
-from unittest import TestCase
+import unittest
 
 from pyiron_workflow import Workflow
 from pyiron_workflow.channels import NotData
 
 
 
-class TestParallelSpeedup(TestCase):
+class TestParallelSpeedup(unittest.TestCase):
     def test_speedup(self):
         @Workflow.wrap_as.single_value_node()
         def Wait(t):
@@ -57,3 +57,7 @@ class TestParallelSpeedup(TestCase):
                 f"{dt_parallel}  and {dt_serial} for parallel and serial times, "
                 f"respectively"
         )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -1,4 +1,4 @@
-import unittest
+from unittest import TestCase
 
 import numpy as np
 
@@ -8,7 +8,7 @@ from pyiron_workflow.function import Function
 from pyiron_workflow.workflow import Workflow
 
 
-class TestTopology(unittest.TestCase):
+class TestTopology(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         ensure_tests_in_python_path()

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+import unittest
 
 import numpy as np
 
@@ -8,7 +8,7 @@ from pyiron_workflow.function import Function
 from pyiron_workflow.workflow import Workflow
 
 
-class TestTopology(TestCase):
+class TestTopology(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         ensure_tests_in_python_path()
@@ -198,3 +198,7 @@ class TestTopology(TestCase):
         wf.before_pickling.executor = None
         wf.after_pickling = wf.create.demo.OptionallyAdd(2, y=3)
         wf()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/snippets/test_dotdict.py
+++ b/tests/unit/snippets/test_dotdict.py
@@ -1,9 +1,9 @@
-from unittest import TestCase
+import unittest
 
 from pyiron_workflow.snippets.dotdict import DotDict
 
 
-class TestDotDict(TestCase):
+class TestDotDict(unittest.TestCase):
     def test_dot_dict(self):
         dd = DotDict({'foo': 42})
 
@@ -12,3 +12,7 @@ class TestDotDict(TestCase):
         self.assertEqual("towel", dd["bar"], msg="Dot assignment should be equivalent.")
 
         self.assertListEqual(dd.to_list(), [42, "towel"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/snippets/test_has_post.py
+++ b/tests/unit/snippets/test_has_post.py
@@ -1,9 +1,9 @@
-from unittest import TestCase
+import unittest
 
 import pyiron_workflow.snippets.has_post
 
 
-class TestHasPost(TestCase):
+class TestHasPost(unittest.TestCase):
     def test_has_post_metaclass(self):
         class Foo(metaclass=pyiron_workflow.snippets.has_post.HasPost):
             def __init__(self, x=0):
@@ -35,3 +35,7 @@ class TestHasPost(TestCase):
             msg="Metaclass should be inherited, able to use input, and happen _after_ "
                 "__init__"
         )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/snippets/test_logger.py
+++ b/tests/unit/snippets/test_logger.py
@@ -2,13 +2,13 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from unittest import TestCase
+import unittest
 from pyiron_workflow.snippets.logger import logger
 import os
 import shutil
 
 
-class TestLogger(TestCase):
+class TestLogger(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -38,3 +38,7 @@ class TestLogger(TestCase):
 
         logger.set_logging_level("WARNING", channel=0)
         self.assertEqual(30, logger.handlers[0].level, "Should be able to set by string")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/snippets/test_logger.py
+++ b/tests/unit/snippets/test_logger.py
@@ -1,7 +1,3 @@
-# coding: utf-8
-# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
-# Distributed under the terms of "New BSD License", see the LICENSE file.
-
 import unittest
 from pyiron_workflow.snippets.logger import logger
 import os

--- a/tests/unit/snippets/test_singleton.py
+++ b/tests/unit/snippets/test_singleton.py
@@ -1,7 +1,3 @@
-# coding: utf-8
-# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
-# Distributed under the terms of "New BSD License", see the LICENSE file.
-
 import unittest
 from pyiron_workflow.snippets.singleton import Singleton
 

--- a/tests/unit/snippets/test_singleton.py
+++ b/tests/unit/snippets/test_singleton.py
@@ -2,11 +2,11 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-from unittest import TestCase
+import unittest
 from pyiron_workflow.snippets.singleton import Singleton
 
 
-class TestSingleton(TestCase):
+class TestSingleton(unittest.TestCase):
     def test_uniqueness(self):
         class Foo(metaclass=Singleton):
             def __init__(self):
@@ -17,4 +17,8 @@ class TestSingleton(TestCase):
         self.assertIs(f1, f2)
         f2.x = 2
         self.assertEqual(2, f1.x)
+
+
+if __name__ == '__main__':
+    unittest.main()
 

--- a/tests/unit/snippets/test_testcase.py
+++ b/tests/unit/snippets/test_testcase.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+import unittest
 
 from pyiron_workflow._tests import ensure_tests_in_python_path
 from pyiron_workflow.snippets.testcase import PyironTestCase
@@ -9,7 +9,7 @@ from static import docs_submodule
 from static.docs_submodule import bad_class, good_function, mix, bad_init_example
 
 
-class TestTestCase(TestCase):
+class TestTestCase(unittest.TestCase):
 
     def setUp(self) -> None:
         self.tester = PyironTestCase()
@@ -65,3 +65,7 @@ class TestTestCase(TestCase):
                 msg="Any failure should cause overall failure"
             ):
                 self.tester.test_docstrings()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+import unittest
 
 
 from pyiron_workflow.channels import (
@@ -18,7 +18,7 @@ class DummyNode:
 
 
 
-class TestChannel(TestCase):
+class TestChannel(unittest.TestCase):
 
     class InputChannel(Channel):
         """Just to de-abstract the base class"""
@@ -123,7 +123,7 @@ class TestChannel(TestCase):
 
 
 
-class TestDataChannels(TestCase):
+class TestDataChannels(unittest.TestCase):
 
     def setUp(self) -> None:
         self.ni1 = InputData(
@@ -346,7 +346,7 @@ class TestDataChannels(TestCase):
         self.assertFalse(self.ni1.ready)
 
 
-class TestSignalChannels(TestCase):
+class TestSignalChannels(unittest.TestCase):
     def setUp(self) -> None:
         node = DummyNode()
         self.inp = InputSignal(label="inp", node=node, callback=node.update)
@@ -465,3 +465,7 @@ class TestSignalChannels(TestCase):
             len(agg.received_signals),
             msg="All signals, including vestigial ones, should get cleared on call"
         )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -1,5 +1,5 @@
-from unittest import TestCase, skipUnless
-from sys import version_info
+from unittest import TestCase
+
 
 from pyiron_workflow.channels import (
     Channel, InputData, OutputData, InputSignal, AccumulatingInputSignal, OutputSignal,
@@ -17,7 +17,7 @@ class DummyNode:
         self.foo.append(self.foo[-1] + 1)
 
 
-@skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestChannel(TestCase):
 
     class InputChannel(Channel):
@@ -122,7 +122,7 @@ class TestChannel(TestCase):
             )
 
 
-@skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestDataChannels(TestCase):
 
     def setUp(self) -> None:

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -1,6 +1,5 @@
 import unittest
 
-
 from pyiron_workflow.channels import (
     Channel, InputData, OutputData, InputSignal, AccumulatingInputSignal, OutputSignal,
     NotData, ChannelConnectionError
@@ -15,7 +14,6 @@ class DummyNode:
 
     def update(self):
         self.foo.append(self.foo[-1] + 1)
-
 
 
 class TestChannel(unittest.TestCase):
@@ -120,7 +118,6 @@ class TestChannel(unittest.TestCase):
                 conn,
                 msg="Promised channels to be iterable over connections"
             )
-
 
 
 class TestDataChannels(unittest.TestCase):

--- a/tests/unit/test_composite.py
+++ b/tests/unit/test_composite.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 from bidict import ValueDuplicationError
@@ -29,7 +28,6 @@ class AComposite(Composite):
     @property
     def outputs(self) -> Outputs:
         return self._build_outputs()  # Dynamic IO reflecting current children
-
 
 
 class TestComposite(unittest.TestCase):

--- a/tests/unit/test_composite.py
+++ b/tests/unit/test_composite.py
@@ -1,4 +1,4 @@
-from sys import version_info
+
 import unittest
 
 from bidict import ValueDuplicationError
@@ -31,7 +31,7 @@ class AComposite(Composite):
         return self._build_outputs()  # Dynamic IO reflecting current children
 
 
-@unittest.skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestComposite(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -1,4 +1,3 @@
-
 from typing import Optional, Union
 import unittest
 import warnings
@@ -34,7 +33,6 @@ def multiple_branches(x):
         return True
     else:
         return False
-
 
 
 class TestFunction(unittest.TestCase):

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -1,4 +1,4 @@
-from sys import version_info
+
 from typing import Optional, Union
 import unittest
 import warnings
@@ -36,7 +36,7 @@ def multiple_branches(x):
         return False
 
 
-@unittest.skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestFunction(unittest.TestCase):
     def test_instantiation(self):
         with self.subTest("Void function is allowable"):
@@ -452,7 +452,7 @@ class TestFunction(unittest.TestCase):
             ref._copy_values(extra, fail_hard=True)
 
 
-@unittest.skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestSingleValue(unittest.TestCase):
     def test_instantiation(self):
         node = SingleValue(no_default, 1, y=2, output_labels="output")

--- a/tests/unit/test_interfaces.py
+++ b/tests/unit/test_interfaces.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 
 from pyiron_workflow._tests import ensure_tests_in_python_path

--- a/tests/unit/test_interfaces.py
+++ b/tests/unit/test_interfaces.py
@@ -1,11 +1,11 @@
 import sys
-from unittest import TestCase
+import unittest
 
 from pyiron_workflow._tests import ensure_tests_in_python_path
 from pyiron_workflow.interfaces import Creator
 
 
-class TestCreator(TestCase):
+class TestCreator(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.creator = Creator()
@@ -76,3 +76,7 @@ class TestCreator(TestCase):
                 len(self.creator._node_packages),
                 msg="Packages should not be getting added if exceptions are raised"
             )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_interfaces.py
+++ b/tests/unit/test_interfaces.py
@@ -1,13 +1,10 @@
 import sys
-from unittest import TestCase, skipUnless
+from unittest import TestCase
 
 from pyiron_workflow._tests import ensure_tests_in_python_path
 from pyiron_workflow.interfaces import Creator
 
 
-@skipUnless(
-    sys.version_info[0] == 3 and sys.version_info[1] >= 10, "Only supported for 3.10+"
-)
 class TestCreator(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -1,6 +1,5 @@
 import unittest
 
-
 from pyiron_workflow.channels import (
     InputData, InputSignal, OutputData, OutputSignal, ChannelConnectionError
 )
@@ -14,7 +13,6 @@ class DummyNode:
 
     def update(self):
         pass
-
 
 
 class TestDataIO(unittest.TestCase):

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -1,5 +1,5 @@
-from unittest import TestCase, skipUnless
-from sys import version_info
+from unittest import TestCase
+
 
 from pyiron_workflow.channels import (
     InputData, InputSignal, OutputData, OutputSignal, ChannelConnectionError
@@ -16,7 +16,7 @@ class DummyNode:
         pass
 
 
-@skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestDataIO(TestCase):
 
     @classmethod
@@ -151,7 +151,7 @@ class TestDataIO(TestCase):
                 "order the channels are added here"
         )
 
-@skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestSignalIO(TestCase):
     def setUp(self) -> None:
         node = DummyNode()

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+import unittest
 
 
 from pyiron_workflow.channels import (
@@ -17,7 +17,7 @@ class DummyNode:
 
 
 
-class TestDataIO(TestCase):
+class TestDataIO(unittest.TestCase):
 
     @classmethod
     def setUp(self) -> None:
@@ -152,7 +152,7 @@ class TestDataIO(TestCase):
         )
 
 
-class TestSignalIO(TestCase):
+class TestSignalIO(unittest.TestCase):
     def setUp(self) -> None:
         node = DummyNode()
 
@@ -192,3 +192,7 @@ class TestSignalIO(TestCase):
             len(no_run_signals.disconnect_run()),
             msg="If there is no run channel, the list of disconnections should be empty"
         )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -23,7 +23,6 @@ def add_three_macro(macro):
     # although these are more thoroughly tested in Workflow tests
 
 
-
 class TestMacro(unittest.TestCase):
 
     def test_static_input(self):

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -1,6 +1,6 @@
 from concurrent.futures import Future
 from functools import partialmethod
-from sys import version_info
+
 from time import sleep
 import unittest
 
@@ -23,7 +23,7 @@ def add_three_macro(macro):
     # although these are more thoroughly tested in Workflow tests
 
 
-@unittest.skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestMacro(unittest.TestCase):
 
     def test_static_input(self):

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -48,7 +48,6 @@ class ANode(Node):
         pass
 
 
-
 class TestNode(unittest.TestCase):
     def setUp(self):
         self.n1 = ANode("start", x=0)

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -344,3 +344,7 @@ class TestNode(unittest.TestCase):
             ANode("right_away", run_after_init=True, x=0).outputs.y.value,
             msg="With run_after_init, the node should run right away"
         )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -1,6 +1,6 @@
 from concurrent.futures import Future
 import os
-from sys import version_info
+
 import unittest
 
 from pyiron_workflow.channels import InputData, OutputData, NotData
@@ -48,7 +48,7 @@ class ANode(Node):
         pass
 
 
-@unittest.skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestNode(unittest.TestCase):
     def setUp(self):
         self.n1 = ANode("start", x=0)

--- a/tests/unit/test_node_package.py
+++ b/tests/unit/test_node_package.py
@@ -1,6 +1,5 @@
 import unittest
 
-
 from pyiron_workflow.node_package import NodePackage
 from pyiron_workflow.function import function_node
 
@@ -8,7 +7,6 @@ from pyiron_workflow.function import function_node
 @function_node()
 def dummy(x: int = 0):
     return x
-
 
 
 class TestNodePackage(unittest.TestCase):

--- a/tests/unit/test_node_package.py
+++ b/tests/unit/test_node_package.py
@@ -1,5 +1,5 @@
-from unittest import TestCase, skipUnless
-from sys import version_info
+from unittest import TestCase
+
 
 from pyiron_workflow.node_package import NodePackage
 from pyiron_workflow.function import function_node
@@ -10,7 +10,7 @@ def dummy(x: int = 0):
     return x
 
 
-@skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestNodePackage(TestCase):
     def setUp(self) -> None:
         self.package = NodePackage(dummy)

--- a/tests/unit/test_node_package.py
+++ b/tests/unit/test_node_package.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+import unittest
 
 
 from pyiron_workflow.node_package import NodePackage
@@ -11,7 +11,7 @@ def dummy(x: int = 0):
 
 
 
-class TestNodePackage(TestCase):
+class TestNodePackage(unittest.TestCase):
     def setUp(self) -> None:
         self.package = NodePackage(dummy)
 
@@ -66,3 +66,7 @@ class TestNodePackage(TestCase):
         self.assertEqual(
             new_dummy_instance.outputs.y.value, 1, msg="Should have new functionality"
         )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_output_parser.py
+++ b/tests/unit/test_output_parser.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 import numpy as np

--- a/tests/unit/test_output_parser.py
+++ b/tests/unit/test_output_parser.py
@@ -1,4 +1,4 @@
-from sys import version_info
+
 import unittest
 
 import numpy as np
@@ -6,9 +6,6 @@ import numpy as np
 from pyiron_workflow.output_parser import ParseOutput
 
 
-@unittest.skipUnless(
-    version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+"
-)
 class TestParseOutput(unittest.TestCase):
     def test_parsing(self):
         with self.subTest("Single return"):

--- a/tests/unit/test_pyiron_workflow.py
+++ b/tests/unit/test_pyiron_workflow.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 

--- a/tests/unit/test_pyiron_workflow.py
+++ b/tests/unit/test_pyiron_workflow.py
@@ -1,8 +1,8 @@
-from sys import version_info
+
 import unittest
 
 
-@unittest.skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestModule(unittest.TestCase):
     def test_single_point_of_entry(self):
         from pyiron_workflow import Workflow

--- a/tests/unit/test_pyiron_workflow.py
+++ b/tests/unit/test_pyiron_workflow.py
@@ -2,9 +2,12 @@
 import unittest
 
 
-
 class TestModule(unittest.TestCase):
     def test_single_point_of_entry(self):
         from pyiron_workflow import Workflow
         # That's it, let's just make sure the main class is available at the topmost
         # level
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_status_management.py
+++ b/tests/unit/test_status_management.py
@@ -1,6 +1,6 @@
 from concurrent.futures import Future
 
-from unittest import TestCase
+import unittest
 
 from pyiron_workflow.node import manage_status
 
@@ -24,7 +24,7 @@ class FauxNode:
 
 
 
-class TestStatusManagement(TestCase):
+class TestStatusManagement(unittest.TestCase):
     def setUp(self) -> None:
         self.node = FauxNode()
 
@@ -45,3 +45,7 @@ class TestStatusManagement(TestCase):
         self.assertTrue(self.node.running)
         self.assertFalse(self.node.failed)
         self.assertIsInstance(out, Future)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_status_management.py
+++ b/tests/unit/test_status_management.py
@@ -23,7 +23,6 @@ class FauxNode:
         return Future()
 
 
-
 class TestStatusManagement(unittest.TestCase):
     def setUp(self) -> None:
         self.node = FauxNode()

--- a/tests/unit/test_status_management.py
+++ b/tests/unit/test_status_management.py
@@ -1,6 +1,6 @@
 from concurrent.futures import Future
-from sys import version_info
-from unittest import TestCase, skipUnless
+
+from unittest import TestCase
 
 from pyiron_workflow.node import manage_status
 
@@ -23,7 +23,7 @@ class FauxNode:
         return Future()
 
 
-@skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestStatusManagement(TestCase):
     def setUp(self) -> None:
         self.node = FauxNode()

--- a/tests/unit/test_type_hinting.py
+++ b/tests/unit/test_type_hinting.py
@@ -1,5 +1,5 @@
 import typing
-from unittest import TestCase
+import unittest
 
 
 from pyiron_workflow.type_hinting import (
@@ -8,7 +8,7 @@ from pyiron_workflow.type_hinting import (
 
 
 
-class TestTypeHinting(TestCase):
+class TestTypeHinting(unittest.TestCase):
     def test_value_validation(self):
         class Foo:
             pass
@@ -80,3 +80,7 @@ class TestTypeHinting(TestCase):
                     type_hint_is_as_or_more_specific_than(target, reference),
                     is_more_specific
                 )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_type_hinting.py
+++ b/tests/unit/test_type_hinting.py
@@ -7,7 +7,6 @@ from pyiron_workflow.type_hinting import (
 )
 
 
-
 class TestTypeHinting(unittest.TestCase):
     def test_value_validation(self):
         class Foo:

--- a/tests/unit/test_type_hinting.py
+++ b/tests/unit/test_type_hinting.py
@@ -1,13 +1,13 @@
 import typing
-from unittest import TestCase, skipUnless
-from sys import version_info
+from unittest import TestCase
+
 
 from pyiron_workflow.type_hinting import (
     type_hint_is_as_or_more_specific_than, valid_value
 )
 
 
-@skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestTypeHinting(TestCase):
     def test_value_validation(self):
         class Foo:

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -1,5 +1,5 @@
 from concurrent.futures import Future
-from sys import version_info
+
 from time import sleep
 import unittest
 
@@ -14,7 +14,7 @@ def plus_one(x=0):
     return y
 
 
-@unittest.skipUnless(version_info[0] == 3 and version_info[1] >= 10, "Only supported for 3.10+")
+
 class TestWorkflow(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -14,7 +14,6 @@ def plus_one(x=0):
     return y
 
 
-
 class TestWorkflow(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:


### PR DESCRIPTION
Since we now only do the CI on python 3.10 and above anyhow!

And always do the unit tests when a tests is `__main__` (Just for you, @samwaseda)