### PR TITLE
Accumulate run signals with scoped labels not objects

### DIFF
--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -789,7 +789,7 @@ class AccumulatingInputSignal(InputSignal):
         callback: callable,
     ):
         super().__init__(label=label, node=node, callback=callback)
-        self.received_signals: set[OutputSignal] = set()
+        self.received_signals: set[str] = set()
 
     def __call__(self, other: OutputSignal) -> None:
         """
@@ -798,8 +798,14 @@ class AccumulatingInputSignal(InputSignal):
 
         Resets the collection of received signals when firing.
         """
-        self.received_signals.update([other])
-        if len(set(self.connections).difference(self.received_signals)) == 0:
+        self.received_signals.update([other.scoped_label])
+        if len(
+            set(
+                c.scoped_label for c in self.connections
+            ).difference(
+                self.received_signals
+            )
+        ) == 0:
             self.reset()
             self.callback()
 

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -799,13 +799,14 @@ class AccumulatingInputSignal(InputSignal):
         Resets the collection of received signals when firing.
         """
         self.received_signals.update([other.scoped_label])
-        if len(
-            set(
-                c.scoped_label for c in self.connections
-            ).difference(
-                self.received_signals
+        if (
+            len(
+                set(c.scoped_label for c in self.connections).difference(
+                    self.received_signals
+                )
             )
-        ) == 0:
+            == 0
+        ):
             self.reset()
             self.callback()
 

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -381,7 +381,7 @@ class TestSignalChannels(unittest.TestCase):
         ):
             agg()
 
-        out2 = OutputSignal(label="out", node=DummyNode())
+        out2 = OutputSignal(label="out2", node=DummyNode())
         agg.connect(self.out, out2)
 
         self.assertEqual(


### PR DESCRIPTION
The scoped label will always be unique, so just store that.

The point is that as we move towards storage and serialization, this gives one less complex object that needs to live on the node.

Right now I lean towards restoring graphs by re-executing from the top, but just not actually re-running nodes who have the same input as they had at their last execution (optional (for slow nodes), evaluated by hash comparison). In that case, we don't _need_ to reload this data as the set will get re-populated at run-time. However, IMO it doesn't hurt to have it serialized, and it will be necessary for finding graph state if we wind up taking a different path to reloading.