### PR TITLE
:bug: stop running

### DIFF
--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -195,6 +195,7 @@ class Composite(Node, ABC):
         # Un-parent existing nodes before ditching them
         for node in self:
             node._parent = None
+        other_self.running = False  # It's done now
         self.__setstate__(other_self.__getstate__())
 
     def disconnect_run(self) -> list[tuple[Channel, Channel]]:

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -238,6 +238,10 @@ class TestMacro(unittest.TestCase):
 
         returned_nodes = result.result(timeout=120)  # Wait for the process to finish
         sleep(1)
+        self.assertFalse(
+            macro.running,
+            msg="Macro should be done running"
+        )
         self.assertIsNot(
             original_one,
             returned_nodes.one,


### PR DESCRIPTION
By setting `running=False` on the local instance _before_ updating the state, we were then re-writing `running=True` when updating the state. Update the flag on the received instance as well, and add a test so the same issue doesn't crop up again.