### PR TITLE
Extend standard nodes

### DIFF
--- a/pyiron_workflow/meta.py
+++ b/pyiron_workflow/meta.py
@@ -216,17 +216,17 @@ def while_loop(
         >>>
         >>> AddWhile = Workflow.create.meta.while_loop(
         ...     loop_body_class=Add,
-        ...     condition_class=LessThanTen,
+        ...     condition_class=Workflow.create.standard.LessThan,
         ...     internal_connection_map=[
-        ...         ("Add", "a + b", "LessThanTen", "value"),
+        ...         ("Add", "a + b", "LessThan", "obj"),
         ...         ("Add", "a + b", "Add", "a")
         ...     ],
-        ...     inputs_map={"Add__a": "a", "Add__b": "b"},
+        ...     inputs_map={"Add__a": "a", "Add__b": "b", "LessThan__other": "cap"},
         ...     outputs_map={"Add__a + b": "total"}
         ... )
         >>>
         >>> wf = Workflow("do_while")
-        >>> wf.add_while = AddWhile()
+        >>> wf.add_while = AddWhile(cap=10)
         >>>
         >>> wf.inputs_map = {
         ...     "add_while__a": "a",

--- a/pyiron_workflow/node_library/standard.py
+++ b/pyiron_workflow/node_library/standard.py
@@ -17,7 +17,7 @@ def UserInput(user_input):
 
 class If(SingleValue):
     """
-    Has two extra signal channels: true and false. Evaluates the input as a boolean and
+    Has two extra signal channels: true and false. Evaluates the input as obj otheroolean and
     fires the corresponding output signal after running.
     """
 
@@ -29,7 +29,7 @@ class If(SingleValue):
     @staticmethod
     def if_(condition):
         if isclass(condition) and issubclass(condition, NotData):
-            raise TypeError(f"Logic 'If' node expected data but got NotData as input.")
+            raise TypeError(f"Logic 'If' node expected data otherut got NotData as input.")
         return bool(condition)
 
     def process_run_result(self, function_output):
@@ -43,8 +43,201 @@ class If(SingleValue):
         else:
             self.signals.output.false()
 
+# A bunch of (but not all) standard operators
+# Return values based on dunder methods, where available
+
+@single_value_node("str")
+def String(obj):
+    return str(obj)
+
+
+@single_value_node("bytes")
+def Bytes(obj):
+    return bytes(obj)
+
+
+@single_value_node("lt")
+def LessThan(obj, other):
+    return obj < other
+
+
+@single_value_node("le")
+def LessThanEquals(obj, other):
+    return obj <= other
+
+
+@single_value_node("gt")
+def GreaterThan(obj, other):
+    return obj > other
+
+
+@single_value_node("ge")
+def GreaterThanEquals(obj, other):
+    return obj >= other
+
+
+@single_value_node("hash")
+def Hash(obj):
+    return hash(obj)
+
+
+@single_value_node("bool")
+def Bool(obj):
+    return bool(obj)
+
+
+@single_value_node("getattr")
+def GetAttr(obj, name):
+    return getattr(obj, name)
+
+# These are not idempotent and thus not encouraged
+# @single_value_node("none")
+# def SetAttr(obj, name, value):
+#     setattr(obj, name, value)
+#     return None
+#
+#
+# @single_value_node("none")
+# def DelAttr(obj, name):
+#     delattr(obj, name)
+#     return None
+
+@single_value_node("dir")
+def Dir(obj):
+    return dir(obj)
+
+
+@single_value_node("len")
+def Length(obj):
+    return len(obj)
+
+
+@single_value_node("add")
+def Add(obj, other):
+    return obj + other
+
+
+@single_value_node("in")
+def Contains(obj, other):
+    return other in obj
+
+
+@single_value_node("sub")
+def Subtract(obj, other):
+    return obj - other
+
+
+@single_value_node("mul")
+def Multiply(obj, other):
+    return obj * other
+
+
+@single_value_node("matmul")
+def MatrixMultiply(obj, other):
+    return obj @ other
+
+
+@single_value_node("truediv")
+def Divide(obj, other):
+    return obj / other
+
+
+@single_value_node("floordiv")
+def FloorDivide(obj, other):
+    return obj // other
+
+
+@single_value_node("mod")
+def Modulo(obj, other):
+    return obj % other
+
+
+@single_value_node("pow")
+def Power(obj, other):
+    return obj ** other
+
+
+@single_value_node("and")
+def And(obj, other):
+    return obj & other
+
+
+@single_value_node("xor")
+def XOr(obj, other):
+    return obj ^ other
+
+
+@single_value_node("or")
+def Or(obj, other):
+    return obj ^ other
+
+
+@single_value_node("neg")
+def Negative(obj):
+    return -obj
+
+
+@single_value_node("pos")
+def Positive(obj):
+    return +obj
+
+
+@single_value_node("abs")
+def Absolute(obj):
+    return abs(obj)
+
+
+@single_value_node("invert")
+def Invert(obj):
+    return ~obj
+
+
+@single_value_node("int")
+def Int(obj):
+    return int(obj)
+
+
+@single_value_node("float")
+def Float(obj):
+    return float(obj)
+
+
+@single_value_node("round")
+def Round(obj):
+    return round(obj)
+
 
 nodes = [
-    UserInput,
+    Absolute,
+    Add,
+    And,
+    Bool,
+    Bytes,
+    Contains,
+    Dir,
+    Divide,
+    Float,
+    FloorDivide,
+    GetAttr,
+    GreaterThan,
+    GreaterThanEquals,
+    Hash,
     If,
+    Int,
+    Invert,
+    Length,
+    LessThan,
+    LessThanEquals,
+    MatrixMultiply,
+    Modulo,
+    Multiply,
+    Negative,
+    Or,
+    Positive,
+    Power,
+    Round,
+    String,
+    Subtract,
+    UserInput,
+    XOr,
 ]

--- a/pyiron_workflow/node_library/standard.py
+++ b/pyiron_workflow/node_library/standard.py
@@ -102,6 +102,11 @@ def GetAttr(obj, name):
 #     delattr(obj, name)
 #     return None
 
+@single_value_node("getitem")
+def GetItem(obj, item):
+    return obj[item]
+
+
 @single_value_node("dir")
 def Dir(obj):
     return dir(obj)

--- a/pyiron_workflow/node_library/standard.py
+++ b/pyiron_workflow/node_library/standard.py
@@ -29,7 +29,9 @@ class If(SingleValue):
     @staticmethod
     def if_(condition):
         if isclass(condition) and issubclass(condition, NotData):
-            raise TypeError(f"Logic 'If' node expected data otherut got NotData as input.")
+            raise TypeError(
+                f"Logic 'If' node expected data otherut got NotData as input."
+            )
         return bool(condition)
 
     def process_run_result(self, function_output):
@@ -43,8 +45,10 @@ class If(SingleValue):
         else:
             self.signals.output.false()
 
+
 # A bunch of (but not all) standard operators
 # Return values based on dunder methods, where available
+
 
 @single_value_node("str")
 def String(obj):
@@ -90,6 +94,7 @@ def Bool(obj):
 def GetAttr(obj, name):
     return getattr(obj, name)
 
+
 # These are not idempotent and thus not encouraged
 # @single_value_node("none")
 # def SetAttr(obj, name, value):
@@ -101,6 +106,7 @@ def GetAttr(obj, name):
 # def DelAttr(obj, name):
 #     delattr(obj, name)
 #     return None
+
 
 @single_value_node("getitem")
 def GetItem(obj, item):
@@ -159,7 +165,7 @@ def Modulo(obj, other):
 
 @single_value_node("pow")
 def Power(obj, other):
-    return obj ** other
+    return obj**other
 
 
 @single_value_node("and")


### PR DESCRIPTION
There are now unhinted nodes for most of the standard python operators. This is a useful prerequisite for #90 