### PR TITLE
Copy and update __dict__

### DIFF
--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -729,11 +729,9 @@ class OutputData(DataChannel):
 
     # Because we override __getattr__ we need to get and set state for serialization
     def __getstate__(self):
-        return self.__dict__
+        return dict(self.__dict__)
 
     def __setstate__(self, state):
-        # Update instead of overriding in case some other attributes were added on the
-        # main process while a remote process was working away
         self.__dict__.update(**state)
 
 

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -192,6 +192,9 @@ class Composite(Node, ABC):
         return DotDict(self.outputs.to_value_dict())
 
     def _parse_remotely_executed_self(self, other_self):
+        # Un-parent existing nodes before ditching them
+        for node in self:
+            node._parent = None
         self.__setstate__(other_self.__getstate__())
 
     def disconnect_run(self) -> list[tuple[Channel, Channel]]:

--- a/pyiron_workflow/interfaces.py
+++ b/pyiron_workflow/interfaces.py
@@ -147,10 +147,10 @@ class Creator(metaclass=Singleton):
             ) from e
 
     def __getstate__(self):
-        return self.__dict__
+        return dict(self.__dict__)
 
     def __setstate__(self, state):
-        self.__dict__ = state
+        self.__dict__.update(**state)
 
     def register(self, package_identifier: str, domain: Optional[str] = None) -> None:
         """

--- a/pyiron_workflow/io.py
+++ b/pyiron_workflow/io.py
@@ -157,7 +157,7 @@ class IO(HasToDict, ABC):
 
     def __getstate__(self):
         # Compatibility with python <3.11
-        return self.__dict__
+        return dict(self.__dict__)
 
     def __setstate__(self, state):
         # Because we override getattr, we need to use __dict__ assignment directly in

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -1040,7 +1040,7 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
             warnings.warn(f"Could not replace_node {self.label}, as it has no parent.")
 
     def __getstate__(self):
-        state = self.__dict__
+        state = dict(self.__dict__)
         state["_parent"] = None
         # I am not at all confident that removing the parent here is the _right_
         # solution.


### PR DESCRIPTION
Sometimes we mess with stuff in __getstate__, e.g. to avoid reflexive relationships between nodes and channels, but getting the state should never modify the current state, so always make a fresh dictionary. Similarly, the returned state might possibly not have all the content our current state does, so use update instead of overwriting.