### PR TITLE
Purge and restore starting nodes from the state

### DIFF
--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -639,7 +639,7 @@ class Composite(Node, ABC):
 
     @property
     def node_labels(self) -> tuple[str]:
-        return (n.label for n in self)
+        return tuple(n.label for n in self)
 
     @property
     def _starting_node_labels(self):

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -657,6 +657,11 @@ class Composite(Node, ABC):
         state["node_labels"] = list(self.nodes.keys())
         for node in self:
             state[node.label] = node
+
+        # Also remove the starting node instances
+        del state["starting_nodes"]
+        state["starting_node_labels"] = [n.label for n in self.starting_nodes]
+
         return state
 
     def __setstate__(self, state):
@@ -676,6 +681,11 @@ class Composite(Node, ABC):
         state["nodes"] = DotDict(
             {label: state[label] for label in state.pop("node_labels")}
         )
+
+        # Restore starting nodes
+        state["starting_nodes"] = [
+            state[label] for label in state.pop("starting_node_labels")
+        ]
 
         super().__setstate__(state)
 

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -641,6 +641,12 @@ class Composite(Node, ABC):
     def node_labels(self) -> tuple[str]:
         return (n.label for n in self)
 
+    @property
+    def _starting_node_labels(self):
+        # As a property so it appears in `__dir__` and thus is guaranteed to not
+        # conflict with a child node name in the state
+        return tuple(n.label for n in self.starting_nodes)
+
     def __getstate__(self):
         state = super().__getstate__()
         # Store connections as strings
@@ -668,7 +674,7 @@ class Composite(Node, ABC):
 
         # Also remove the starting node instances
         del state["starting_nodes"]
-        state["starting_node_labels"] = [n.label for n in self.starting_nodes]
+        state["_starting_node_labels"] = self._starting_node_labels
 
         return state
 
@@ -692,7 +698,7 @@ class Composite(Node, ABC):
 
         # Restore starting nodes
         state["starting_nodes"] = [
-            state[label] for label in state.pop("starting_node_labels")
+            state[label] for label in state.pop("_starting_node_labels")
         ]
 
         super().__setstate__(state)


### PR DESCRIPTION
To minimize the number of complex instance objects stored in the state