### PR TITLE
`NotData` as singleton instead

### DIFF
--- a/notebooks/deepdive.ipynb
+++ b/notebooks/deepdive.ipynb
@@ -90,7 +90,7 @@
    "id": "22ee2a49-47d1-4cec-bb25-8441ea01faf7",
    "metadata": {},
    "source": [
-    "The output is still empty (`NotData`) because we haven't `run()` the node:"
+    "The output is still empty (`NOT_DATA`) because we haven't `run()` the node:"
    ]
   },
   {
@@ -3501,7 +3501,7 @@
    "source": [
     "from time import perf_counter, sleep\n",
     "\n",
-    "from pyiron_workflow.channels import NotData\n",
+    "from pyiron_workflow.channels import NOT_DATA\n",
     "\n",
     "@Workflow.wrap_as.single_value_node()\n",
     "def Wait(t):\n",
@@ -3536,7 +3536,7 @@
     "wf.starting_nodes = [wf.a]\n",
     "t0 = perf_counter()\n",
     "out = wf()\n",
-    "while wf.outputs.d__user_input.value is NotData:\n",
+    "while wf.outputs.d__user_input.value is NOT_DATA:\n",
     "    sleep(0.001)\n",
     "dt_serial = perf_counter() - t0\n",
     "\n",
@@ -3575,7 +3575,7 @@
     "\n",
     "    t1 = perf_counter()\n",
     "    out = wf()\n",
-    "    while wf.outputs.d__user_input.value is NotData:\n",
+    "    while wf.outputs.d__user_input.value is NOT_DATA:\n",
     "        sleep(0.001)\n",
     "    dt_parallel = perf_counter() - t1\n",
     "\n",

--- a/notebooks/deepdive.ipynb
+++ b/notebooks/deepdive.ipynb
@@ -103,7 +103,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'x+1': <class 'pyiron_workflow.channels.NotData'>, 'x-1': <class 'pyiron_workflow.channels.NotData'>}\n"
+      "{'x+1': NOT_DATA, 'x-1': NOT_DATA}\n"
      ]
     }
    ],
@@ -524,7 +524,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:166: UserWarning: The channel run was not connected to ran, andthus could not disconnect from it.\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:168: UserWarning: The channel run was not connected to ran, andthus could not disconnect from it.\n",
       "  warn(\n"
      ]
     },
