### PR TITLE
Add and test wrappers for sticking nodes in a pyiron job

### DIFF
--- a/pyiron_workflow/job.py
+++ b/pyiron_workflow/job.py
@@ -61,27 +61,21 @@ class NodeJob(TemplateJob):
         >>> from pyiron_workflow import Workflow
         >>> import pyiron_workflow.job  # To get the job registered in JOB_CLASS_DICT
         >>> 
-        >>> @Workflow.wrap_as.single_value_node("t")
-        ... def Sleep(t):
-        ...     from time import sleep
-        ...     sleep(t)
-        ...     return t
-        >>> 
         >>> wf = Workflow("pyiron_node", overwrite_save=True)
-        >>> wf.sleep = Sleep(0)
-        >>> wf.out = wf.create.standard.UserInput(wf.sleep)
+        >>> wf.answer = Workflow.create.standard.UserInput(42)  # Or your nodes
         >>> 
         >>> pr = Project("test")
         >>> 
         >>> nj = pr.create.job.NodeJob("my_node")
         >>> nj.node = wf
-        >>> nj.run()
+        >>> nj.run()  # doctest:+ELLIPSIS
+        The job my_node was saved and received the ID: ...
         >>> print(nj.node.outputs.to_value_dict())
-        {'out__user_input': 0}
+        {'answer__user_input': 42}
 
         >>> lj = pr.load(nj.job_name)
         >>> print(nj.node.outputs.to_value_dict())
-        {'out__user_input': 0}
+        {'answer__user_input': 42}
 
         >>> pr.remove_jobs(recursive=True, silently=True)
         >>> pr.remove(enable=True)
@@ -183,26 +177,19 @@ def create_job_with_python_wrapper(project, node):
         >>> from pyiron_workflow import Workflow
         >>> from pyiron_workflow.job import create_job_with_python_wrapper
         >>> 
-        >>> @Workflow.wrap_as.single_value_node("t")
-        ... def Sleep(t):
-        ...     from time import sleep
-        ...     sleep(t)
-        ...     return t
-        >>> 
         >>> wf = Workflow("pyiron_node", overwrite_save=True)
-        >>> wf.sleep = Sleep(0)
-        >>> wf.out = wf.create.standard.UserInput(wf.sleep)
+        >>> wf.answer = Workflow.create.standard.UserInput(42)  # Or your nodes
         >>> 
         >>> pr = Project("test")
         >>> 
         >>> nj = create_job_with_python_wrapper(pr, wf)
         >>> nj.run()
         >>> print(nj.output["result"].outputs.to_value_dict())
-        {'out__user_input': 0}
+        {'answer__user_input': 42}
 
         >>> lj = pr.load(nj.job_name)
         >>> print(nj.output["result"].outputs.to_value_dict())
-        {'out__user_input': 0}
+        {'answer__user_input': 42}
 
         >>> pr.remove_jobs(recursive=True, silently=True)
         >>> pr.remove(enable=True)

