### PR TITLE
Expose root node

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,10 @@ channels:
 - conda-forge
 dependencies:
 - ipykernel
+- myst-parser
 - nbsphinx
+- sphinx-gallery
+- sphinx-rtd-theme
 - coveralls
 - coverage
 - bidict =0.22.1
@@ -13,4 +16,3 @@ dependencies:
 - python-graphviz =0.20.1
 - toposort =1.10
 - typeguard =4.1.5
-- myst-parser

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -183,6 +183,7 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
             owning this, if any.
         ready (bool): Whether the inputs are all ready and the node is neither
             already running nor already failed.
+        root (Node): The parent-most node in this graph.
         run_args (dict): **Abstract** the argmuments to use for actually running the
             node. Must be specified in child classes.
         running (bool): Whether the node has called :meth:`run` and has not yet

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -183,7 +183,7 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
             owning this, if any.
         ready (bool): Whether the inputs are all ready and the node is neither
             already running nor already failed.
-        root (Node): The parent-most node in this graph.
+        graph_root (Node): The parent-most node in this graph.
         run_args (dict): **Abstract** the argmuments to use for actually running the
             node. Must be specified in child classes.
         running (bool): Whether the node has called :meth:`run` and has not yet
@@ -318,9 +318,9 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         )
 
     @property
-    def root(self) -> Node:
+    def graph_root(self) -> Node:
         """The parent-most node in this graph."""
-        return self if self.parent is None else self.parent.root
+        return self if self.parent is None else self.parent.graph_root
 
     @property
     def readiness_report(self) -> str:

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -318,6 +318,11 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         )
 
     @property
+    def root(self) -> Node:
+        """The parent-most node in this graph."""
+        return self if self.parent is None else self.parent.root
+
+    @property
     def readiness_report(self) -> str:
         input_readiness = "\n".join(
             [f"{k} ready: {v.ready}" for k, v in self.inputs.items()]

--- a/tests/unit/test_composite.py
+++ b/tests/unit/test_composite.py
@@ -598,24 +598,24 @@ class TestComposite(unittest.TestCase):
 
         self.assertIs(
             top,
-            top.root,
-            msg="The parent-most node should be its own root."
+            top.graph_root,
+            msg="The parent-most node should be its own graph_root."
         )
         self.assertIs(
             top,
-            top.middle_composite.root,
-            msg="The parent-most node should be the root."
+            top.middle_composite.graph_root,
+            msg="The parent-most node should be the graph_root."
         )
         self.assertIs(
             top,
-            top.middle_function.root,
-            msg="The parent-most node should be the root."
+            top.middle_function.graph_root,
+            msg="The parent-most node should be the graph_root."
         )
         self.assertIs(
             top,
-            top.middle_composite.deep_node.root,
-            msg="The parent-most node should be the root, recursively accessible from "
-                "all depths."
+            top.middle_composite.deep_node.graph_root,
+            msg="The parent-most node should be the graph_root, recursively accessible "
+                "from all depths."
         )
 
 

--- a/tests/unit/test_composite.py
+++ b/tests/unit/test_composite.py
@@ -590,6 +590,34 @@ class TestComposite(unittest.TestCase):
             msg="Activating should propagate to children"
         )
 
+    def test_root(self):
+        top = AComposite("topmost")
+        top.middle_composite = AComposite("middle_composite")
+        top.middle_composite.deep_node = Composite.create.SingleValue(plus_one)
+        top.middle_function = Composite.create.SingleValue(plus_one)
+
+        self.assertIs(
+            top,
+            top.root,
+            msg="The parent-most node should be its own root."
+        )
+        self.assertIs(
+            top,
+            top.middle_composite.root,
+            msg="The parent-most node should be the root."
+        )
+        self.assertIs(
+            top,
+            top.middle_function.root,
+            msg="The parent-most node should be the root."
+        )
+        self.assertIs(
+            top,
+            top.middle_composite.deep_node.root,
+            msg="The parent-most node should be the root, recursively accessible from "
+                "all depths."
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -344,6 +344,14 @@ class TestNode(unittest.TestCase):
             msg="With run_after_init, the node should run right away"
         )
 
+    def test_root(self):
+        n = ANode("n")
+        self.assertIs(
+            n,
+            n.root,
+            msg="Lone nodes should be their own root, as there is no parent above."
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -348,8 +348,9 @@ class TestNode(unittest.TestCase):
         n = ANode("n")
         self.assertIs(
             n,
-            n.root,
-            msg="Lone nodes should be their own root, as there is no parent above."
+            n.graph_root,
+            msg="Lone nodes should be their own graph_root, as there is no parent "
+                "above."
         )
 
 


### PR DESCRIPTION
Adds a new instance property `Node.root: -> Node` that returns the parent-most node in the node's graph. For the parent-most node or nodes all alone, the `root` is just `self`.

Access to this sort of graph property seems intrinsically nice to me, but in particular I have in mind to use it for specifying nodes as "checkpoints", i.e. points at which the graphs save themselves, by adding a `finally` clause to `Node._finish_run` like:

```python
finally:
    if self.is_checkpoint:
        self.root.save()
```

I included documentation at the docstring level, but since we don't yet have a use-case (e.g. above) I don't see a need to modify any notebooks or train users on this property.