@@ -983,13 +983,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:166: UserWarning: The channel run was not connected to ran, andthus could not disconnect from it.\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:168: UserWarning: The channel run was not connected to ran, andthus could not disconnect from it.\n",
       "  warn(\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8g+/7EAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAh+UlEQVR4nO3df1Bc1d3H8c+yBDam2XVIDKwJjSQ1GmTUAkOENOPUx2Cig02nTvCxSdTGjkRtTKi2SdMRyTjDaEen/gj4K9FxElOq1VZmKIZ/GsmPloaQjpHM6BhaErPIAOOCPyAGzvNHCo8rS8LdwJ7s5v2a2T84nMt+994w95Nzzj24jDFGAAAAliTYLgAAAFzYCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArEq0XcBYDA4O6sSJE5o6dapcLpftcgAAwBgYY9Tb26tLL71UCQmjj3/ERBg5ceKE0tPTbZcBAAAicOzYMc2aNWvU78dEGJk6daqk0x/G6/VargYAAIxFT0+P0tPTh+/jo4mJMDI0NeP1egkjAADEmLMtsWABKwAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMCqmNj0DBgYNGps7VZHb59mTPUoLyNF7gT+ThEAxAPCyDniJjnx6g4HVF7TokCwb7jN7/OorChTS7L8FisDAIwHwsg54CY58eoOB7Rm+0GZb7W3B/u0ZvtBVa3I5lwDQIxjzUiEhm6S3wwi0v/fJOsOByxVFj8GBo3Ka1pGBBFJw23lNS0aGAzXAwAQKwgjEeAmGR2Nrd0jwt43GUmBYJ8aW7ujVxQAYNwRRiLATTI6OnpHP8eR9AMAnJ8IIxHgJhkdM6Z6xrUfAOD8RBiJADfJ6MjLSJHf59Fozya5dHrBcF5GSjTLAgCMM8JIBLhJRoc7waWyokxJGnGuh74uK8rkUWoAiHGEkQhwk4yeJVl+Va3IVpovdJQpzefhsV4AiBMuY8x5/8hHT0+PfD6fgsGgvF6v7XKGsc9I9LC5HADEnrHevwkj54ibJAAA4Y31/s0OrOfIneBS/txptssAACBmsWYEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVRGFkcrKSmVkZMjj8SgnJ0cNDQ1n7L9jxw5dc801uuiii+T3+3X33Xerq6srooIBAEB8cRxGqqurtW7dOm3atEnNzc1atGiRli5dqra2trD99+zZo1WrVmn16tX64IMP9MYbb+if//yn7rnnnnMuHgAAxD7HYeSpp57S6tWrdc8992j+/Pn6/e9/r/T0dFVVVYXt//e//12XXXaZ1q5dq4yMDP3gBz/QvffeqwMHDpxz8QAAIPY5CiMnT55UU1OTCgsLQ9oLCwu1b9++sMcUFBTo+PHjqq2tlTFGn376qd58803dcssto75Pf3+/enp6Ql4AACA+OQojnZ2dGhgYUGpqakh7amqq2tvbwx5TUFCgHTt2qLi4WElJSUpLS9PFF1+sZ599dtT3qaiokM/nG36lp6c7KRMAAMSQiBawulyukK+NMSPahrS0tGjt2rV65JFH1NTUpLq6OrW2tqqkpGTUn79x40YFg8Hh17FjxyIpEwAAxIBEJ52nT58ut9s9YhSko6NjxGjJkIqKCi1cuFAPP/ywJOnqq6/WlClTtGjRIj322GPy+/0jjklOTlZycrKT0gAAQIxyNDKSlJSknJwc1dfXh7TX19eroKAg7DFffvmlEhJC38btdks6PaICAAAubI6naUpLS/Xyyy9r27ZtOnLkiNavX6+2trbhaZeNGzdq1apVw/2Lior01ltvqaqqSkePHtXevXu1du1a5eXl6dJLLx2/TwIAAGKSo2kaSSouLlZXV5c2b96sQCCgrKws1dbWavbs2ZKkQCAQsufIXXfdpd7eXj333HP65S9/qYsvvlg33HCDHn/88fH7FAAAIGa5TAzMlfT09Mjn8ykYDMrr9douBwAAjMFY79/8bRoAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFgVURiprKxURkaGPB6PcnJy1NDQcMb+/f392rRpk2bPnq3k5GTNnTtX27Zti6hgAAAQXxKdHlBdXa1169apsrJSCxcu1AsvvKClS5eqpaVF3/3ud8Mes3z5cn366afaunWrvve976mjo0OnTp065+IBAEDscxljjJMDFixYoOzsbFVVVQ23zZ8/X8uWLVNFRcWI/nV1dbr99tt19OhRpaSkRFRkT0+PfD6fgsGgvF5vRD8DAABE11jv346maU6ePKmmpiYVFhaGtBcWFmrfvn1hj3nnnXeUm5urJ554QjNnztS8efP00EMP6auvvhr1ffr7+9XT0xPyAgAA8cnRNE1nZ6cGBgaUmpoa0p6amqr29vawxxw9elR79uyRx+PR22+/rc7OTt13333q7u4edd1IRUWFysvLnZQGAMC4Ghg0amztVkdvn2ZM9SgvI0XuBJftsuKS4zUjkuRyhV4MY8yItiGDg4NyuVzasWOHfD6fJOmpp57Sbbfdpi1btmjy5Mkjjtm4caNKS0uHv+7p6VF6enokpQIA4Fjd4YDKa1oUCPYNt/l9HpUVZWpJlt9iZfHJ0TTN9OnT5Xa7R4yCdHR0jBgtGeL3+zVz5szhICKdXmNijNHx48fDHpOcnCyv1xvyAgAgGuoOB7Rm+8GQICJJ7cE+rdl+UHWHA5Yqi1+OwkhSUpJycnJUX18f0l5fX6+CgoKwxyxcuFAnTpzQ559/Ptz24YcfKiEhQbNmzYqgZAAAJsbAoFF5TYvCPdkx1FZe06KBQUfPfuAsHO8zUlpaqpdfflnbtm3TkSNHtH79erW1tamkpETS6SmWVatWDfe/4447NG3aNN19991qaWnRe++9p4cfflg/+9nPwk7RAABgS2Nr94gRkW8ykgLBPjW2dkevqAuA4zUjxcXF6urq0ubNmxUIBJSVlaXa2lrNnj1bkhQIBNTW1jbc/zvf+Y7q6+v1i1/8Qrm5uZo2bZqWL1+uxx57bPw+BQAA46Cjd/QgEkk/jI3jfUZsYJ8RAEA07P+4S//70t/P2m/nz69T/txpUagotk3IPiMAAMSzvIwU+X0ejfYAr0unn6rJy4hsE0+ERxgBAOC/3AkulRVlStKIQDL0dVlRJvuNjDPCCAAA37Aky6+qFdlK83lC2tN8HlWtyGafkQkQ0aZnAADEsyVZfi3OTGMH1ighjAAAEIY7wcUi1ShhmgYAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYFWi7QIAAIAdA4NGja3d6ujt04ypHuVlpMid4Ip6HYQRAAAuQHWHAyqvaVEg2Dfc5vd5VFaUqSVZ/qjWwjQNAAAXmLrDAa3ZfjAkiEhSe7BPa7YfVN3hQFTrIYwAAHABGRg0Kq9pkQnzvaG28poWDQyG6zExCCMAAFxAGlu7R4yIfJORFAj2qbG1O2o1EUYAALiAdPSOHkQi6TceCCMAAFxAZkz1jGu/8cDTNGNwvjz6BADAucrLSJHf51F7sC/suhGXpDTf6XtdtBBGzuJ8evQJAIBz5U5wqawoU2u2H5RLCgkkQ//NLivKjOp/upmmOYPz7dEnAADGw5Isv6pWZCvNFzoVk+bzqGpFdtT/s83IyCjO9uiTS6cffVqcmcaUDQAg5izJ8mtxZtp5sQyBMDIKJ48+5c+dFr3CAAAYJ+4E13lxD2OaZhTn46NPAADEI8LIKM7HR58AAIhHhJFRDD36NNrMmUunn6qJ5qNPAADEI8LIKIYefZI0IpDYevQJAIB4RBg5g/Pt0ScAAOIRT9Ocxfn06BMAAPGIMDIG58ujTwAAxCOmaQAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGBVRGGksrJSGRkZ8ng8ysnJUUNDw5iO27t3rxITE3XttddG8rYAACAOOQ4j1dXVWrdunTZt2qTm5mYtWrRIS5cuVVtb2xmPCwaDWrVqlf7nf/4n4mIBAED8cRljjJMDFixYoOzsbFVVVQ23zZ8/X8uWLVNFRcWox91+++26/PLL5Xa79ec//1mHDh0a83v29PTI5/MpGAzK6/U6KRcAAFgy1vu3o5GRkydPqqmpSYWFhSHthYWF2rdv36jHvfLKK/r4449VVlY2pvfp7+9XT09PyAsAAMQnR2Gks7NTAwMDSk1NDWlPTU1Ve3t72GM++ugjbdiwQTt27FBiYuKY3qeiokI+n2/4lZ6e7qRMAAAQQyJawOpyuUK+NsaMaJOkgYEB3XHHHSovL9e8efPG/PM3btyoYDA4/Dp27FgkZQIAgBgwtqGK/5o+fbrcbveIUZCOjo4RoyWS1NvbqwMHDqi5uVkPPPCAJGlwcFDGGCUmJmrXrl264YYbRhyXnJys5ORkJ6UBAIAY5WhkJCkpSTk5Oaqvrw9pr6+vV0FBwYj+Xq9X77//vg4dOjT8Kikp0RVXXKFDhw5pwYIF51Y9AACIeY5GRiSptLRUK1euVG5urvLz8/Xiiy+qra1NJSUlkk5PsXzyySd67bXXlJCQoKysrJDjZ8yYIY/HM6IdAABcmByHkeLiYnV1dWnz5s0KBALKyspSbW2tZs+eLUkKBAJn3XMEAABgiON9RmxgnxEAAGLPhOwzAgAAMN4IIwAAwCrCCAAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArEq0XUCsGhg0amztVkdvn2ZM9SgvI0XuBJftsgAAiDmEkQjUHQ6ovKZFgWDfcJvf51FZUaaWZPktVgYAQOxhmsahusMBrdl+MCSISFJ7sE9rth9U3eGApcoAAIhNhBEHBgaNymtaZMJ8b6itvKZFA4PhegAAgHAIIw40tnaPGBH5JiMpEOxTY2t39IoCACDGEUYc6OgdPYhE0g8AABBGHJkx1TOu/QAAAGHEkbyMFPl9Ho32AK9Lp5+qyctIiWZZAADENMKIA+4El8qKMiVpRCAZ+rqsKJP9RgAAcIAw4tCSLL+qVmQrzRc6FZPm86hqRTb7jAAA4BCbnkVgSZZfizPT2IEVAIBxQBiJkDvBpfy502yXAQBAzGOaBgAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFgVURiprKxURkaGPB6PcnJy1NDQMGrft956S4sXL9Yll1wir9er/Px8vfvuuxEXDAAA4ovjMFJdXa1169Zp06ZNam5u1qJFi7R06VK1tbWF7f/ee+9p8eLFqq2tVVNTk374wx+qqKhIzc3N51w8AACIfS5jjHFywIIFC5Sdna2qqqrhtvnz52vZsmWqqKgY08+46qqrVFxcrEceeWRM/Xt6euTz+RQMBuX1ep2UCwAALBnr/dvRyMjJkyfV1NSkwsLCkPbCwkLt27dvTD9jcHBQvb29SklJcfLWAAAgTiU66dzZ2amBgQGlpqaGtKempqq9vX1MP+PJJ5/UF198oeXLl4/ap7+/X/39/cNf9/T0OCkT42hg0KixtVsdvX2aMdWjvIwUuRNctssCAMQRR2FkiMsVejMyxoxoC2fnzp169NFH9Ze//EUzZswYtV9FRYXKy8sjKQ3jqO5wQOU1LQoE+4bb/D6PyooytSTLb7EyAEA8cTRNM336dLnd7hGjIB0dHSNGS76turpaq1ev1h//+EfdeOONZ+y7ceNGBYPB4dexY8eclIlxUHc4oDXbD4YEEUlqD/ZpzfaDqjscsFQZACDeOAojSUlJysnJUX19fUh7fX29CgoKRj1u586duuuuu/T666/rlltuOev7JCcny+v1hrwQPQODRuU1LQq3snmorbymRQODjtY+AwAQluNpmtLSUq1cuVK5ubnKz8/Xiy++qLa2NpWUlEg6ParxySef6LXXXpN0OoisWrVKTz/9tK677rrhUZXJkyfL5/ON40fBeGls7R4xIvJNRlIg2KfG1m7lz50WvcIAAHHJcRgpLi5WV1eXNm/erEAgoKysLNXW1mr27NmSpEAgELLnyAsvvKBTp07p/vvv1/333z/cfuedd+rVV18990+AcdfRO3oQiaQfAABn4nifERvYZyS69n/cpf996e9n7bfz59cxMgIAGNWE7DOCC0NeRor8Po9Gez7KpdNP1eRlsFcMAODcEUYwgjvBpbKiTEkaEUiGvi4rymS/EQDAuCCMIKwlWX5VrchWms8T0p7m86hqRTb7jAAAxk1Em57hwrAky6/FmWnswAoAmFCEEZyRO8HFIlUAwIRimgYAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWJdou4EI1MGjU2Nqtjt4+zZjqUV5GitwJLttlAQAQdYQRC+oOB1Re06JAsG+4ze/zqKwoU0uy/BYrAwAg+pimibK6wwGt2X4wJIhIUnuwT2u2H1Td4YClygAAsIMwEkUDg0blNS0yYb431FZe06KBwXA9AACIT4SRKGps7R4xIvJNRlIg2KfG1u7oFQUAgGWEkSjq6B09iETSDwCAeEAYiaIZUz3j2g8AgHhAGImivIwU+X0ejfYAr0unn6rJy0iJZlkAAFhFGIkid4JLZUWZkjQikAx9XVaUyX4jAIALCmEkypZk+VW1IltpvtCpmDSfR1UrstlnBABwwWHTMwuWZPm1ODONHVgBABBhxBp3gkv5c6fZLgMAAOuYpgEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYFWi7QIQewYGjRpbu9XR26cZUz3Ky0iRO8FluywAQIwijMCRusMBlde0KBDsG27z+zwqK8rUkiy/xcoAALGKaRqMWd3hgNZsPxgSRCSpPdinNdsPqu5wwFJlAIBYRhjBmAwMGpXXtMiE+d5QW3lNiwYGw/UAAGB0hBGMSWNr94gRkW8ykgLBPjW2dkevKABAXLhg14ywCNOZjt7Rg0gk/QAAGHJBhhEWYTo3Y6pnXPsBADDkgpumYRFmZPIyUuT3eTTa2JFLpwNdXkZKNMsCAMSBiMJIZWWlMjIy5PF4lJOTo4aGhjP23717t3JycuTxeDRnzhw9//zzERV7rliEGTl3gktlRZmSNCKQDH1dVpTJVBcAwDHHYaS6ulrr1q3Tpk2b1NzcrEWLFmnp0qVqa2sL27+1tVU333yzFi1apObmZv3mN7/R2rVr9ac//emci3eKRZjnZkmWX1UrspXmC52KSfN5VLUimykuAEBEXMYYR8MACxYsUHZ2tqqqqobb5s+fr2XLlqmiomJE/1//+td65513dOTIkeG2kpIS/etf/9L+/fvH9J49PT3y+XwKBoPyer1Oyg3xl0Of6ME/HDprv6dvv1Y/unZmxO8T71j8CwAYi7Hevx0tYD158qSampq0YcOGkPbCwkLt27cv7DH79+9XYWFhSNtNN92krVu36uuvv9akSZNGHNPf36/+/v6QDzMeWIQ5PtwJLuXPnWa7DABAnHA0TdPZ2amBgQGlpqaGtKempqq9vT3sMe3t7WH7nzp1Sp2dnWGPqaiokM/nG36lp6c7KXNULMIEAOD8E9ECVpcr9HZujBnRdrb+4dqHbNy4UcFgcPh17NixSMocgUWYAACcfxyFkenTp8vtdo8YBeno6Bgx+jEkLS0tbP/ExERNmxZ+qD85OVlerzfkNV5YhAkAwPnF0ZqRpKQk5eTkqL6+Xj/+8Y+H2+vr6/WjH/0o7DH5+fmqqakJadu1a5dyc3PDrheJhiVZfi3OTGMRJgAA5wHHO7CWlpZq5cqVys3NVX5+vl588UW1tbWppKRE0ukplk8++USvvfaapNNPzjz33HMqLS3Vz3/+c+3fv19bt27Vzp07x/eTOMQiTAAAzg+Ow0hxcbG6urq0efNmBQIBZWVlqba2VrNnz5YkBQKBkD1HMjIyVFtbq/Xr12vLli269NJL9cwzz+gnP/nJ+H0KAAAQsxzvM2LDeO0zAgAAomes9+8L7m/TAACA8wthBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWOd70zIahrVB6enosVwIAAMZq6L59ti3NYiKM9Pb2SpLS09MtVwIAAJzq7e2Vz+cb9fsxsQPr4OCgTpw4oalTp8rlGtsfs+vp6VF6erqOHTvGrq2WcA3s4vzbxzWwj2tglzFGvb29uvTSS5WQMPrKkJgYGUlISNCsWbMiOtbr9fIP0DKugV2cf/u4BvZxDew504jIEBawAgAAqwgjAADAqrgNI8nJySorK1NycrLtUi5YXAO7OP/2cQ3s4xrEhphYwAoAAOJX3I6MAACA2EAYAQAAVhFGAACAVYQRAABgVUyHkcrKSmVkZMjj8SgnJ0cNDQ1n7L97927l5OTI4/Fozpw5ev7556NUafxycg3eeustLV68WJdccom8Xq/y8/P17rvvRrHa+OP0d2DI3r17lZiYqGuvvXZiC7wAOL0G/f392rRpk2bPnq3k5GTNnTtX27Zti1K18cfp+d+xY4euueYaXXTRRfL7/br77rvV1dUVpWoxKhOj/vCHP5hJkyaZl156ybS0tJgHH3zQTJkyxfznP/8J2//o0aPmoosuMg8++KBpaWkxL730kpk0aZJ58803o1x5/HB6DR588EHz+OOPm8bGRvPhhx+ajRs3mkmTJpmDBw9GufL44PT8D/nss8/MnDlzTGFhobnmmmuiU2yciuQa3HrrrWbBggWmvr7etLa2mn/84x9m7969Uaw6fjg9/w0NDSYhIcE8/fTT5ujRo6ahocFcddVVZtmyZVGuHN8Ws2EkLy/PlJSUhLRdeeWVZsOGDWH7/+pXvzJXXnllSNu9995rrrvuugmrMd45vQbhZGZmmvLy8vEu7YIQ6fkvLi42v/3tb01ZWRlh5Bw5vQZ//etfjc/nM11dXdEoL+45Pf+/+93vzJw5c0LannnmGTNr1qwJqxFjE5PTNCdPnlRTU5MKCwtD2gsLC7Vv376wx+zfv39E/5tuukkHDhzQ119/PWG1xqtIrsG3DQ4Oqre3VykpKRNRYlyL9Py/8sor+vjjj1VWVjbRJca9SK7BO++8o9zcXD3xxBOaOXOm5s2bp4ceekhfffVVNEqOK5Gc/4KCAh0/fly1tbUyxujTTz/Vm2++qVtuuSUaJeMMYuIP5X1bZ2enBgYGlJqaGtKempqq9vb2sMe0t7eH7X/q1Cl1dnbK7/dPWL3xKJJr8G1PPvmkvvjiCy1fvnwiSoxrkZz/jz76SBs2bFBDQ4MSE2PyV/+8Esk1OHr0qPbs2SOPx6O3335bnZ2duu+++9Td3c26EYciOf8FBQXasWOHiouL1dfXp1OnTunWW2/Vs88+G42ScQYxOTIyxOVyhXxtjBnRdrb+4doxdk6vwZCdO3fq0UcfVXV1tWbMmDFR5cW9sZ7/gYEB3XHHHSovL9e8efOiVd4FwcnvwODgoFwul3bs2KG8vDzdfPPNeuqpp/Tqq68yOhIhJ+e/paVFa9eu1SOPPKKmpibV1dWptbVVJSUl0SgVZxCT/z2aPn263G73iPTb0dExIiUPSUtLC9s/MTFR06ZNm7Ba41Uk12BIdXW1Vq9erTfeeEM33njjRJYZt5ye/97eXh04cEDNzc164IEHJJ2+MRpjlJiYqF27dumGG26ISu3xIpLfAb/fr5kzZ4b8SfX58+fLGKPjx4/r8ssvn9Ca40kk57+iokILFy7Uww8/LEm6+uqrNWXKFC1atEiPPfYYI+QWxeTISFJSknJyclRfXx/SXl9fr4KCgrDH5Ofnj+i/a9cu5ebmatKkSRNWa7yK5BpIp0dE7rrrLr3++uvM054Dp+ff6/Xq/fff16FDh4ZfJSUluuKKK3To0CEtWLAgWqXHjUh+BxYuXKgTJ07o888/H2778MMPlZCQoFmzZk1ovfEmkvP/5ZdfKiEh9Lbndrsl/f9IOSyxtXL2XA090rV161bT0tJi1q1bZ6ZMmWL+/e9/G2OM2bBhg1m5cuVw/6FHe9evX29aWlrM1q1bebT3HDm9Bq+//rpJTEw0W7ZsMYFAYPj12Wef2foIMc3p+f82nqY5d06vQW9vr5k1a5a57bbbzAcffGB2795tLr/8cnPPPffY+ggxzen5f+WVV0xiYqKprKw0H3/8sdmzZ4/Jzc01eXl5tj4C/itmw4gxxmzZssXMnj3bJCUlmezsbLN79+7h7915553m+uuvD+n/t7/9zXz/+983SUlJ5rLLLjNVVVVRrjj+OLkG119/vZE04nXnnXdGv/A44fR34JsII+PD6TU4cuSIufHGG83kyZPNrFmzTGlpqfnyyy+jXHX8cHr+n3nmGZOZmWkmT55s/H6/+elPf2qOHz8e5arxbS5jGJsCAAD2xOSaEQAAED8IIwAAwCrCCAAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKz6PygrOcUH0mZqAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8g+/7EAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAkVklEQVR4nO3dfUzd5f3/8dfhUDjalWNoBU5v1h0bb4pkOiB04BozZ7HV4K+JixhXq06XUbfVlulW1kWkMSHuxkw3i1NbjWl1RKf7ScKwZL+s0puNlcIi0kxjmbT2MAJkB7yB2nOu3x/9wtfjOVTOKZzrcM7zkZw/znWuD+d9ctmcl9d1ruvjMMYYAQAAWJJmuwAAAJDaCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArEq3XcB0BINBnTp1SgsWLJDD4bBdDgAAmAZjjEZHR7V48WKlpU09/zEnwsipU6e0bNky22UAAIAYnDhxQkuXLp3y9ajDyJtvvqlf/vKX6ujokM/n02uvvab169ef85r9+/erurpab7/9thYvXqyf/OQnqqqqmvZ7LliwQNLZD5OVlRVtyQAAwIKRkREtW7Zs8nt8KlGHkY8++khXXXWV7r77bt1yyy1f2L+3t1c33nijvve972nPnj06ePCg7rvvPl188cXTul7S5NJMVlYWYQQAgDnmi35iEXUYWbdundatWzft/k899ZS+/OUv6ze/+Y0kaeXKlTpy5Ih+9atfTTuMAACA5DXru2kOHz6s8vLykLYbbrhBR44c0aeffhrxmvHxcY2MjIQ8AABAcpr1MNLf36/c3NyQttzcXJ05c0aDg4MRr6mvr5fb7Z588ONVAACSV1zOGfn8WpExJmL7hJqaGvn9/snHiRMnZr1GAABgx6xv7c3Ly1N/f39I28DAgNLT07Vw4cKI12RmZiozM3O2SwMAAAlg1mdGSktL1draGtK2b98+FRcXa968ebP99gAAIMFFHUY+/PBDdXV1qaurS9LZrbtdXV3q6+uTdHaJZePGjZP9q6qq9P7776u6ulrHjh3T7t27tWvXLj3wwAMz8wkAAMCcFvUyzZEjR/TNb35z8nl1dbUk6c4779Tzzz8vn883GUwkyev1qrm5WVu3btWTTz6pxYsX64knnmBbLwAAkCQ5zMSvSRPYyMiI3G63/H4/h54BQIoIBI3ae4c1MDqmnAUulXiz5Uzj/mRzyXS/v+fEvWkAAKmlpdunuqYe+fxjk20et0u1FflaW+CxWBlmQ1y29gIAMF0t3T5t2nM0JIhIUr9/TJv2HFVLt89SZZgthBEAQMIIBI3qmnoU6fcDE211TT0KBBP+FwaIAmEEAJAw2nuHw2ZEPstI8vnH1N47HL+iMOsIIwCAhDEwOnUQiaUf5gbCCAAgYeQscM1oP8wNhBEAQMIo8WbL43Zpqg28Dp3dVVPizY5nWZhlhBEAQMJwpjlUW5EvSWGBZOJ5bUU+540kGcIIACChrC3wqGFDofLcoUsxeW6XGjYUcs5IEuLQMwBAwllb4NGa/DxOYE0RhBEAQEJypjlUumKh7TIQByzTAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALAq3XYBtgSCRu29wxoYHVPOApdKvNlypjlslwUAQMpJyTDS0u1TXVOPfP6xyTaP26XainytLfBYrAwAgNSTcss0Ld0+bdpzNCSISFK/f0yb9hxVS7fPUmUAAKSmlAojgaBRXVOPTITXJtrqmnoUCEbqAQAAZkNKhZH23uGwGZHPMpJ8/jG19w7HrygAAFJcSoWRgdGpg0gs/QAAwPlLqTCSs8A1o/0AAMD5S6kwUuLNlsft0lQbeB06u6umxJsdz7IAAEhpKRVGnGkO1VbkS1JYIJl4XluRz3kjAADEUUqFEUlaW+BRw4ZC5blDl2Ly3C41bCjknBEAAOIsJQ89W1vg0Zr8PE5gBQAgAaRkGJHOLtmUrlhouwwAAFJeyi3TAACAxEIYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGBVTGFk586d8nq9crlcKioqUltb2zn77927V1dddZUuvPBCeTwe3X333RoaGoqpYAAAkFyiDiONjY3asmWLtm/frs7OTq1evVrr1q1TX19fxP4HDhzQxo0bdc899+jtt9/Wyy+/rH/84x+69957z7t4AAAw90UdRh577DHdc889uvfee7Vy5Ur95je/0bJly9TQ0BCx/9/+9jd95Stf0ebNm+X1evWNb3xD3//+93XkyJHzLh4AAMx9UYWR06dPq6OjQ+Xl5SHt5eXlOnToUMRrysrKdPLkSTU3N8sYo//85z965ZVXdNNNN035PuPj4xoZGQl5AACA5BRVGBkcHFQgEFBubm5Ie25urvr7+yNeU1ZWpr1796qyslIZGRnKy8vTRRddpN/+9rdTvk99fb3cbvfkY9myZdGUCQAA5pCYfsDqcDhCnhtjwtom9PT0aPPmzXrooYfU0dGhlpYW9fb2qqqqasq/X1NTI7/fP/k4ceJELGUCAIA5ID2azosWLZLT6QybBRkYGAibLZlQX1+va665Rg8++KAk6atf/armz5+v1atX65FHHpHH4wm7JjMzU5mZmdGUBgAA5qioZkYyMjJUVFSk1tbWkPbW1laVlZVFvObjjz9WWlro2zidTklnZ1QAAEBqi3qZprq6Ws8++6x2796tY8eOaevWrerr65tcdqmpqdHGjRsn+1dUVOjVV19VQ0ODjh8/roMHD2rz5s0qKSnR4sWLZ+6TAACAOSmqZRpJqqys1NDQkHbs2CGfz6eCggI1Nzdr+fLlkiSfzxdy5shdd92l0dFR/e53v9OPf/xjXXTRRbruuuv06KOPztynAAAAc5bDzIG1kpGREbndbvn9fmVlZdkuBwAATMN0v7+5Nw0AALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArIr6nBHETyBo1N47rIHRMeUscKnEmy1nWuR7AAEAMFcRRhJUS7dPdU098vnHJts8bpdqK/K1tiD8fj4AAMxVLNMkoJZunzbtORoSRCSp3z+mTXuOqqXbZ6kyAABmHmEkwQSCRnVNPYp0LO5EW11TjwLBhD84FwCAaSGMJJj23uGwGZHPMpJ8/jG19w7HrygAAGYRYSTBDIxOHURi6QcAQKIjjCSYnAWuGe0HAECiI4wkmBJvtjxul6bawOvQ2V01Jd7seJYFAMCsIYwkGGeaQ7UV+ZIUFkgmntdW5HPeCAAgaRBGEtDaAo8aNhQqzx26FJPndqlhQyHnjAAAkgqHniWotQUercnP4wRWAEDSI4wkMGeaQ6UrFtouAwCAWcUyDQAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwKp02wUAAJCKAkGj9t5hDYyOKWeBSyXebDnTHLbLsoIwAgBAnLV0+1TX1COff2yyzeN2qbYiX2sLPBYrs4NlGgAA4qil26dNe46GBBFJ6vePadOeo2rp9lmqzB7CCAAAcRIIGtU19chEeG2ira6pR4FgpB7JizACAECctPcOh82IfJaR5POPqb13OH5FJQDCCAAAcTIwOnUQiaVfsiCMAAAQJzkLXDPaL1kQRgAAiJMSb7Y8bpem2sDr0NldNSXe7HiWZV1MYWTnzp3yer1yuVwqKipSW1vbOfuPj49r+/btWr58uTIzM7VixQrt3r07poIBAJirnGkO1VbkS1JYIJl4XluRn3LnjUQdRhobG7VlyxZt375dnZ2dWr16tdatW6e+vr4pr7n11lv1l7/8Rbt27dK//vUvvfTSS7riiivOq3AAAOaitQUeNWwoVJ47dCkmz+1Sw4bClDxnxGGMiWr/0KpVq1RYWKiGhobJtpUrV2r9+vWqr68P69/S0qLbbrtNx48fV3Z2bNNOIyMjcrvd8vv9ysrKiulvAACQSFLhBNbpfn9HNTNy+vRpdXR0qLy8PKS9vLxchw4dinjN66+/ruLiYv3iF7/QkiVLdNlll+mBBx7QJ598MuX7jI+Pa2RkJOQBAEAycaY5VLpiof7P1UtUumJh0gWRaER1HPzg4KACgYByc3ND2nNzc9Xf3x/xmuPHj+vAgQNyuVx67bXXNDg4qPvuu0/Dw8NT/m6kvr5edXV10ZQGAADmqJh+wOpwhKY3Y0xY24RgMCiHw6G9e/eqpKREN954ox577DE9//zzU86O1NTUyO/3Tz5OnDgRS5kAAGAOiGpmZNGiRXI6nWGzIAMDA2GzJRM8Ho+WLFkit9s92bZy5UoZY3Ty5EldeumlYddkZmYqMzMzmtIAAMAcFdXMSEZGhoqKitTa2hrS3traqrKysojXXHPNNTp16pQ+/PDDybZ33nlHaWlpWrp0aQwlAwCAZBL1Mk11dbWeffZZ7d69W8eOHdPWrVvV19enqqoqSWeXWDZu3DjZ//bbb9fChQt19913q6enR2+++aYefPBBffe739UFF1wwc58EAADMSVEt00hSZWWlhoaGtGPHDvl8PhUUFKi5uVnLly+XJPl8vpAzR770pS+ptbVVP/rRj1RcXKyFCxfq1ltv1SOPPDJznwIpIxW2wgFAqon6nBEbOGcEktTS7VNdU0/IHS89bpdqK/JT8pAgAEh0s3LOCGBLS7dPm/YcDbv1dr9/TJv2HFVLt89SZQCA80UYQcILBI3qmnoUaQpvoq2uqUeBYMJP8gEAIiCMIOG19w6HzYh8lpHk84+pvXc4fkUBAGYMYQQJb2B06iASSz8AQGIhjCDh5SxwfXGnKPoBABILYQQJr8SbLY/bpak28Dp0dldNiTe2u0IDAOwijCDhOdMcqq3Il6SwQDLxvLYin/NGAGCOIoxgTlhb4FHDhkLluUOXYvLcLjVsKOScEQCYw6I+gRWwZW2BR2vy8ziBFQCSDGEEc4ozzaHSFQttlwEAmEEs0wAAAKsIIwAAwCrCCAAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwinNGACAFBIKGAwORsAgjAJDkWrp9qmvqkc8/NtnmcbtUW5HPrRSQEFimAYAk1tLt06Y9R0OCiCT1+8e0ac9RtXT7LFUG/C/CCAAkqUDQqK6pRybCaxNtdU09CgQj9QDihzACAEmqvXc4bEbks4wkn39M7b3D8SsKiIAwAgBJamB06iASSz9gthBGACBJ5SxwzWg/YLYQRgAgSZV4s+VxuzTVBl6Hzu6qKfFmx7MsIAxhBACSlDPNodqKfEkKCyQTz2sr8jlvBNYRRgAgia0t8KhhQ6Hy3KFLMXlulxo2FHLOCBICh54BQJJbW+DRmvw8TmBFwiKMAEAKcKY5VLpioe0ygIhYpgEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYFW67QIAAIAdgaBRe++wBkbHlLPApRJvtpxpjrjXQRgBACAFtXT7VNfUI59/bLLN43aptiJfaws8ca2FZRoAAFJMS7dPm/YcDQkiktTvH9OmPUfV0u2Laz2EEQAAUkggaFTX1CMT4bWJtrqmHgWCkXrMDsIIAAAppL13OGxG5LOMJJ9/TO29w3GrKaYwsnPnTnm9XrlcLhUVFamtrW1a1x08eFDp6em6+uqrY3lbAABwngZGpw4isfSbCVGHkcbGRm3ZskXbt29XZ2enVq9erXXr1qmvr++c1/n9fm3cuFHf+ta3Yi4WAIBYBYJGh98b0v/t+kCH3xuK6zJEIslZ4JrRfjPBYYyJajRWrVqlwsJCNTQ0TLatXLlS69evV319/ZTX3Xbbbbr00kvldDr1pz/9SV1dXdN+z5GREbndbvn9fmVlZUVTLgAACbVzxLZA0Ogbj/4/9fvHIv5uxCEpz+3SgZ9ed97bfKf7/R3VzMjp06fV0dGh8vLykPby8nIdOnRoyuuee+45vffee6qtrZ3W+4yPj2tkZCTkAQBALBJt54htzjSHaivyJZ0NHp818by2Ij+u541EFUYGBwcVCASUm5sb0p6bm6v+/v6I17z77rvatm2b9u7dq/T06R1rUl9fL7fbPflYtmxZNGUCACApMXeOJIK1BR41bChUnjt0KSbP7VLDhsK4zxbFdOiZwxGalowxYW2SFAgEdPvtt6uurk6XXXbZtP9+TU2NqqurJ5+PjIwQSAAAUYtm50jpioXxKywBrC3waE1+3tw7gXXRokVyOp1hsyADAwNhsyWSNDo6qiNHjqizs1M//OEPJUnBYFDGGKWnp2vfvn267rrrwq7LzMxUZmZmNKUBABAmEXeOJBJnmiMhQlhUyzQZGRkqKipSa2trSHtra6vKysrC+mdlZemtt95SV1fX5KOqqkqXX365urq6tGrVqvOrHgCAc0jEnSMIF/UyTXV1te644w4VFxertLRUTz/9tPr6+lRVVSXp7BLLBx98oBdeeEFpaWkqKCgIuT4nJ0culyusHQCAmVbizZbH7frCnSMl3ux4l4bPiDqMVFZWamhoSDt27JDP51NBQYGam5u1fPlySZLP5/vCM0cAAIiHiZ0jm/YclUMKCSS2do4gXNTnjNjAOSMAgPPBOSN2TPf7O6bdNAAAzCWJtHME4QgjAICUkCg7RxCOu/YCAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsIowAgAArCKMAAAAqwgjAADAKsIIAACwijACAACsIowAAACrCCMAAMAqwggAALCKMAIAAKwijAAAAKvSbRcAILEFgkbtvcMaGB1TzgKXSrzZcqY5bJcFIIkQRgBMqaXbp7qmHvn8Y5NtHrdLtRX5WlvgsVgZgGTCMg2AiFq6fdq052hIEJGkfv+YNu05qpZun6XKACQbwgiAMIGgUV1Tj0yE1yba6pp6FAhG6gEA0SGMAAjT3jscNiPyWUaSzz+m9t7h+BUFIGkRRgCEGRidOojE0g8AzoUwAiBMzgLXjPYDgHMhjAAIU+LNlsft0lQbeB06u6umxJsdz7IAJCnCCIAwzjSHaivyJSkskEw8r63I57wRADOCMAIgorUFHjVsKFSeO3QpJs/tUsOGQs4ZATBjOPQMwJTWFni0Jj+PE1gBzCrCCIBzcqY5VLpioe0yACQxlmkAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWBVTGNm5c6e8Xq9cLpeKiorU1tY2Zd9XX31Va9as0cUXX6ysrCyVlpbqjTfeiLlgAACQXKIOI42NjdqyZYu2b9+uzs5OrV69WuvWrVNfX1/E/m+++abWrFmj5uZmdXR06Jvf/KYqKirU2dl53sUDAIC5z2GMMdFcsGrVKhUWFqqhoWGybeXKlVq/fr3q6+un9TeuvPJKVVZW6qGHHppW/5GREbndbvn9fmVlZUVTLgAAsGS6399RzYycPn1aHR0dKi8vD2kvLy/XoUOHpvU3gsGgRkdHlZ2dPWWf8fFxjYyMhDwAAEByiiqMDA4OKhAIKDc3N6Q9NzdX/f390/obv/71r/XRRx/p1ltvnbJPfX293G735GPZsmXRlAkAAOaQmH7A6nA4Qp4bY8LaInnppZf08MMPq7GxUTk5OVP2q6mpkd/vn3ycOHEiljIBAMAckB5N50WLFsnpdIbNggwMDITNlnxeY2Oj7rnnHr388su6/vrrz9k3MzNTmZmZ0ZQGAADmqKhmRjIyMlRUVKTW1taQ9tbWVpWVlU153UsvvaS77rpLL774om666abYKgUAAEkpqpkRSaqurtYdd9yh4uJilZaW6umnn1ZfX5+qqqoknV1i+eCDD/TCCy9IOhtENm7cqMcff1xf//rXJ2dVLrjgArnd7hn8KAAAYC6KOoxUVlZqaGhIO3bskM/nU0FBgZqbm7V8+XJJks/nCzlz5Pe//73OnDmjH/zgB/rBD34w2X7nnXfq+eefP/9PAAAA5rSozxmxgXNGAACYe2blnBEAAICZRhgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVYQRAABgFWEEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYFW67QIAINUFgkbtvcMaGB1TzgKXSrzZcqY5bJcFxA1hBAAsaun2qa6pRz7/2GSbx+1SbUW+1hZ4LFYGxA/LNABgSUu3T5v2HA0JIpLU7x/Tpj1H1dLts1QZEF+EEQCwIBA0qmvqkYnw2kRbXVOPAsFIPYDkQhgBAAvae4fDZkQ+y0jy+cfU3jscv6IASwgjAGDBwOjUQSSWfsBcRhgBAAtyFrhmtB8wlxFGAMCCEm+2PG6XptrA69DZXTUl3ux4lgVYQRgBAAucaQ7VVuRLUlggmXheW5HPeSNICYQRALBkbYFHDRsKlecOXYrJc7vUsKGQc0aQMjj0DAAsWlvg0Zr8PE5gRUojjACAZc40h0pXLLRdBmANyzQAAMAqwggAALCKMAIAAKwijAAAAKsIIwAAwCrCCAAAsCqmMLJz5055vV65XC4VFRWpra3tnP3379+voqIiuVwuXXLJJXrqqadiKhYAACSfqMNIY2OjtmzZou3bt6uzs1OrV6/WunXr1NfXF7F/b2+vbrzxRq1evVqdnZ362c9+ps2bN+uPf/zjeRcPAADmPocxxkRzwapVq1RYWKiGhobJtpUrV2r9+vWqr68P6//Tn/5Ur7/+uo4dOzbZVlVVpX/+8586fPjwtN5zZGREbrdbfr9fWVlZ0ZQLAAAsme73d1QnsJ4+fVodHR3atm1bSHt5ebkOHToU8ZrDhw+rvLw8pO2GG27Qrl279Omnn2revHlh14yPj2t8fHzyud/vl3T2QwEAgLlh4nv7i+Y9ogojg4ODCgQCys3NDWnPzc1Vf39/xGv6+/sj9j9z5owGBwfl8YTfCKq+vl51dXVh7cuWLYumXAAAkABGR0fldrunfD2me9M4HKE3cDLGhLV9Uf9I7RNqampUXV09+TwYDOr999/X1VdfrRMnTrBUkyBGRka0bNkyxiSBMCaJhfFIPIxJfBljNDo6qsWLF5+zX1RhZNGiRXI6nWGzIAMDA2GzHxPy8vIi9k9PT9fChZFvDJWZmanMzMyQtrS0s7+1zcrK4j+gBMOYJB7GJLEwHomHMYmfc82ITIhqN01GRoaKiorU2toa0t7a2qqysrKI15SWlob137dvn4qLiyP+XgQAAKSWqLf2VldX69lnn9Xu3bt17Ngxbd26VX19faqqqpJ0doll48aNk/2rqqr0/vvvq7q6WseOHdPu3bu1a9cuPfDAAzP3KQAAwJwV9W9GKisrNTQ0pB07dsjn86mgoEDNzc1avny5JMnn84WcOeL1etXc3KytW7fqySef1OLFi/XEE0/olltuiep9MzMzVVtbG7Z8A3sYk8TDmCQWxiPxMCaJKepzRgAAAGYS96YBAABWEUYAAIBVhBEAAGAVYQQAAFiVUGFk586d8nq9crlcKioqUltb2zn779+/X0VFRXK5XLrkkkv01FNPxanS1BHNmLz66qtas2aNLr74YmVlZam0tFRvvPFGHKtNftH+G5lw8OBBpaen6+qrr57dAlNQtGMyPj6u7du3a/ny5crMzNSKFSu0e/fuOFWbGqIdk7179+qqq67ShRdeKI/Ho7vvvltDQ0NxqhaSJJMg/vCHP5h58+aZZ555xvT09Jj777/fzJ8/37z//vsR+x8/ftxceOGF5v777zc9PT3mmWeeMfPmzTOvvPJKnCtPXtGOyf33328effRR097ebt555x1TU1Nj5s2bZ44ePRrnypNTtOMx4b///a+55JJLTHl5ubnqqqviU2yKiGVMbr75ZrNq1SrT2tpqent7zd///ndz8ODBOFad3KIdk7a2NpOWlmYef/xxc/z4cdPW1mauvPJKs379+jhXntoSJoyUlJSYqqqqkLYrrrjCbNu2LWL/n/zkJ+aKK64Iafv+979vvv71r89ajakm2jGJJD8/39TV1c10aSkp1vGorKw0P//5z01tbS1hZIZFOyZ//vOfjdvtNkNDQ/EoLyVFOya//OUvzSWXXBLS9sQTT5ilS5fOWo0IlxDLNKdPn1ZHR4fKy8tD2svLy3Xo0KGI1xw+fDis/w033KAjR47o008/nbVaU0UsY/J5wWBQo6Ojys7Ono0SU0qs4/Hcc8/pvffeU21t7WyXmHJiGZPXX39dxcXF+sUvfqElS5bosssu0wMPPKBPPvkkHiUnvVjGpKysTCdPnlRzc7OMMfrPf/6jV155RTfddFM8Ssb/iOmuvTNtcHBQgUAg7GZ7ubm5YTfZm9Df3x+x/5kzZzQ4OCiPxzNr9aaCWMbk837961/ro48+0q233jobJaaUWMbj3Xff1bZt29TW1qb09IT4p55UYhmT48eP68CBA3K5XHrttdc0ODio++67T8PDw/xuZAbEMiZlZWXau3evKisrNTY2pjNnzujmm2/Wb3/723iUjP+REDMjExwOR8hzY0xY2xf1j9SO2EU7JhNeeuklPfzww2psbFROTs5slZdypjsegUBAt99+u+rq6nTZZZfFq7yUFM2/kWAwKIfDob1796qkpEQ33nijHnvsMT3//PPMjsygaMakp6dHmzdv1kMPPaSOjg61tLSot7d38n5riI+E+N+lRYsWyel0hiXXgYGBsIQ7IS8vL2L/9PR0LVy4cNZqTRWxjMmExsZG3XPPPXr55Zd1/fXXz2aZKSPa8RgdHdWRI0fU2dmpH/7wh5LOfhEaY5Senq59+/bpuuuui0vtySqWfyMej0dLliwJuaX6ypUrZYzRyZMndemll85qzckuljGpr6/XNddcowcffFCS9NWvflXz58/X6tWr9cgjjzDLHicJMTOSkZGhoqIitba2hrS3traqrKws4jWlpaVh/fft26fi4mLNmzdv1mpNFbGMiXR2RuSuu+7Siy++yJrrDIp2PLKysvTWW2+pq6tr8lFVVaXLL79cXV1dWrVqVbxKT1qx/Bu55pprdOrUKX344YeTbe+8847S0tK0dOnSWa03FcQyJh9//LHS0kK/Cp1Op6T/nW1HHNj65eznTWzH2rVrl+np6TFbtmwx8+fPN//+97+NMcZs27bN3HHHHZP9J7b2bt261fT09Jhdu3axtXeGRTsmL774oklPTzdPPvmk8fl8k4///ve/tj5CUol2PD6P3TQzL9oxGR0dNUuXLjXf/va3zdtvv232799vLr30UnPvvffa+ghJJ9oxee6550x6errZuXOnee+998yBAwdMcXGxKSkpsfURUlLChBFjjHnyySfN8uXLTUZGhiksLDT79++ffO3OO+801157bUj/v/71r+ZrX/uaycjIMF/5yldMQ0NDnCtOftGMybXXXmskhT3uvPPO+BeepKL9N/JZhJHZEe2YHDt2zFx//fXmggsuMEuXLjXV1dXm448/jnPVyS3aMXniiSdMfn6+ueCCC4zH4zHf+c53zMmTJ+NcdWpzGMM8FAAAsCchfjMCAABSF2EEAABYRRgBAABWEUYAAIBVhBEAAGAVYQQAAFhFGAEAAFYRRgAAgFWEEQAAYBVhBAAAWEUYAQAAVhFGAACAVf8fBF+wjk5nx9AAAAAASUVORK5CYII=",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -1581,7 +1581,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x13ba84290>"
