### PR TITLE
Add a shortcut for removing file(s) by name

### DIFF
--- a/pyiron_workflow/snippets/files.py
+++ b/pyiron_workflow/snippets/files.py
@@ -75,6 +75,12 @@ class DirectoryObject:
     def is_empty(self) -> bool:
         return len(self) == 0
 
+    def remove(self, *files: str):
+        for file in files:
+            path = self.get_path(file)
+            if path.is_file():
+                path.unlink()
+
 
 class FileObject:
     def __init__(self, file_name: str, directory: DirectoryObject):

--- a/tests/unit/snippets/test_files.py
+++ b/tests/unit/snippets/test_files.py
@@ -68,6 +68,34 @@ class TestFiles(unittest.TestCase):
         )
         self.directory = DirectoryObject("test")  # Rebuild it so the tearDown works
 
+    def test_remove(self):
+        self.directory.write(file_name="test1.txt", content="something")
+        self.directory.write(file_name="test2.txt", content="something")
+        self.directory.write(file_name="test3.txt", content="something")
+        self.assertEqual(
+            3,
+            len(self.directory),
+            msg="Sanity check on initial state"
+        )
+        self.directory.remove("test1.txt", "test2.txt")
+        self.assertEqual(
+            1,
+            len(self.directory),
+            msg="Should be able to remove multiple files at once",
+        )
+        self.directory.remove("not even there", "nor this")
+        self.assertEqual(
+            1,
+            len(self.directory),
+            msg="Removing non-existent things should have no effect",
+        )
+        self.directory.remove("test3.txt")
+        self.assertEqual(
+            0,
+            len(self.directory),
+            msg="Should be able to remove just one file",
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Introduces the following convenience method to `DirectoryObject`:

```python
    def remove(self, *files: str):
        for file in files:
            path = self.get_path(file)
            if path.is_file():
                path.unlink()
```