--- a/pyiron_workflow/job.py
+++ b/pyiron_workflow/job.py
@@ -42,7 +42,8 @@ _WARNINGS_STRING = """
 
 
 class NodeJob(TemplateJob):
-    __doc__ = """
+    __doc__ = (
+        """
     This job is an intermediate feature for accessing pyiron's queue submission
     infrastructure for nodes (function nodes, macros, or entire workflows).
 
@@ -80,7 +81,9 @@ class NodeJob(TemplateJob):
         >>> pr.remove_jobs(recursive=True, silently=True)
         >>> pr.remove(enable=True)
 
-    """ + _WARNINGS_STRING
+    """
+        + _WARNINGS_STRING
+    )
 
     def __init__(self, project, job_name):
         super().__init__(project, job_name)
@@ -105,8 +108,9 @@ class NodeJob(TemplateJob):
             self.raise_working_directory_error()
         else:
             self._node = new_node
-            self.input._class_type = f"{new_node.__class__.__module__}." \
-                                    f"{new_node.__class__.__name__}"
+            self.input._class_type = (
+                f"{new_node.__class__.__module__}." f"{new_node.__class__.__name__}"
+            )
             self.input._label = new_node.label
 
     @staticmethod
@@ -158,7 +162,8 @@ def _run_node(node):
 
 
 def create_job_with_python_wrapper(project, node):
-    __doc__ = """
+    __doc__ = (
+        """
     A convenience wrapper around :meth:`pyiron_base.Project.wrap_python_function` for 
     running a `pyiron_workflow.Workflow`. (And _only_ workflows, `Function` and `Macro`
     children will fail.)
@@ -194,7 +199,9 @@ def create_job_with_python_wrapper(project, node):
         >>> pr.remove_jobs(recursive=True, silently=True)
         >>> pr.remove(enable=True)
         
-    """ + _WARNINGS_STRING
+    """
+        + _WARNINGS_STRING
+    )
     job = project.wrap_python_function(_run_node)
     job.input["node"] = node
     return job

--- a/pyiron_workflow/job.py
+++ b/pyiron_workflow/job.py
@@ -1,0 +1,213 @@
+"""
+Wrapper for running a node as a pyiron base job.
+
+Two approaches are provided while we work out which is more convenient and how some
+edge cases may be handled differently:
+- A direct sub-class of :class:`TemplateJob`, created using the usual job creation.
+- A helper method for using :meth:`Project.wrap_python_function`.
+
+The wrapper   function appears to be slightly slower (presumably because of the extra
+layer of serialization).
+
+The intent of this module is to provide immediate access to pyiron's queue submission
+functionality, while in the long run this should be integrated more directly with the
+workflows. E.g., this solution doesn't permit individual nodes in a workflow to be
+submitted to the queue, but only standalone nodes/macros, or entire workflows.
+
+Parallel processing inside node job will not be possible until the node executor can
+take values _other_ than an actual executor instance (which don't serialize). The
+infrastructure is in place for this in :meth:`Node._parse_executor`, but it is not yet
+leveraged.
+"""
+
+from __future__ import annotations
+
+import os
+
+from pyiron_base import TemplateJob, JOB_CLASS_DICT
+from pyiron_workflow.node import Node
+from h5io._h5io import _import_class
+
+_WARNINGS_STRING = """    
+    Warnings:
+        The job can be run with `run_mode="non_modal"`, but _only_ if all the nodes
+        being run are defined in an importable file location -- i.e. copying and
+        pasting the example above into a jupyter notebook works fine in modal mode, but
+        will throw an exception if you try to run it non-modally.
+
+        This hasn't been tested for running on a remote queue. It should work, but it's
+        _possible_ the same requirement from non-modal mode (importable nodes) will
+        apply.
+"""
+
+
+class NodeJob(TemplateJob):
+    __doc__ = """
+    This job is an intermediate feature for accessing pyiron's queue submission
+    infrastructure for nodes (function nodes, macros, or entire workflows).
+
+    It leans directly on the storage capabilities of the node itself, except for
+    the node class and name, and the storage backend mode, all of which are held in the
+    traditional job input. (Only the storage backend ever needs to be specified, the
+    node information gets populated automatically).
+
+    The job provides direct access to its owned node (as both input and output) on the
+    :attr:`node` attribute. The only requirement is that the node have an untouched
+    working directory (so we can make sure its files get stored _inside_ the job's
+    directory tree), and that it be compatible with the storage backend used.
+
+    Examples:
+        >>> from pyiron_base import Project
+        >>> from pyiron_workflow import Workflow
+        >>> import pyiron_workflow.job  # To get the job registered in JOB_CLASS_DICT
+        >>> 
+        >>> @Workflow.wrap_as.single_value_node("t")
+        ... def Sleep(t):
+        ...     from time import sleep
+        ...     sleep(t)
+        ...     return t
+        >>> 
+        >>> wf = Workflow("pyiron_node", overwrite_save=True)
+        >>> wf.sleep = Sleep(0)
+        >>> wf.out = wf.create.standard.UserInput(wf.sleep)
+        >>> 
+        >>> pr = Project("test")
+        >>> 
+        >>> nj = pr.create.job.NodeJob("my_node")
+        >>> nj.node = wf
+        >>> nj.run()
+        >>> print(nj.node.outputs.to_value_dict())
+        {'out__user_input': 0}
+
+        >>> lj = pr.load(nj.job_name)
+        >>> print(nj.node.outputs.to_value_dict())
+        {'out__user_input': 0}
+
+        >>> pr.remove_jobs(recursive=True, silently=True)
+        >>> pr.remove(enable=True)
+
+    """ + _WARNINGS_STRING
+
+    def __init__(self, project, job_name):
+        super().__init__(project, job_name)
+        self._python_only_job = True
+        self._write_work_dir_warnings = False
+        self._node = None
+        self.input._label = None
+        self.input._class_type = None
+        self.input.storage_backend = "h5io"  # Or "tinybase"
+
+    @property
+    def node(self) -> Node:
+        if self._node is None and self.status.finished:
+            self._load_node()
+        return self._node
+
+    @node.setter
+    def node(self, new_node: Node):
+        if self._node is not None:
+            raise ValueError("Node already set, make a new job")
+        elif self._node_working_directory_already_there(new_node):
+            self.raise_working_directory_error()
+        else:
+            self._node = new_node
+            self.input._class_type = f"{new_node.__class__.__module__}." \
+                                    f"{new_node.__class__.__name__}"
+            self.input._label = new_node.label
+
+    @staticmethod
+    def _node_working_directory_already_there(node):
+        return node._working_directory is not None
+
+    @staticmethod
+    def raise_working_directory_error():
+        raise ValueError("Only nodes with un-touched working directories!")
+
+    def _save_node(self):
+        here = os.getcwd()
+        os.makedirs(self.working_directory, exist_ok=True)
+        os.chdir(self.working_directory)
+        self.node.save(backend=self.input.storage_backend)
+        os.chdir(here)
+
+    def _load_node(self):
+        here = os.getcwd()
+        os.chdir(self.working_directory)
+        self._node = _import_class(self.input._class_type)(self.input._label)
+        os.chdir(here)
+
+    def to_hdf(self, hdf=None, group_name=None):
+        super().to_hdf(hdf=hdf, group_name=group_name)
+        self._save_node()
+
+    def from_hdf(self, hdf=None, group_name=None):
+        super().from_hdf(hdf=hdf, group_name=group_name)
+        self._load_node()
+
+    def validate_ready_to_run(self):
+        if self._node_working_directory_already_there(self.node):
+            self.raise_working_directory_error()
+
+    def run_static(self):
+        self.status.running = True
+        self.node.run()
+        self.to_hdf()
+        self.status.finished = True
+
+
+JOB_CLASS_DICT[NodeJob.__name__] = NodeJob.__module__
+
+
+def _run_node(node):
+    node.run()
+    return node
+
+
+def create_job_with_python_wrapper(project, node):
+    __doc__ = """
+    A convenience wrapper around :meth:`pyiron_base.Project.wrap_python_function` for 
+    running a `pyiron_workflow.Workflow`. (And _only_ workflows, `Function` and `Macro`
+    children will fail.)
+
+    Args:
+        project (pyiron_base.Project): A pyiron project.
+        node (pyiron_workflow.node.Node): The node to run.
+
+    Returns:
+        (pyiron_base.jobs.flex.pythonfunctioncontainer.PythonFunctionContainerJob):
+            A job which wraps a function for running the node, with the `"node"` input
+            pre-populated with the provided node.
+            
+    Examples:
+        >>> from pyiron_base import Project
+        >>> from pyiron_workflow import Workflow
+        >>> from pyiron_workflow.job import create_job_with_python_wrapper
+        >>> 
+        >>> @Workflow.wrap_as.single_value_node("t")
+        ... def Sleep(t):
+        ...     from time import sleep
+        ...     sleep(t)
+        ...     return t
+        >>> 
+        >>> wf = Workflow("pyiron_node", overwrite_save=True)
+        >>> wf.sleep = Sleep(0)
+        >>> wf.out = wf.create.standard.UserInput(wf.sleep)
+        >>> 
+        >>> pr = Project("test")
+        >>> 
+        >>> nj = create_job_with_python_wrapper(pr, wf)
+        >>> nj.run()
+        >>> print(nj.output["result"].outputs.to_value_dict())
+        {'out__user_input': 0}
+
+        >>> lj = pr.load(nj.job_name)
+        >>> print(nj.output["result"].outputs.to_value_dict())
+        {'out__user_input': 0}
+
+        >>> pr.remove_jobs(recursive=True, silently=True)
+        >>> pr.remove(enable=True)
+        
+    """ + _WARNINGS_STRING
+    job = project.wrap_python_function(_run_node)
+    job.input["node"] = node
+    return job

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -1,0 +1,195 @@
+from abc import ABC, abstractmethod
+from time import sleep
+import unittest
+
+from pyiron_base import Project
+from pyiron_workflow import Workflow
+from pyiron_workflow.channels import NOT_DATA
+from pyiron_workflow.job import create_job_with_python_wrapper
+
+
+@Workflow.wrap_as.single_value_node("t")
+def Sleep(t):
+    sleep(t)
+    return t
+
+
+class _WithAJob(unittest.TestCase, ABC):
+    @abstractmethod
+    def make_a_job_from_node(self, node):
+        pass
+
+    def setUp(self) -> None:
+        self.pr = Project("test")
+
+    def tearDown(self) -> None:
+        self.pr.remove_jobs(recursive=True, silently=True)
+        self.pr.remove(enable=True)
+
+
+class TestNodeJob(_WithAJob):
+    def make_a_job_from_node(self, node):
+        job = self.pr.create.job.NodeJob(node.label)
+        job.node = node
+        return job
+
+    def test_modal(self):
+        modal_wf = Workflow("modal_wf")
+        modal_wf.sleep = Sleep(0)
+        modal_wf.out = modal_wf.create.standard.UserInput(modal_wf.sleep)
+        nj = self.make_a_job_from_node(modal_wf)
+
+        nj.run()
+        self.assertTrue(
+            nj.status.finished,
+            msg="The interpreter should not release until the job is done"
+        )
+        self.assertEqual(
+            0,
+            nj.node.outputs.out__user_input.value,
+            msg="The node should have run, and since it's modal there's no need to "
+                "update the instance"
+        )
+
+        lj = self.pr.load(nj.job_name)
+        self.assertIsNot(
+            lj,
+            nj,
+            msg="The loaded job should be a new instance."
+        )
+        self.assertEqual(
+            nj.node.outputs.out__user_input.value,
+            lj.node.outputs.out__user_input.value,
+            msg="The loaded job should still have all the same values"
+        )
+
+    def test_nonmodal(self):
+        nonmodal_node = Workflow("non_modal")
+        nonmodal_node.out = Workflow.create.standard.UserInput(42)
+
+        nj = self.make_a_job_from_node(nonmodal_node)
+        nj.run(run_mode="non_modal")
+        self.assertFalse(
+            nj.status.finished,
+            msg=f"The local process should released immediately per non-modal "
+                f"style, but got status {nj.status}"
+        )
+        while not nj.status.finished:
+            sleep(0.1)
+        self.assertTrue(
+            nj.status.finished,
+            msg="The job status should update on completion"
+        )
+        self.assertIs(
+            nj.node.outputs.out__user_input.value,
+            NOT_DATA,
+            msg="As usual with remote processes, we expect to require a data read "
+                "before the local instance reflects its new state."
+        )
+
+        lj = self.pr.load(nj.job_name)
+        self.assertEqual(
+            42,
+            lj.node.outputs.out__user_input.value,
+            msg="The loaded job should have the finished values"
+        )
+
+    def test_bad_workflow(self):
+        has_wd_wf = Workflow("not_empty")
+        try:
+            has_wd_wf.working_directory  # Touch the working directory, creating it
+            with self.assertRaises(
+                ValueError,
+                msg="To make sure the node gets stored _inside_ the job, we only "
+                    "accept the assignment of nodes who haven't looked at their working "
+                    "directory yet"
+            ):
+                self.make_a_job_from_node(has_wd_wf)
+        finally:
+            has_wd_wf.working_directory.delete()
+
+
+class TestWrapperFunction(_WithAJob):
+    def make_a_job_from_node(self, node):
+        return create_job_with_python_wrapper(self.pr, node)
+
+    def test_modal(self):
+        modal_wf = Workflow("modal_wf")
+        modal_wf.sleep = Sleep(0)
+        modal_wf.out = modal_wf.create.standard.UserInput(modal_wf.sleep)
+        nj = self.make_a_job_from_node(modal_wf)
+
+        nj.run()
+        self.assertTrue(
+            nj.status.finished,
+            msg="The interpreter should not release until the job is done"
+        )
+        self.assertEqual(
+            0,
+            nj.output["result"].outputs.out__user_input.value,
+            msg="The node should have run, and since it's modal there's no need to "
+                "update the instance"
+        )
+
+        lj = self.pr.load(nj.job_name)
+        self.assertIsNot(
+            lj,
+            nj,
+            msg="The loaded job should be a new instance."
+        )
+        self.assertEqual(
+            nj.output["result"].outputs.out__user_input.value,
+            lj.output["result"].outputs.out__user_input.value,
+            msg="The loaded job should still have all the same values"
+        )
+
+    def test_node(self):
+        node = Workflow.create.standard.UserInput(42)
+        nj = self.make_a_job_from_node(node)
+        nj.run()
+        self.assertEqual(
+            42,
+            nj.node.outputs.user_input,
+            msg="A single node should run just as well as a workflow"
+        )
+
+    def test_nonmodal(self):
+        nonmodal_node = Workflow("non_modal")
+        nonmodal_node.out = Workflow.create.standard.UserInput(42)
+
+        nj = self.make_a_job_from_node(nonmodal_node)
+        nj.run(run_mode="non_modal")
+        self.assertFalse(
+            nj.status.finished,
+            msg=f"The local process should released immediately per non-modal "
+                f"style, but got status {nj.status}"
+        )
+        while not nj.status.finished:
+            sleep(0.1)
+        self.assertTrue(
+            nj.status.finished,
+            msg="The job status should update on completion"
+        )
+        with self.assertRaises(
+            KeyError,
+            msg="As usual with remote processes, we expect to require a data read "
+                "before the local instance reflects its new state."
+        ):
+            nj.output["result"]
+
+        lj = self.pr.load(nj.job_name)
+        self.assertEqual(
+            42,
+            lj.output["result"].outputs.out__user_input.value,
+            msg="The loaded job should have the finished values"
+        )
+
+    def test_node(self):
+        node = Workflow.create.standard.UserInput(42)
+        nj = self.make_a_job_from_node(node)
+        with self.assertRaises(
+            AttributeError,
+            msg="The wrapping routine doesn't interact well with getattr overrides on "
+                "node state elements (output data)"
+        ):
+            nj.run()


### PR DESCRIPTION
In the long run we want to have queue submission fully integrated with nodes; in the short term, we can get that by making a `pyiron_base` job out of a node. This isn't a permanent solution as it doesn't allow, e.g., sending just one node from a graph off to the queue, only entire graphs (even if they're just one node themself).

Here I introduce two solutions: one defines a new subclass of `TemplateJob` and relies on the node's own storage capabilities to (de)serialize itself (from)to HDF _inside_ the job's working directory. The only true `input` on the job is a string saying what storage backend the node should use (`"h5io"`/`"tinybase"`, per #160); then the user supplies a node instance to the job's `.node` attribute. The executed node can be found in the same place on the job on reloading.

The other exploits the [new](https://github.com/pyiron/pyiron_base/pull/1285) `pyiron_base.Project.wrap_python_function`, which takes a node in `job.input["node"]` and returns the executed version in `job.output["result"]` using the wrapper's `cloudpickle` and ignoring the nodes own storage.

Here's an example of the first approach copied from the docstring:

```python
        >>> from pyiron_base import Project
        >>> from pyiron_workflow import Workflow
        >>> import pyiron_workflow.job  # To get the job registered in JOB_CLASS_DICT
        >>> 
        >>> @Workflow.wrap_as.single_value_node("t")
        ... def Sleep(t):
        ...     from time import sleep
        ...     sleep(t)
        ...     return t
        >>> 
        >>> wf = Workflow("pyiron_node", overwrite_save=True)
        >>> wf.sleep = Sleep(0)
        >>> wf.out = wf.create.standard.UserInput(wf.sleep)
        >>> 
        >>> pr = Project("test")
        >>> 
        >>> nj = pr.create.job.NodeJob("my_node")
        >>> nj.node = wf
        >>> nj.run()
        >>> print(nj.node.outputs.to_value_dict())
        {'out__user_input': 0}

        >>> lj = pr.load(nj.job_name)
        >>> print(nj.node.outputs.to_value_dict())
        {'out__user_input': 0}

        >>> pr.remove_jobs(recursive=True, silently=True)
        >>> pr.remove(enable=True)
```

The docstrings and tests are relatively thorough, but I'm not keen to document it in the tutorial notebooks or expose the functionality directly on the `Workflow` class yet -- I'd rather if some people at MPIE played around with it a bit and let me know what would be helpful, which interface they prefer, etc.

The one big constraint in this PR is that the nodes will still only run on a single core, even when shipped off to a queue. This is because the node's `.executor` attribute is (so far) `None` or an instance of an executor -- and the later can't be easily serialized. @jan-janssen is working on this [for the underlying `PythonFunctionContainerJob`](https://github.com/pyiron/pyiron_base/pull/1296/files), but we may also be able to solve it independently for the `NodeJob` here using the same attack -- namely, supplying information on how to instantiate a fresh executor on the far side instead of passing along a live instance. We already have the infrastructure in place to do this in the [`Node._parse_executor` method](https://github.com/pyiron/pyiron_workflow/blob/f7e810c86a049f555836b41ddfc8d33878b6b15e/pyiron_workflow/node.py#L534), it's simply a matter of populating that method with the logic to parse a class name and args/kwargs for the new executor.

@ligerzero-ai, IIRC you were going to look at running multi-core Vasp jobs in a workflow? This should let you do it on the queue, so basically you just need to write parser nodes, and a shell node (preferably a generic one, and a more specific one that executes VASP in particular), then put them all together in a macro. @JNmpi has examples of these things for other codes over on his branch (#33), so we're not too far off.  I don't expect you to do anything with this immediately, I just want to stay mutually well informed so we don't wind up doubling up on work. If you do want to work on it, maybe you could first/also open a PR to extend `_parse_executors`?

**Note** that this PR depends on [pyiron_contrib](https://github.com/pyiron/pyiron_contrib/pull/949) and [h5io](https://github.com/h5io/h5io/pull/77) code that isn't merged to main yet, much less released, so none of it will run unless you clone those branches locally. This is also why the CI tests all fail.