+       "<graphviz.graphs.Digraph at 0x12f892c90>"
       ]
      },
      "execution_count": 41,
@@ -1618,7 +1618,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5bd9e89a0aa74920939a5c6d01de2db7",
+       "model_id": "4fef19c0ced14384945efb5eaa3a64a5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1645,7 +1645,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x151ffb390>"
+       "<matplotlib.collections.PathCollection at 0x14620b5d0>"
       ]
      },
      "execution_count": 42,
@@ -1905,7 +1905,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x151ff6690>"
+       "<graphviz.graphs.Digraph at 0x14620a010>"
       ]
      },
      "execution_count": 43,
@@ -1963,7 +1963,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:166: UserWarning: The channel run was not connected to ran, andthus could not disconnect from it.\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:168: UserWarning: The channel run was not connected to ran, andthus could not disconnect from it.\n",
       "  warn(\n"
      ]
     },
@@ -3094,7 +3094,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x15201a250>"
+       "<graphviz.graphs.Digraph at 0x1461ca6d0>"
       ]
      },
      "execution_count": 49,
@@ -3159,7 +3159,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:166: UserWarning: The channel ran was not connected to accumulate_and_run, andthus could not disconnect from it.\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:168: UserWarning: The channel ran was not connected to accumulate_and_run, andthus could not disconnect from it.\n",
       "  warn(\n",
       "/Users/huber/work/pyiron/pyiron_atomistics/pyiron_atomistics/lammps/base.py:294: UserWarning: No potential set via job.potential - use default potential, 1997--Liu-X-Y--Al-Mg--LAMMPS--ipr1\n",
       "  warnings.warn(\n"
