### PR TITLE
Composites pass self instead of children and starting nodes

### DIFF
--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -729,11 +729,9 @@ class OutputData(DataChannel):
 
     # Because we override __getattr__ we need to get and set state for serialization
     def __getstate__(self):
-        return self.__dict__
+        return dict(self.__dict__)
 
     def __setstate__(self, state):
-        # Update instead of overriding in case some other attributes were added on the
-        # main process while a remote process was working away
         self.__dict__.update(**state)
 
 

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -192,6 +192,10 @@ class Composite(Node, ABC):
         return DotDict(self.outputs.to_value_dict())
 
     def _parse_remotely_executed_self(self, other_self):
+        # Un-parent existing nodes before ditching them
+        for node in self:
+            node._parent = None
+        other_self.running = False  # It's done now
         self.__setstate__(other_self.__getstate__())
 
     def disconnect_run(self) -> list[tuple[Channel, Channel]]:

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -194,16 +194,6 @@ class Composite(Node, ABC):
     def _parse_remotely_executed_self(self, other_self):
         self.__setstate__(other_self.__getstate__())
 
-    def _update_children(self, children_from_another_process: DotDict[str, Node]):
-        """
-        If you receive a new dictionary of children, e.g. from unpacking a futures
-        object of your own children you sent off to another process for computation,
-        replace your own nodes with them, and set yourself as their parent.
-        """
-        for child in children_from_another_process.values():
-            child._parent = self
-        self.nodes = children_from_another_process
-
     def disconnect_run(self) -> list[tuple[Channel, Channel]]:
         """
         Disconnect all `signals.input.run` connections on all child nodes.

--- a/pyiron_workflow/interfaces.py
+++ b/pyiron_workflow/interfaces.py
@@ -147,10 +147,10 @@ class Creator(metaclass=Singleton):
             ) from e
 
     def __getstate__(self):
-        return self.__dict__
+        return dict(self.__dict__)
 
     def __setstate__(self, state):
-        self.__dict__ = state
+        self.__dict__.update(**state)
 
     def register(self, package_identifier: str, domain: Optional[str] = None) -> None:
         """

--- a/pyiron_workflow/io.py
+++ b/pyiron_workflow/io.py
@@ -157,7 +157,7 @@ class IO(HasToDict, ABC):
 
     def __getstate__(self):
         # Compatibility with python <3.11
-        return self.__dict__
+        return dict(self.__dict__)
 
     def __setstate__(self, state):
         # Because we override getattr, we need to use __dict__ assignment directly in

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -507,10 +507,6 @@ class Macro(Composite):
             for c in channel
         ]
 
-    def _update_children(self, children_from_another_process):
-        super()._update_children(children_from_another_process)
-        self._rebuild_data_io()
-
     def _configure_graph_execution(self):
         run_signals = self.disconnect_run()
 

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from functools import partialmethod
 import inspect
-from typing import get_type_hints, Literal, Optional
+from typing import get_type_hints, Literal, Optional, TYPE_CHECKING
 
 from bidict import bidict
 
@@ -16,6 +16,9 @@ from pyiron_workflow.composite import Composite
 from pyiron_workflow.has_channel import HasChannel
 from pyiron_workflow.io import Outputs, Inputs
 from pyiron_workflow.output_parser import ParseOutput
+
+if TYPE_CHECKING:
+    from pyiron_workflow.channels import Channel
 
 
 class Macro(Composite):
@@ -470,6 +473,39 @@ class Macro(Composite):
     @property
     def outputs(self) -> Outputs:
         return self._outputs
+
+    def _parse_remotely_executed_self(self, other_self):
+        local_connection_data = [
+            [(c, c.label, c.connections) for c in io_panel]
+            for io_panel
+            in [self.inputs, self.outputs, self.signals.input, self.signals.output]
+        ]
+
+        super()._parse_remotely_executed_self(other_self)
+
+        for old_data, io_panel in zip(
+            local_connection_data,
+            [self.inputs, self.outputs, self.signals.input, self.signals.output]
+            # Get fresh copies of the IO panels post-update
+        ):
+            for original_channel, label, connections in old_data:
+                new_channel = io_panel[label]  # Fetch it from the fresh IO panel
+                new_channel.connections = connections
+                for other_channel in connections:
+                    self._replace_connection(
+                        other_channel, original_channel, new_channel
+                    )
+
+    @staticmethod
+    def _replace_connection(
+        channel: Channel, old_connection: Channel, new_connection: Channel
+    ):
+        """Brute-force replace an old connection in a channel with a new one"""
+        channel.connections = [
+            c if c is not old_connection
+            else new_connection
+            for c in channel
+        ]
 
     def _update_children(self, children_from_another_process):
         super()._update_children(children_from_another_process)

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -477,8 +477,12 @@ class Macro(Composite):
     def _parse_remotely_executed_self(self, other_self):
         local_connection_data = [
             [(c, c.label, c.connections) for c in io_panel]
-            for io_panel
-            in [self.inputs, self.outputs, self.signals.input, self.signals.output]
+            for io_panel in [
+                self.inputs,
+                self.outputs,
+                self.signals.input,
+                self.signals.output,
+            ]
         ]
 
         super()._parse_remotely_executed_self(other_self)
@@ -502,9 +506,7 @@ class Macro(Composite):
     ):
         """Brute-force replace an old connection in a channel with a new one"""
         channel.connections = [
-            c if c is not old_connection
-            else new_connection
-            for c in channel
+            c if c is not old_connection else new_connection for c in channel
         ]
 
     def _configure_graph_execution(self):

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -1073,7 +1073,7 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         # _but_ if the user is just passing instructions on how to _build_ an executor,
         # we'll trust that those serialize OK (this way we can, hopefully, eventually
         # support nesting executors!)
-        return self.__dict__
+        return state
 
     def __setstate__(self, state):
         # Update instead of overriding in case some other attributes were added on the

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -1040,7 +1040,7 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
             warnings.warn(f"Could not replace_node {self.label}, as it has no parent.")
 
     def __getstate__(self):
-        state = self.__dict__
+        state = dict(self.__dict__)
         state["_parent"] = None
         # I am not at all confident that removing the parent here is the _right_
         # solution.

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -238,6 +238,10 @@ class TestMacro(unittest.TestCase):
 
         returned_nodes = result.result(timeout=120)  # Wait for the process to finish
         sleep(1)
+        self.assertFalse(
+            macro.running,
+            msg="Macro should be done running"
+        )
         self.assertIsNot(
             original_one,
             returned_nodes.one,

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -270,7 +270,7 @@ class TestMacro(unittest.TestCase):
         self.assertIs(
             downstream.inputs.x.connections[0],
             macro.outputs.three__result,
-            msg="The macro should still be connected to "
+            msg=f"The macro output should still be connected to downstream"
         )
         sleep(0.2)  # Give a moment for the ran signal to emit and downstream to run
         # I'm a bit surprised this sleep is necessary


### PR DESCRIPTION
Previously, for remote execution `Composite` passed its children and starting nodes, and then updated those properties with the new instances of them returned in the resulting future. Now, we just ship the entire `self` off and use `__get/setstate__` to update ourselves.

The only subtlety is that when a `Macro` does this, the local instance might be aware of connections to other nodes -- the remote instance has no information about these (it only cares about the current IO values). Thus, when we update the state we need to first grab these connections from the local instance, and then re-map them so the new channel instances returned by the future get used in their place.