### PR TITLE
Canonically scoped labels for channels

### DIFF
--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -92,6 +92,11 @@ class Channel(HasChannel, HasToDict, ABC):
         connection partners.
         """
 
+    @property
+    def scoped_label(self) -> str:
+        """A label combining the channel's usual label and its node's label"""
+        return f"{self.node.label}__{self.label}"
+
     def _valid_connection(self, other: Channel) -> bool:
         """
         Logic for determining if a connection is valid.

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -261,6 +261,8 @@ class Composite(Node, ABC):
                     io_panel_key = key_map[channel.scoped_label]
                     if not isinstance(io_panel_key, tuple):
                         # Tuples indicate that the channel has been deactivated
+                        # This is a necessary misdirection to keep the bidict working,
+                        # as we can't simply map _multiple_ keys to `None`
                         io[io_panel_key] = self._get_linking_channel(
                             channel, io_panel_key
                         )

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -256,11 +256,9 @@ class Composite(Node, ABC):
         io = Inputs() if i_or_o == "inputs" else Outputs()
         for node in self.nodes.values():
             panel = getattr(node, i_or_o)
-            for channel_label in panel.labels:
-                channel = panel[channel_label]
-                default_key = f"{node.label}__{channel_label}"
+            for channel in panel:
                 try:
-                    io_panel_key = key_map[default_key]
+                    io_panel_key = key_map[channel.scoped_label]
                     if not isinstance(io_panel_key, tuple):
                         # Tuples indicate that the channel has been deactivated
                         io[io_panel_key] = self._get_linking_channel(
@@ -268,8 +266,8 @@ class Composite(Node, ABC):
                         )
                 except KeyError:
                     if not channel.connected:
-                        io[default_key] = self._get_linking_channel(
-                            channel, default_key
+                        io[channel.scoped_label] = self._get_linking_channel(
+                            channel, channel.scoped_label
                         )
         return io
 


### PR DESCRIPTION
Closes #116 

We still string-code the "__" in examples, but I think that's OK since I expect users to be writing this stuff out in their maps anyhow, only #86 will really help that. 

The while-loop meta node still uses "__" manually, but in a different context so I'm leaving it.