@@ -3216,15 +3216,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:166: UserWarning: The channel job was not connected to job, andthus could not disconnect from it.\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:168: UserWarning: The channel job was not connected to job, andthus could not disconnect from it.\n",
       "  warn(\n",
-      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:166: UserWarning: The channel accumulate_and_run was not connected to ran, andthus could not disconnect from it.\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:168: UserWarning: The channel accumulate_and_run was not connected to ran, andthus could not disconnect from it.\n",
       "  warn(\n",
-      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:166: UserWarning: The channel element was not connected to user_input, andthus could not disconnect from it.\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:168: UserWarning: The channel element was not connected to user_input, andthus could not disconnect from it.\n",
       "  warn(\n",
-      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:166: UserWarning: The channel structure was not connected to obj, andthus could not disconnect from it.\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:168: UserWarning: The channel structure was not connected to obj, andthus could not disconnect from it.\n",
       "  warn(\n",
-      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:166: UserWarning: The channel energy was not connected to obj, andthus could not disconnect from it.\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:168: UserWarning: The channel energy was not connected to obj, andthus could not disconnect from it.\n",
       "  warn(\n"
      ]
     }
@@ -3254,7 +3254,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:166: UserWarning: The channel ran was not connected to accumulate_and_run, andthus could not disconnect from it.\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:168: UserWarning: The channel ran was not connected to accumulate_and_run, andthus could not disconnect from it.\n",
       "  warn(\n",
       "/Users/huber/work/pyiron/pyiron_atomistics/pyiron_atomistics/lammps/base.py:294: UserWarning: No potential set via job.potential - use default potential, 1995--Angelo-J-E--Ni-Al-H--LAMMPS--ipr1\n",
       "  warnings.warn(\n"
