### PR TITLE
Parent decorated nodes to the module their function came from

### DIFF
--- a/pyiron_workflow/function.py
+++ b/pyiron_workflow/function.py
@@ -764,6 +764,7 @@ def _wrapper_factory(
                 ),
                 "node_function": staticmethod(node_function),
                 "_type_hints": get_type_hints(node_function),
+                "__module__": node_function.__module__,
             },
         )
 

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -625,6 +625,7 @@ def macro_node(*output_labels, **node_class_kwargs):
                     **node_class_kwargs,
                 ),
                 "graph_creator": staticmethod(graph_creator),
+                "__module__": graph_creator.__module__,
             },
         )
 


### PR DESCRIPTION
Instead of `abc`.

This isn't particularly important by itself, just aesthetically nice,  but together with the two PRs I opened on `h5io` it lets us save and load with that package since the nodes become pickle-findable.

E.g. we can do this and it works*:

```python
from pyiron_workflow import Workflow

wf = Workflow("some_graph")

wf.inp = wf.create.standard.UserInput(42)
wf.double = 2 * wf.inp
wf.out = wf.create.standard.UserInput(wf.double)

out = wf()

import h5io

h5io.write_hdf5(
    fname="stuff.h5",
    data=wf,
    use_state=True,
    overwrite=True,
)

wf_reloaded = h5io.read_hdf5(fname="stuff.h5")
```

*Kind of. `h5io` still borks for some node content, e.g. for the `atomistics` library it complains about some random method on the `Calculator` object that `EMT` inherits from. In contrast, `tinybase` can serialize atomistics workflows without any trouble -- I think because it ultimately falls back on `cloudpickle` if it gets really stuck?