### PR TITLE
Non-reflexive state

### DIFF
--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -489,6 +489,13 @@ class DataChannel(Channel, ABC):
             else storage["value"]
         )
 
+    def __getstate__(self):
+        state = super().__getstate__()
+        state["_value_receiver"] = None
+        # Value receivers live in the scope of Macros, so (re)storing them is the
+        # owning macro's responsibility
+        return state
+
 
 class InputData(DataChannel):
     @property

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -215,6 +215,19 @@ class Channel(HasChannel, HasToDict, ABC):
             "connections": [f"{c.node.label}.{c.label}" for c in self.connections],
         }
 
+    def __getstate__(self):
+        state = self.__dict__
+        # To avoid cyclic storage and avoid storing complex objects, purge some
+        # properties from the state
+        state["node"] = None
+        # It is the responsibility of the owning node to restore the node property
+        return state
+
+    def __setstate__(self, state):
+        # Update instead of overriding in case some other attributes were added on the
+        # main process while a remote process was working away
+        self.__dict__.update(**state)
+
 
 class NotData:
     """

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -750,13 +750,6 @@ class OutputData(DataChannel):
 
         return self._node_injection(Round)
 
-    # Because we override __getattr__ we need to get and set state for serialization
-    def __getstate__(self):
-        return dict(self.__dict__)
-
-    def __setstate__(self, state):
-        self.__dict__.update(**state)
-
 
 class SignalChannel(Channel, ABC):
     """

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -216,11 +216,14 @@ class Channel(HasChannel, HasToDict, ABC):
         }
 
     def __getstate__(self):
-        state = self.__dict__
+        state = dict(self.__dict__)
         # To avoid cyclic storage and avoid storing complex objects, purge some
         # properties from the state
         state["node"] = None
         # It is the responsibility of the owning node to restore the node property
+        state["connections"] = []
+        # It is the responsibility of the owning node's parent to store and restore
+        # connections (if any)
         return state
 
     def __setstate__(self, state):

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -611,10 +611,7 @@ class Composite(Node, ABC):
         the name is protected.
         """
         return [
-            (
-                (inp.node.label, inp.label),
-                (out.node.label, out.label)
-            )
+            ((inp.node.label, inp.label), (out.node.label, out.label))
             for child in self
             for inp in panel_getter(child)
             for out in inp.connections
@@ -634,7 +631,7 @@ class Composite(Node, ABC):
 
     @property
     def _child_signal_connections(
-        self
+        self,
     ) -> list[tuple[tuple[str, str], tuple[str, str]]]:
         return self._get_connections_as_strings(self._get_signals_input)
 
@@ -679,7 +676,7 @@ class Composite(Node, ABC):
                 among these nodes in the format ((input node label, input channel label
                 ), (output node label, output channel label)).
         """
-        for ((inp_node, inp), (out_node, out)) in connections:
+        for (inp_node, inp), (out_node, out) in connections:
             input_panel_getter(nodes[inp_node])[inp].connect(
                 output_panel_getter(nodes[out_node])[out]
             )
@@ -711,4 +708,3 @@ class Composite(Node, ABC):
             self._get_signals_input,
             self._get_signals_output,
         )