@@ -3300,7 +3300,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:166: UserWarning: The channel ran was not connected to accumulate_and_run, andthus could not disconnect from it.\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:168: UserWarning: The channel ran was not connected to accumulate_and_run, andthus could not disconnect from it.\n",
       "  warn(\n",
       "/Users/huber/work/pyiron/pyiron_atomistics/pyiron_atomistics/lammps/base.py:294: UserWarning: No potential set via job.potential - use default potential, 1995--Angelo-J-E--Ni-Al-H--LAMMPS--ipr1\n",
       "  warnings.warn(\n"
@@ -3377,7 +3377,7 @@
      "output_type": "stream",
      "text": [
       "None 1\n",
-      "<Future at 0x154a03d50 state=pending> <class 'pyiron_workflow.channels.NotData'>\n"
+      "<Future at 0x148cb9110 state=pending> NOT_DATA\n"
      ]
     }
    ],
@@ -3459,7 +3459,7 @@
      "output_type": "stream",
      "text": [
       "None 1\n",
-      "<Future at 0x1549c2f10 state=pending> <class 'pyiron_workflow.channels.NotData'>\n",
+      "<Future at 0x148bd0b50 state=pending> NOT_DATA\n",
       "Finally 5\n",
       "b (Add) output single-value: 6\n"
      ]
