### PR TITLE
Introduce ~semantic~ graph path

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,10 @@ channels:
 - conda-forge
 dependencies:
 - ipykernel
+- myst-parser
 - nbsphinx
+- sphinx-gallery
+- sphinx-rtd-theme
 - coveralls
 - coverage
 - bidict =0.22.1
@@ -13,4 +16,3 @@ dependencies:
 - python-graphviz =0.20.1
 - toposort =1.10
 - typeguard =4.1.5
-- myst-parser

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -342,15 +342,6 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         return path
 
     @property
-    def semantic_path(self):
-        path = self.label
-        if self.parent is not None:
-            path = self.parent.semantic_path + self._semantic_delimiter + path
-        # else:
-        #     path = self.semantic_root + self._semantic_delimiter + path
-        return path
-
-    @property
     def readiness_report(self) -> str:
         input_readiness = "\n".join(
             [f"{k} ready: {v.ready}" for k, v in self.inputs.items()]

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -183,6 +183,8 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
             owning this, if any.
         ready (bool): Whether the inputs are all ready and the node is neither
             already running nor already failed.
+        graph_path (str): The file-path-like path of node labels from the parent-most
+            node down to this node.
         graph_root (Node): The parent-most node in this graph.
         run_args (dict): **Abstract** the argmuments to use for actually running the
             node. Must be specified in child classes.
@@ -335,7 +337,11 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         return self if self.parent is None else self.parent.graph_root
 
     @property
-    def graph_path(self):
+    def graph_path(self) -> str:
+        """
+        The path of node labels from the graph root (parent-most node) down to this
+        node.
+        """
         path = self.label
         if self.parent is not None:
             path = self.parent.graph_path + self._semantic_delimiter + path

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -247,6 +247,7 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
             **kwargs: Keyword arguments passed on with `super`.
         """
         super().__init__(*args, **kwargs)
+        self._label = None
         self.label: str = label
         self._parent = None
         if parent is not None:
@@ -267,6 +268,16 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
                 self.run()
             except ReadinessError:
                 pass
+
+    @property
+    def label(self) -> str:
+        return self._label
+
+    @label.setter
+    def label(self, new_label: str):
+        if self._semantic_delimiter in new_label:
+            raise ValueError(f"{self._semantic_delimiter} cannot be in the label")
+        self._label = new_label
 
     @property
     @abstractmethod

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -348,15 +348,6 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         return self if self.parent is None else self.parent.graph_root
 
     @property
-    def semantic_path(self):
-        path = self.label
-        if self.parent is not None:
-            path = self.parent.semantic_path + self._semantic_delimiter + path
-        # else:
-        #     path = self.semantic_root + self._semantic_delimiter + path
-        return path
-
-    @property
     def readiness_report(self) -> str:
         input_readiness = "\n".join(
             [f"{k} ready: {v.ready}" for k, v in self.inputs.items()]

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -183,7 +183,7 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
             owning this, if any.
         ready (bool): Whether the inputs are all ready and the node is neither
             already running nor already failed.
-        root (Node): The parent-most node in this graph.
+        graph_root (Node): The parent-most node in this graph.
         run_args (dict): **Abstract** the argmuments to use for actually running the
             node. Must be specified in child classes.
         running (bool): Whether the node has called :meth:`run` and has not yet
@@ -318,9 +318,9 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         )
 
     @property
-    def root(self) -> Node:
+    def graph_root(self) -> Node:
         """The parent-most node in this graph."""
-        return self if self.parent is None else self.parent.root
+        return self if self.parent is None else self.parent.graph_root
 
     @property
     def readiness_report(self) -> str:

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -225,6 +225,7 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
     """
 
     package_identifier = None
+    _semantic_delimiter = "/"
 
     def __init__(
         self,
@@ -321,6 +322,15 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
     def graph_root(self) -> Node:
         """The parent-most node in this graph."""
         return self if self.parent is None else self.parent.graph_root
+
+    @property
+    def semantic_path(self):
+        path = self.label
+        if self.parent is not None:
+            path = self.parent.semantic_path + self._semantic_delimiter + path
+        # else:
+        #     path = self.semantic_root + self._semantic_delimiter + path
+        return path
 
     @property
     def readiness_report(self) -> str:

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -342,6 +342,15 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         return path
 
     @property
+    def semantic_path(self):
+        path = self.label
+        if self.parent is not None:
+            path = self.parent.semantic_path + self._semantic_delimiter + path
+        # else:
+        #     path = self.semantic_root + self._semantic_delimiter + path
+        return path
+
+    @property
     def readiness_report(self) -> str:
         input_readiness = "\n".join(
             [f"{k} ready: {v.ready}" for k, v in self.inputs.items()]

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -339,8 +339,6 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         path = self.label
         if self.parent is not None:
             path = self.parent.graph_path + self._semantic_delimiter + path
-        # else:
-        #     path = self.semantic_root + self._semantic_delimiter + path
         return path
 
     @property

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -332,11 +332,6 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         )
 
     @property
-    def graph_root(self) -> Node:
-        """The parent-most node in this graph."""
-        return self if self.parent is None else self.parent.graph_root
-
-    @property
     def graph_path(self) -> str:
         """
         The path of node labels from the graph root (parent-most node) down to this
@@ -346,6 +341,11 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         if self.parent is not None:
             path = self.parent.graph_path + self._semantic_delimiter + path
         return path
+
+    @property
+    def graph_root(self) -> Node:
+        """The parent-most node in this graph."""
+        return self if self.parent is None else self.parent.graph_root
 
     @property
     def readiness_report(self) -> str:

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -335,10 +335,10 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         return self if self.parent is None else self.parent.graph_root
 
     @property
-    def semantic_path(self):
+    def graph_path(self):
         path = self.label
         if self.parent is not None:
-            path = self.parent.semantic_path + self._semantic_delimiter + path
+            path = self.parent.graph_path + self._semantic_delimiter + path
         # else:
         #     path = self.semantic_root + self._semantic_delimiter + path
         return path

--- a/tests/unit/test_composite.py
+++ b/tests/unit/test_composite.py
@@ -596,27 +596,61 @@ class TestComposite(unittest.TestCase):
         top.middle_composite.deep_node = Composite.create.SingleValue(plus_one)
         top.middle_function = Composite.create.SingleValue(plus_one)
 
-        self.assertIs(
-            top,
-            top.graph_root,
-            msg="The parent-most node should be its own graph_root."
-        )
-        self.assertIs(
-            top,
-            top.middle_composite.graph_root,
-            msg="The parent-most node should be the graph_root."
-        )
-        self.assertIs(
-            top,
-            top.middle_function.graph_root,
-            msg="The parent-most node should be the graph_root."
-        )
-        self.assertIs(
-            top,
-            top.middle_composite.deep_node.graph_root,
-            msg="The parent-most node should be the graph_root, recursively accessible "
-                "from all depths."
-        )
+        with self.subTest("test_graph_path"):
+            self.assertEqual(
+                top.label,
+                top.graph_path,
+                msg="The parent-most node should be its own path."
+            )
+            self.assertEqual(
+                Composite._semantic_delimiter.join(
+                    [top.label, top.middle_composite.label]
+                ),
+                top.middle_composite.graph_path,
+                msg="The path should go to the parent-most object."
+            )
+            self.assertEqual(
+                Composite._semantic_delimiter.join(
+                    [top.label, top.middle_function.label]
+                ),
+                top.middle_function.graph_path,
+                msg="The path should go to the parent-most object."
+            )
+            self.assertEqual(
+                Composite._semantic_delimiter.join(
+                    [
+                        top.label,
+                        top.middle_composite.label,
+                        top.middle_composite.deep_node.label
+                    ]
+                ),
+                top.middle_composite.deep_node.graph_path,
+                msg="The path should go to the parent-most object, recursively from all "
+                    "depths."
+            )
+
+        with self.subTest("test_graph_root"):
+            self.assertIs(
+                top,
+                top.graph_root,
+                msg="The parent-most node should be its own graph_root."
+            )
+            self.assertIs(
+                top,
+                top.middle_composite.graph_root,
+                msg="The parent-most node should be the graph_root."
+            )
+            self.assertIs(
+                top,
+                top.middle_function.graph_root,
+                msg="The parent-most node should be the graph_root."
+            )
+            self.assertIs(
+                top,
+                top.middle_composite.deep_node.graph_root,
+                msg="The parent-most node should be the graph_root, recursively accessible "
+                    "from all depths."
+            )
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_composite.py
+++ b/tests/unit/test_composite.py
@@ -598,24 +598,24 @@ class TestComposite(unittest.TestCase):
 
         self.assertIs(
             top,
-            top.root,
-            msg="The parent-most node should be its own root."
+            top.graph_root,
+            msg="The parent-most node should be its own graph_root."
         )
         self.assertIs(
             top,
-            top.middle_composite.root,
-            msg="The parent-most node should be the root."
+            top.middle_composite.graph_root,
+            msg="The parent-most node should be the graph_root."
         )
         self.assertIs(
             top,
-            top.middle_function.root,
-            msg="The parent-most node should be the root."
+            top.middle_function.graph_root,
+            msg="The parent-most node should be the graph_root."
         )
         self.assertIs(
             top,
-            top.middle_composite.deep_node.root,
-            msg="The parent-most node should be the root, recursively accessible from "
-                "all depths."
+            top.middle_composite.deep_node.graph_root,
+            msg="The parent-most node should be the graph_root, recursively accessible "
+                "from all depths."
         )
 
 

--- a/tests/unit/test_composite.py
+++ b/tests/unit/test_composite.py
@@ -590,7 +590,7 @@ class TestComposite(unittest.TestCase):
             msg="Activating should propagate to children"
         )
 
-    def test_root(self):
+    def test_graph_info(self):
         top = AComposite("topmost")
         top.middle_composite = AComposite("middle_composite")
         top.middle_composite.deep_node = Composite.create.SingleValue(plus_one)

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -344,7 +344,7 @@ class TestNode(unittest.TestCase):
             msg="With run_after_init, the node should run right away"
         )
 
-    def test_root(self):
+    def test_graph_info(self):
         n = ANode("n")
 
         self.assertEqual(

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -346,6 +346,14 @@ class TestNode(unittest.TestCase):
 
     def test_root(self):
         n = ANode("n")
+
+        self.assertEqual(
+            n.label,
+            n.graph_path,
+            msg="Lone nodes should just have their label as the path, as there is no "
+                "parent above."
+        )
+
         self.assertIs(
             n,
             n.graph_root,

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -348,8 +348,9 @@ class TestNode(unittest.TestCase):
         n = ANode("n")
         self.assertIs(
             n,
-            n.root,
-            msg="Lone nodes should be their own root, as there is no parent above."
+            n.graph_root,
+            msg="Lone nodes should be their own graph_root, as there is no parent "
+                "above."
         )
 
 


### PR DESCRIPTION
Short term intention: for finding location inside a parent-most storage file (related to #165)

Long term intention: for identification independent of storage location (related to #126)

TODO: (super simple, but I've got to run)
- [x] Attribute docstring
- [x] Unit tests (basically identical in structure to that in #165)


EDIT:

Ok, I reduced the scope just a little. This no longer claims to be the `semantic_path` -- an object which may or may not contain super-parent-most-node information in the future -- but just the path _within_ the scope of the current graph. 

Whether and how we allow the _semantic_ grouping (in contrast to operational grouping where data actually flows automatically) of multiple workflow objects is left to the future. In that hypothetical, the `graph_path` becomes merely the tail of the `semantic_path`, but for now we don't close any doors or take any attributes we'd wind up changing the meaning of later!