-

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -556,8 +556,7 @@ class Macro(Composite):
         """
         return [
             (c.label, (c.value_receiver.node.label, c.value_receiver.label))
-            for c
-            in self.inputs
+            for c in self.inputs
         ]
 
     @property
@@ -590,10 +589,10 @@ class Macro(Composite):
         super().__setstate__(state)
 
         # Re-forge value links
-        for (inp, (child, child_inp)) in input_links:
+        for inp, (child, child_inp) in input_links:
             self.inputs[inp].value_receiver = self.nodes[child].inputs[child_inp]
 
-        for ((child, child_out), out) in output_links:
+        for (child, child_out), out in output_links:
             self.nodes[child].outputs[child_out].value_receiver = self.outputs[out]
 
 

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -484,7 +484,6 @@ class Macro(Composite):
                 self.signals.output,
             ]
         ]
-
         super()._parse_remotely_executed_self(other_self)
 
         for old_data, io_panel in zip(
@@ -584,14 +583,18 @@ class Macro(Composite):
         return state
 
     def __setstate__(self, state):
-        # Purge value links from the state and re-forge them
-        for (inp, (child, child_inp)) in state.pop("_input_value_links"):
-            self.inputs[inp].value_receiver = self.nodes[child].inputs[child_inp]
-
-        for ((child, child_out), out) in state.pop("_output_value_links"):
-            self.nodes[child].outputs[child_out].value_receiver = self.outputs[out]
+        # Purge value links from the state
+        input_links = state.pop("_input_value_links")
+        output_links = state.pop("_output_value_links")
 
         super().__setstate__(state)
+
+        # Re-forge value links
+        for (inp, (child, child_inp)) in input_links:
+            self.inputs[inp].value_receiver = self.nodes[child].inputs[child_inp]
+
+        for ((child, child_out), out) in output_links:
+            self.nodes[child].outputs[child_out].value_receiver = self.outputs[out]
 
 
 def macro_node(*output_labels, **node_class_kwargs):

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -546,6 +546,53 @@ class Macro(Composite):
         for label, node in self.nodes.items():
             node.from_storage(storage[label])
 
+    @property
+    def _input_value_links(self):
+        """
+        Value connections between child output and macro in string representation based
+        on labels.
+
+        The string representation helps storage, and having it as a property ensures
+        the name is protected.
+        """
+        return [
+            (c.label, (c.value_receiver.node.label, c.value_receiver.label))
+            for c
+            in self.inputs
+        ]
+
+    @property
+    def _output_value_links(self):
+        """
+        Value connections between macro and child input in string representation based
+        on labels.
+
+        The string representation helps storage, and having it as a property ensures
+        the name is protected.
+        """
+        return [
+            ((c.node.label, c.label), c.value_receiver.label)
+            for child in self
+            for c in child.outputs
+            if c.value_receiver is not None
+        ]
+
+    def __getstate__(self):
+        state = super().__getstate__()
+        state["_input_value_links"] = self._input_value_links
+        state["_output_value_links"] = self._output_value_links
+        return state
+
+    def __setstate__(self, state):
+        # Purge value links from the state and re-forge them
+        for (inp, (child, child_inp)) in state.pop("_input_value_links"):
+            self.inputs[inp].value_receiver = self.nodes[child].inputs[child_inp]
+
+        for ((child, child_out), out) in state.pop("_output_value_links"):
+            self.nodes[child].outputs[child_out].value_receiver = self.outputs[out]
+
+        super().__setstate__(state)
+
 
 def macro_node(*output_labels, **node_class_kwargs):
     """

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -1079,6 +1079,14 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         # Update instead of overriding in case some other attributes were added on the
         # main process while a remote process was working away
         self.__dict__.update(**state)
+        for io_panel in [
+            self.inputs,
+            self.outputs,
+            self.signals.input,
+            self.signals.output,
+        ]:
+            for channel in io_panel:
+                channel.node = self
 
     def executor_shutdown(self, wait=True, *, cancel_futures=False):
         """Invoke shutdown on the executor (if present)."""

--- a/pyiron_workflow/workflow.py
+++ b/pyiron_workflow/workflow.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from bidict import bidict
 
     from pyiron_workflow.channels import InputData, OutputData
+    from pyiron_workflow.io import IO
     from pyiron_workflow.node import Node
 
 
@@ -383,3 +384,13 @@ class Workflow(Composite):
                 f"be in your python path and importable at load time too."
             )
         self.to_storage(self.storage)
+
+    @property
+    def _owned_io_panels(self) -> list[IO]:
+        # Workflow data IO is just pointers to child IO, not actually owned directly
+        # by the workflow; this is used in re-parenting channels, and we don't want to
+        # override the real parent with this workflow!
+        return [
+            self.signals.input,
+            self.signals.output,
+        ]


### PR DESCRIPTION
Purge the remaining references from children to their parents in `__get/setstate__`:
- `Node` purges `parent`, responsibility to (re)store falls on `Composite`
- `Channel` purges `node`, responsibility to (re)store falls on `Node`
- `DataChannel` purges `_value_receiver`, responsibility to (re)store falls on `Macro`
- `Channel` purges `connections`, responsibility to (re)store falls on the `Composite` that is the channel instance's `node.parent` (if any)

This allows us to avoid recursion in serialization, which is treated ok (to a recursion limit if I understand) in `(cloud)pickle`, but not acceptable for `h5io`.