@@ -3521,7 +3521,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "6.015147686994169\n"
+      "6.011735447998944\n"
      ]
     }
    ],
@@ -3553,7 +3553,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.5117498940089718\n"
+      "2.7731033529998967\n"
      ]
     }
    ],
@@ -3799,9 +3799,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:166: UserWarning: The channel run was not connected to true, andthus could not disconnect from it.\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:168: UserWarning: The channel run was not connected to true, andthus could not disconnect from it.\n",
       "  warn(\n",
-      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:166: UserWarning: The channel run was not connected to ran, andthus could not disconnect from it.\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/channels.py:168: UserWarning: The channel run was not connected to ran, andthus could not disconnect from it.\n",
       "  warn(\n"
      ]
     }
@@ -3882,14 +3882,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.696 > 0.2\n",
-      "0.855 > 0.2\n",
-      "0.355 > 0.2\n",
-      "0.690 > 0.2\n",
-      "0.439 > 0.2\n",
-      "0.527 > 0.2\n",
-      "0.172 <= 0.2\n",
-      "Finally 0.172\n"
+      "0.785 > 0.2\n",
+      "0.073 <= 0.2\n",
+      "Finally 0.073\n"
      ]
     }
    ],

--- a/pyiron_workflow/__init__.py
+++ b/pyiron_workflow/__init__.py
@@ -28,4 +28,5 @@ Planned:
 - Ontological hinting for data channels in order to provide guided workflow design
 - GUI on top for code-lite/code-free visual scripting
 """
+
 from pyiron_workflow.workflow import Workflow

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -249,6 +249,9 @@ class NotData(metaclass=Singleton):
     def __reduce__(self):
         return "NOT_DATA"
 
+    def __bool__(self):
+        return False
+
 
 NOT_DATA = NotData()
 

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -828,17 +828,11 @@ class InputSignal(SignalChannel):
 
     @staticmethod
     def _no_positional_args(func):
-        return (
-            sum(
-                1
-                for parameter in inspect.signature(func).parameters.values()
-                if (
-                    parameter.default == inspect.Parameter.empty
-                    and parameter.kind != inspect._ParameterKind.VAR_KEYWORD
-                )
-            )
-            == 0
-        )
+        return all([
+            parameter.default != inspect.Parameter.empty
+            or parameter.kind == inspect.Parameter.VAR_KEYWORD
+            for parameter in inspect.signature(func).parameters.values()
+        ])
 
     @property
     def callback(self) -> callable:

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -260,7 +260,7 @@ class DataChannel(Channel, ABC):
     They store data persistently (:attr:`value`).
 
     This value may have a default (:attr:`default`) and the default-default is to be
-    `NotData`.
+    `NOT_DATA`.
 
     They may optionally have a type hint (:attr:`type_hint`).
 
@@ -284,8 +284,8 @@ class DataChannel(Channel, ABC):
     in production runs.
 
     Channels can indicate whether they hold data they are happy with
-    (:attr:`ready: bool`), which is to say it is data (not :class:`NotData`) and that
-    it conforms to the type hint (if one is provided and checking is active).
+    (:attr:`ready: bool`), which is to say it is data (not the singleton `NOT_DATA`)
+    and that it conforms to the type hint (if one is provided and checking is active).
 
     Output data facilitates many (but not all) python operators by injecting a new
     node to perform that operation. Where the operator is not supported, we try to
@@ -331,7 +331,7 @@ class DataChannel(Channel, ABC):
         label (str): The label for the channel.
         node (pyiron_workflow.node.Node): The node to which this channel belongs.
         default (typing.Any|None): The default value to initialize to.
-            (Default is the class `NotData`.)
+            (Default is the singleton `NOT_DATA`.)
         type_hint (typing.Any|None): A type hint for values. (Default is None.)
         strict_hints (bool): Whether to check new values, connections, and partners
             when this node is a value receiver. This can potentially be expensive, so
@@ -514,9 +514,9 @@ class InputData(DataChannel):
 
     def fetch(self) -> None:
         """
-        Sets :attr:`value` to the first value among connections that is something other than
-        :class:`NotData`; if no such value exists (e.g. because there are no connections or
-        because all the connected output channels have `NotData` as their value),
+        Sets :attr:`value` to the first value among connections that is something other
+        than `NOT_DATA`; if no such value exists (e.g. because there are no connections
+        or because all the connected output channels have `NOT_DATA` as their value),
         :attr:`value` remains unchanged.
         I.e., the connection with the highest priority for updating input data is the
         0th connection; build graphs accordingly.

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -750,13 +750,6 @@ class OutputData(DataChannel):
 
         return self._node_injection(Round)
 
