### PR TITLE
Raise the intuitive type of error

### DIFF
--- a/pyiron_workflow/snippets/dotdict.py
+++ b/pyiron_workflow/snippets/dotdict.py
@@ -1,6 +1,11 @@
 class DotDict(dict):
     def __getattr__(self, item):
-        return self.__getitem__(item)
+        try:
+            return self.__getitem__(item)
+        except KeyError:
+            raise AttributeError(
+                f"{self.__class__.__name__} object has no attribute '{item}'"
+            )
 
     def __setattr__(self, key, value):
         self[key] = value

--- a/tests/unit/snippets/test_dotdict.py
+++ b/tests/unit/snippets/test_dotdict.py
@@ -13,6 +13,16 @@ class TestDotDict(unittest.TestCase):
 
         self.assertListEqual(dd.to_list(), [42, "towel"])
 
+        with self.assertRaises(
+            KeyError, msg="Failed item access should raise key error"
+        ):
+            dd["missing"]
+
+        with self.assertRaises(
+            AttributeError, msg="Failed attribute access should raise attribute error"
+        ):
+            dd.missing
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Depending on how you tried to get something from a dot-dict, i.e. key errors from item access, attribute errors from attribute access.