### PR TITLE
Working dir emptiness check

### DIFF
--- a/pyiron_workflow/files.py
+++ b/pyiron_workflow/files.py
@@ -43,8 +43,9 @@ class DirectoryObject:
     def create(self):
         self.path.mkdir(parents=True, exist_ok=True)
 
-    def delete(self):
-        delete_files_and_directories_recursively(self.path)
+    def delete(self, only_if_empty: bool = False):
+        if self.is_empty or not only_if_empty:
+            delete_files_and_directories_recursively(self.path)
 
     def list_content(self):
         return categorize_folder_items(self.path)

--- a/pyiron_workflow/files.py
+++ b/pyiron_workflow/files.py
@@ -44,7 +44,7 @@ class DirectoryObject:
         self.path.mkdir(parents=True, exist_ok=True)
 
     def delete(self, only_if_empty: bool = False):
-        if self.is_empty or not only_if_empty:
+        if self.is_empty() or not only_if_empty:
             delete_files_and_directories_recursively(self.path)
 
     def list_content(self):
@@ -72,7 +72,6 @@ class DirectoryObject:
     def create_file(self, file_name):
         return FileObject(file_name, self)
 
-    @property
     def is_empty(self) -> bool:
         return len(self) == 0
 

--- a/pyiron_workflow/files.py
+++ b/pyiron_workflow/files.py
@@ -71,6 +71,10 @@ class DirectoryObject:
     def create_file(self, file_name):
         return FileObject(file_name, self)
 
+    @property
+    def is_empty(self) -> bool:
+        return len(self) == 0
+
 
 class FileObject:
     def __init__(self, file_name: str, directory: DirectoryObject):

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -46,9 +46,9 @@ class TestFiles(unittest.TestCase):
         self.assertFalse(f.is_file())
 
     def test_is_empty(self):
-        self.assertTrue(self.directory.is_empty)
+        self.assertTrue(self.directory.is_empty())
         self.directory.write(file_name="test.txt", content="something")
-        self.assertFalse(self.directory.is_empty)
+        self.assertFalse(self.directory.is_empty())
 
     def test_delete(self):
         self.assertTrue(
@@ -58,7 +58,7 @@ class TestFiles(unittest.TestCase):
         self.directory.write(file_name="test.txt", content="something")
         self.directory.delete(only_if_empty=True)
         self.assertFalse(
-            self.directory.is_empty,
+            self.directory.is_empty(),
             msg="Flag argument on delete should have prevented removal"
         )
         self.directory.delete()

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -50,6 +50,24 @@ class TestFiles(unittest.TestCase):
         self.directory.write(file_name="test.txt", content="something")
         self.assertFalse(self.directory.is_empty)
 
+    def test_delete(self):
+        self.assertTrue(
+            Path("test").exists() and Path("test").is_dir(),
+            msg="Sanity check on initial state"
+        )
+        self.directory.write(file_name="test.txt", content="something")
+        self.directory.delete(only_if_empty=True)
+        self.assertFalse(
+            self.directory.is_empty,
+            msg="Flag argument on delete should have prevented removal"
+        )
+        self.directory.delete()
+        self.assertFalse(
+            Path("test").exists(),
+            msg="Delete should remove the entire directory"
+        )
+        self.directory = DirectoryObject("test")  # Rebuild it so the tearDown works
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -45,6 +45,11 @@ class TestFiles(unittest.TestCase):
         f.delete()
         self.assertFalse(f.is_file())
 
+    def test_is_empty(self):
+        self.assertTrue(self.directory.is_empty)
+        self.directory.write(file_name="test.txt", content="something")
+        self.assertFalse(self.directory.is_empty)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Just very minor convenience changes to the filesystem stuff: adds a property `DirectoryObject.is_empty` that checks agains length, and  modifies deletion so you can choose to only delete if it's empty: `DirectoryObject.(self, only_if_empty: bool = False)`