-    # Because we override __getattr__ we need to get and set state for serialization
-    def __getstate__(self):
-        return dict(self.__dict__)
-
-    def __setstate__(self, state):
-        self.__dict__.update(**state)
-
 
 class SignalChannel(Channel, ABC):
     """

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -216,11 +216,14 @@ class Channel(HasChannel, HasToDict, ABC):
         }
 
     def __getstate__(self):
-        state = self.__dict__
+        state = dict(self.__dict__)
         # To avoid cyclic storage and avoid storing complex objects, purge some
         # properties from the state
         state["node"] = None
         # It is the responsibility of the owning node to restore the node property
+        state["connections"] = []
+        # It is the responsibility of the owning node's parent to store and restore
+        # connections (if any)
         return state
 
     def __setstate__(self, state):

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -611,10 +611,7 @@ class Composite(Node, ABC):
         the name is protected.
         """
         return [
-            (
-                (inp.node.label, inp.label),
-                (out.node.label, out.label)
-            )
+            ((inp.node.label, inp.label), (out.node.label, out.label))
             for child in self
             for inp in panel_getter(child)
             for out in inp.connections
@@ -634,7 +631,7 @@ class Composite(Node, ABC):
 
     @property
     def _child_signal_connections(
-        self
+        self,
     ) -> list[tuple[tuple[str, str], tuple[str, str]]]:
         return self._get_connections_as_strings(self._get_signals_input)
 
@@ -679,7 +676,7 @@ class Composite(Node, ABC):
                 among these nodes in the format ((input node label, input channel label
                 ), (output node label, output channel label)).
         """
-        for ((inp_node, inp), (out_node, out)) in connections:
+        for (inp_node, inp), (out_node, out) in connections:
             input_panel_getter(nodes[inp_node])[inp].connect(
                 output_panel_getter(nodes[out_node])[out]
             )
@@ -711,4 +708,3 @@ class Composite(Node, ABC):
             self._get_signals_input,
             self._get_signals_output,
         )
-

--- a/pyiron_workflow/function.py
+++ b/pyiron_workflow/function.py
@@ -82,8 +82,8 @@ class Function(Node):
 
         There is no output because we haven't given our function any input, it has
         no defaults, and we never ran it! So outputs have the channel default value of
-        `NotData` -- a special non-data class (since `None` is sometimes a meaningful
-        value in python).
+        `NOT_DATA` -- a special non-data singleton (since `None` is sometimes a
+        meaningful value in python).
 
         We'll run into a hiccup if we try to set only one of the inputs and force the
         run:
@@ -115,7 +115,7 @@ class Function(Node):
         y ready: False
 
         This is because the second input (`y`) still has no input value -- indicated in
-        the error message -- so we can't do the sum between `NotData` and `2`.
+        the error message -- so we can't do the sum between `NOT_DATA` and `2`.
 
         Once we update `y`, all the input is ready we will be allowed to proceed to a
         `run()` call, which succeeds and updates the output.

--- a/pyiron_workflow/function.py
+++ b/pyiron_workflow/function.py
@@ -5,7 +5,7 @@ import warnings
 from functools import partialmethod
 from typing import Any, get_args, get_type_hints, Optional, TYPE_CHECKING
 
-from pyiron_workflow.channels import InputData, OutputData, NotData
+from pyiron_workflow.channels import InputData, OutputData, NOT_DATA
 from pyiron_workflow.has_channel import HasChannel
 from pyiron_workflow.io import Inputs, Outputs
 from pyiron_workflow.node import Node
@@ -78,7 +78,7 @@ class Function(Node):
         >>> plus_minus_1 = Function(mwe)
         >>>
         >>> print(plus_minus_1.outputs["x+1"])
-        <class 'pyiron_workflow.channels.NotData'>
+        NOT_DATA
 
         There is no output because we haven't given our function any input, it has
         no defaults, and we never ran it! So outputs have the channel default value of
@@ -445,7 +445,7 @@ class Function(Node):
             except KeyError:
                 type_hint = None
 
-            default = NotData  # The standard default in DataChannel
+            default = NOT_DATA  # The standard default in DataChannel
             if value.default is not inspect.Parameter.empty:
                 if is_self:
                     warnings.warn("default value for self ignored")

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -488,7 +488,7 @@ class Macro(Composite):
 
         for old_data, io_panel in zip(
             local_connection_data,
-            [self.inputs, self.outputs, self.signals.input, self.signals.output]
+            [self.inputs, self.outputs, self.signals.input, self.signals.output],
             # Get fresh copies of the IO panels post-update
         ):
             for original_channel, label, connections in old_data:

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -11,7 +11,7 @@ from typing import get_type_hints, Literal, Optional, TYPE_CHECKING
 
 from bidict import bidict
 
-from pyiron_workflow.channels import InputData, OutputData, NotData
+from pyiron_workflow.channels import InputData, OutputData, NOT_DATA
 from pyiron_workflow.composite import Composite
 from pyiron_workflow.has_channel import HasChannel
 from pyiron_workflow.io import Outputs, Inputs
@@ -364,7 +364,7 @@ class Macro(Composite):
                 continue  # Skip the macro argument itself, it's like `self` here
 
             default = (
-                NotData
+                NOT_DATA
                 if inspected_value.default is inspect.Parameter.empty
                 else inspected_value.default
             )

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -556,8 +556,7 @@ class Macro(Composite):
         """
         return [
             (c.label, (c.value_receiver.node.label, c.value_receiver.label))
-            for c
-            in self.inputs
+            for c in self.inputs
         ]
 
     @property
@@ -590,10 +589,10 @@ class Macro(Composite):
         super().__setstate__(state)
 
         # Re-forge value links
-        for (inp, (child, child_inp)) in input_links:
+        for inp, (child, child_inp) in input_links:
             self.inputs[inp].value_receiver = self.nodes[child].inputs[child_inp]
 
-        for ((child, child_out), out) in output_links:
+        for (child, child_out), out in output_links:
             self.nodes[child].outputs[child_out].value_receiver = self.outputs[out]
 
 

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -484,7 +484,6 @@ class Macro(Composite):
                 self.signals.output,
             ]
         ]
-
         super()._parse_remotely_executed_self(other_self)
 
         for old_data, io_panel in zip(
@@ -584,14 +583,18 @@ class Macro(Composite):
         return state
 
     def __setstate__(self, state):
-        # Purge value links from the state and re-forge them
-        for (inp, (child, child_inp)) in state.pop("_input_value_links"):
-            self.inputs[inp].value_receiver = self.nodes[child].inputs[child_inp]
-
-        for ((child, child_out), out) in state.pop("_output_value_links"):
-            self.nodes[child].outputs[child_out].value_receiver = self.outputs[out]
+        # Purge value links from the state
+        input_links = state.pop("_input_value_links")
+        output_links = state.pop("_output_value_links")
 
         super().__setstate__(state)
+
+        # Re-forge value links
+        for (inp, (child, child_inp)) in input_links:
+            self.inputs[inp].value_receiver = self.nodes[child].inputs[child_inp]
+
+        for ((child, child_out), out) in output_links:
+            self.nodes[child].outputs[child_out].value_receiver = self.outputs[out]
 
 
 def macro_node(*output_labels, **node_class_kwargs):

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -17,7 +17,7 @@ from pyiron_workflow.channels import (
     InputSignal,
     AccumulatingInputSignal,
     OutputSignal,
-    NotData,
+    NOT_DATA,
 )
 from pyiron_workflow.draw import Node as GraphvizNode
 from pyiron_workflow.snippets.files import FileObject, DirectoryObject
@@ -1006,7 +1006,7 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
             (self.outputs, other.outputs),
         ]:
             for key, to_copy in other_panel.items():
-                if to_copy.value is not NotData:
+                if to_copy.value is not NOT_DATA:
                     try:
                         old_value = my_panel[key].value
                         my_panel[key].value = to_copy.value  # Gets hint-checked

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -503,9 +503,9 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
             )
 
         return self._run(
-            finished_callback=self._finish_run_and_emit_ran
-            if emit_ran_signal
-            else self._finish_run,
+            finished_callback=(
+                self._finish_run_and_emit_ran if emit_ran_signal else self._finish_run
+            ),
             force_local_execution=force_local_execution,
         )
 

--- a/pyiron_workflow/node_library/pyiron_atomistics.py
+++ b/pyiron_workflow/node_library/pyiron_atomistics.py
@@ -1,6 +1,7 @@
 """
 Nodes wrapping a subset of pyiron_atomistics functionality
 """
+
 from __future__ import annotations
 
 from typing import Literal, Optional
@@ -126,10 +127,12 @@ def CalcMd(
     n_ionic_steps: int = 1000,
     n_print: int = 100,
     temperature: int | float = 300.0,
-    pressure: float
-    | tuple[float, float, float]
-    | tuple[float, float, float, float, float, float]
-    | None = None,
+    pressure: (
+        float
+        | tuple[float, float, float]
+        | tuple[float, float, float, float, float, float]
+        | None
+    ) = None,
 ):
     def calc_md(job, n_ionic_steps, n_print, temperature, pressure):
         job.calc_md(
@@ -169,10 +172,12 @@ def CalcMin(
     job: AtomisticGenericJob,
     n_ionic_steps: int = 1000,
     n_print: int = 100,
-    pressure: float
-    | tuple[float, float, float]
-    | tuple[float, float, float, float, float, float]
-    | None = None,
+    pressure: (
+        float
+        | tuple[float, float, float]
+        | tuple[float, float, float, float, float, float]
+        | None
+    ) = None,
 ):
     def calc_min(job, n_ionic_steps, n_print, pressure):
         job.calc_minimize(

--- a/pyiron_workflow/node_library/standard.py
+++ b/pyiron_workflow/node_library/standard.py
@@ -30,7 +30,7 @@ class If(SingleValue):
     def if_(condition):
         if condition is NOT_DATA:
             raise TypeError(
-                f"Logic 'If' node expected data other but got NotData as input."
+                f"Logic 'If' node expected data other but got NOT_DATA as input."
             )
         return bool(condition)
 

--- a/pyiron_workflow/node_library/standard.py
+++ b/pyiron_workflow/node_library/standard.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from inspect import isclass
 
-from pyiron_workflow.channels import NotData, OutputSignal
+from pyiron_workflow.channels import NOT_DATA, OutputSignal
 from pyiron_workflow.function import SingleValue, single_value_node
 
 
@@ -28,9 +28,9 @@ class If(SingleValue):
 
     @staticmethod
     def if_(condition):
-        if isclass(condition) and issubclass(condition, NotData):
+        if condition is NOT_DATA:
             raise TypeError(
-                f"Logic 'If' node expected data otherut got NotData as input."
+                f"Logic 'If' node expected data other but got NotData as input."
             )
         return bool(condition)
 
@@ -47,7 +47,7 @@ class If(SingleValue):
 
 
 @single_value_node("slice")
-def Slice(start=None, stop=NotData, step=None):
+def Slice(start=None, stop=NOT_DATA, step=None):
     if start is None:
         if stop is None:
             raise ValueError(

--- a/pyiron_workflow/snippets/testcase.py
+++ b/pyiron_workflow/snippets/testcase.py
@@ -3,7 +3,6 @@ A test case that encourages you to test your docstrings and makes it easier to t
 numpy arrays (if numpy is available).
 """
 
-
 from abc import ABC
 from contextlib import redirect_stdout
 import doctest
@@ -30,7 +29,6 @@ __date__ = "Dec 5, 2023"
 
 
 class PyironTestCase(unittest.TestCase, ABC):
-
     """
     Base class for all pyiron unit tets.
 

--- a/tests/integration/test_parallel_speedup.py
+++ b/tests/integration/test_parallel_speedup.py
@@ -2,7 +2,7 @@ from time import perf_counter, sleep
 import unittest
 
 from pyiron_workflow import Workflow
-from pyiron_workflow.channels import NotData
+from pyiron_workflow.channels import NOT_DATA
 
 
 class TestParallelSpeedup(unittest.TestCase):
@@ -28,7 +28,7 @@ class TestParallelSpeedup(unittest.TestCase):
         wf.starting_nodes = [wf.a]
         t0 = perf_counter()
         wf()
-        while wf.outputs.d__user_input.value is NotData:
+        while wf.outputs.d__user_input.value is NOT_DATA:
             sleep(0.001)
         dt_serial = perf_counter() - t0
 
@@ -43,7 +43,7 @@ class TestParallelSpeedup(unittest.TestCase):
 
             t1 = perf_counter()
             wf()
-            while wf.outputs.d__user_input.value is NotData:
+            while wf.outputs.d__user_input.value is NOT_DATA:
                 sleep(0.001)
             dt_parallel = perf_counter() - t1
 

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -329,6 +329,15 @@ class TestDataChannels(unittest.TestCase):
         self.ni1._value = "Not numeric at all"  # Bypass type checking
         self.assertFalse(self.ni1.ready)
 
+    def test_if_not_data(self):
+        if NOT_DATA:
+            a = 0
+        else:
+            a = 1
+        self.assertEqual(
+            a, 1, msg="NOT_DATA failed behave like None in the if-statement"
+        )
+
 
 class TestSignalChannels(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -156,7 +156,7 @@ class TestDataChannels(unittest.TestCase):
         self.assertEqual(
             self.ni1.value,
             1,
-            msg="NotData values should not be getting pulled, so no update expected"
+            msg="NOT_DATA values should not be getting pulled, so no update expected"
         )
 
         self.no.value = 3
@@ -314,13 +314,13 @@ class TestDataChannels(unittest.TestCase):
             self.assertIs(
                 without_default.value,
                 NOT_DATA,
-                msg=f"Without a default, spec is to have a NotData value but got "
+                msg=f"Without a default, spec is to have a NOT_DATA value but got "
                     f"{type(without_default.value)}"
             )
             self.assertFalse(
                 without_default.ready,
-                msg="Even without type hints, readiness should be false when the value"
-                    "is NotData"
+                msg="Even without type hints, readiness should be false when the value "
+                    "is NOT_DATA"
             )
 
         self.ni1.value = 1

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -2,7 +2,7 @@ import unittest
 
 from pyiron_workflow.channels import (
     Channel, InputData, OutputData, InputSignal, AccumulatingInputSignal, OutputSignal,
-    NotData, ChannelConnectionError, BadCallbackError
+    NOT_DATA, ChannelConnectionError, BadCallbackError
 )
 
 
@@ -140,7 +140,7 @@ class TestDataChannels(unittest.TestCase):
         )
 
     def test_fetch(self):
-        self.no.value = NotData
+        self.no.value = NOT_DATA
         self.ni1.value = 1
 
         self.ni1.connect(self.no_empty)
@@ -285,7 +285,7 @@ class TestDataChannels(unittest.TestCase):
 
     def test_value_assignment(self):
         self.ni1.value = 2  # Should be fine when value matches hint
-        self.ni1.value = NotData  # Should be able to clear the data
+        self.ni1.value = NOT_DATA  # Should be able to clear the data
 
         self.ni1.node.running = True
         with self.assertRaises(
@@ -313,7 +313,7 @@ class TestDataChannels(unittest.TestCase):
             without_default = InputData(label="without_default", node=DummyNode())
             self.assertIs(
                 without_default.value,
-                NotData,
+                NOT_DATA,
                 msg=f"Without a default, spec is to have a NotData value but got "
                     f"{type(without_default.value)}"
             )

--- a/tests/unit/test_composite.py
+++ b/tests/unit/test_composite.py
@@ -3,7 +3,7 @@ import unittest
 from bidict import ValueDuplicationError
 
 from pyiron_workflow._tests import ensure_tests_in_python_path
-from pyiron_workflow.channels import NotData
+from pyiron_workflow.channels import NOT_DATA
 from pyiron_workflow.composite import Composite
 from pyiron_workflow.io import Outputs, Inputs
 from pyiron_workflow.topology import CircularDataFlowError
@@ -423,7 +423,7 @@ class TestComposite(unittest.TestCase):
             msg="Expected to start from starting node and propagate"
         )
         self.assertIs(
-            NotData,
+            NOT_DATA,
             self.comp.n3.outputs.y.value,
             msg="n3 was omitted from the execution diagram, it should not have run"
         )

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -2,7 +2,7 @@ from typing import Optional, Union
 import unittest
 import warnings
 
-from pyiron_workflow.channels import NotData, ChannelConnectionError
+from pyiron_workflow.channels import NOT_DATA, ChannelConnectionError
 from pyiron_workflow.function import Function, SingleValue, function_node
 from pyiron_workflow.interfaces import Executor
 
@@ -44,7 +44,7 @@ class TestFunction(unittest.TestCase):
         with self.subTest("Args and kwargs at initialization"):
             node = Function(plus_one)
             self.assertIs(
-                NotData,
+                NOT_DATA,
                 node.outputs.y.value,
                 msg="Sanity check that output just has the standard not-data value at "
                     "instantiation",
@@ -52,7 +52,7 @@ class TestFunction(unittest.TestCase):
             node.inputs.x = 10
             self.assertIs(
                 node.outputs.y.value,
-                NotData,
+                NOT_DATA,
                 msg="Nodes should not run on input updates",
             )
             node.run()
@@ -104,8 +104,8 @@ class TestFunction(unittest.TestCase):
         without_defaults = Function(no_default)
         self.assertIs(
             without_defaults.inputs.x.value,
-            NotData,
-            msg=f"Expected values with no default specified to start as {NotData} but "
+            NOT_DATA,
+            msg=f"Expected values with no default specified to start as {NOT_DATA} but "
                 f"got {without_defaults.inputs.x.value}",
         )
         self.assertFalse(
@@ -383,7 +383,7 @@ class TestFunction(unittest.TestCase):
             return out
 
         @function_node()
-        def all_floats(x=1.1, y=1.1, z=1.1, omega=NotData, extra_there=None) -> float:
+        def all_floats(x=1.1, y=1.1, z=1.1, omega=NOT_DATA, extra_there=None) -> float:
             out = 42.1
             return out
 
@@ -531,9 +531,9 @@ class TestSingleValue(unittest.TestCase):
 
         with self.subTest("Not data"):
             svn = SingleValue(no_default, output_labels="output")
-            self.assertIs(svn.outputs.output.value, NotData)
+            self.assertIs(svn.outputs.output.value, NOT_DATA)
             self.assertTrue(
-                svn.__repr__().endswith(NotData.__name__),
+                svn.__repr__().endswith(NOT_DATA.__repr__()),
                 msg="When the output is still not data, the representation should "
                     "indicate this"
             )

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -394,7 +394,7 @@ class TestFunction(unittest.TestCase):
         floats.run(
             check_readiness=False,
             # We force-skip the readiness check since we are explicitly _trying_ to
-            # have one of the inputs be `NotData` -- a value which triggers the channel
+            # have one of the inputs be `NOT_DATA` -- a value which triggers the channel
             # to be "not ready"
         )
 
@@ -417,7 +417,7 @@ class TestFunction(unittest.TestCase):
         self.assertEqual(
             ref.inputs.omega.value,
             None,
-            msg="NotData should be ignored when copying"
+            msg="NOT_DATA should be ignored when copying"
         )
         self.assertEqual(
             ref.outputs.out.value,

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -4,7 +4,7 @@ from functools import partialmethod
 from time import sleep
 import unittest
 
-from pyiron_workflow.channels import NotData
+from pyiron_workflow.channels import NOT_DATA
 from pyiron_workflow.function import SingleValue
 from pyiron_workflow.macro import Macro, macro_node
 from pyiron_workflow.topology import CircularDataFlowError
@@ -142,7 +142,7 @@ class TestMacro(unittest.TestCase):
 
         self.assertIs(
             m.outputs.three__result.value,
-            NotData,
+            NOT_DATA,
             msg="Output should be accessible with the usual naming convention, but we "
                 "have not run yet so there shouldn't be any data"
         )
@@ -218,7 +218,7 @@ class TestMacro(unittest.TestCase):
         macro.executor = macro.create.Executor()
 
         self.assertIs(
-            NotData,
+            NOT_DATA,
             macro.outputs.three__result.value,
             msg="Sanity check that test is in right starting condition"
         )
@@ -230,7 +230,7 @@ class TestMacro(unittest.TestCase):
             msg="Should be running as a parallel process"
         )
         self.assertIs(
-            NotData,
+            NOT_DATA,
             downstream.outputs.result.value,
             msg="Downstream events should not yet have triggered either, we should wait"
                 "for the callback when the result is ready"

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -3,7 +3,7 @@ import os
 
 import unittest
 
-from pyiron_workflow.channels import InputData, OutputData, NotData
+from pyiron_workflow.channels import InputData, OutputData, NOT_DATA
 from pyiron_workflow.snippets.files import DirectoryObject
 from pyiron_workflow.interfaces import Executor
 from pyiron_workflow.io import Inputs, Outputs
@@ -342,7 +342,7 @@ class TestNode(unittest.TestCase):
     def test_run_after_init(self):
         self.assertIs(
             self.n1.outputs.y.value,
-            NotData,
+            NOT_DATA,
             msg="By default, nodes should not be getting run until asked"
         )
         self.assertEqual(
@@ -371,7 +371,7 @@ class TestNode(unittest.TestCase):
     def test_storage(self):
         self.assertIs(
             self.n1.outputs.y.value,
-            NotData,
+            NOT_DATA,
             msg="Sanity check on initial state"
         )
         y = self.n1()
@@ -388,7 +388,7 @@ class TestNode(unittest.TestCase):
         clean_slate = ANode(self.n1.label, x=x, overwrite_save=True)
         self.assertIs(
             clean_slate.outputs.y.value,
-            NotData,
+            NOT_DATA,
             msg="Users should be able to ignore a save"
         )
 
@@ -420,7 +420,7 @@ class TestNode(unittest.TestCase):
 
         not_reloaded = ANode("just_run")
         self.assertIs(
-            NotData,
+            NOT_DATA,
             not_reloaded.outputs.y.value,
             msg="Should not have saved, therefore should have been nothing to load"
         )

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -4,7 +4,7 @@ from time import sleep
 import unittest
 
 from pyiron_workflow._tests import ensure_tests_in_python_path
-from pyiron_workflow.channels import NotData
+from pyiron_workflow.channels import NOT_DATA
 from pyiron_workflow.snippets.dotdict import DotDict
 from pyiron_workflow.workflow import Workflow
 
@@ -83,7 +83,7 @@ class TestWorkflow(unittest.TestCase):
         wf.executor = wf.create.Executor()
 
         self.assertIs(
-            NotData,
+            NOT_DATA,
             wf.outputs.b__y.value,
             msg="Sanity check that test is in right starting condition"
         )
@@ -151,7 +151,7 @@ class TestWorkflow(unittest.TestCase):
         )
         self.assertEqual(
             wf.sum.outputs.sum.value,
-            NotData,
+            NOT_DATA,
             msg="The slow node _should_ hold up the downstream node to which it inputs"
         )
 


### PR DESCRIPTION
The original motivation was to get the non-data data working better with `h5io`, but I actually like the singleton better than using a raw class. Also the `is` comparisons all keep working, since it's literally the same instance.

Defining `__reduce__` allows pickle to get back the exact same global instance defined alongside the singleton class.

After @samwaseda's addition (#185), I start to wonder if this is actually something that would be nice to have generically available in `snippets`?