### PR TITLE
Patch tinybase safe save dynamics

### DIFF
--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -157,6 +157,13 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         - On instantiation, nodes will load automatically if they find saved content.
           - Discovered content can instead be deleted with a kwarg.
           - You can't load saved content _and_ run after instantiation at once.
+        - The nodes must be somewhere importable, and the imported object must match
+            the type of the node being saved. This basically just rules out one edge
+            case where a node class is defined like
+            `SomeFunctionNode = Workflow.wrap_as.function_node()(some_function)`, since
+            then the new class gets the name `some_function`, which when imported is
+            the _function_ "some_function" and not the desired class "SomeFunctionNode".
+            This is checked for at save-time and will cause a nice early failure.
         - [ALPHA ISSUE] If the source code (cells, `.py` files...) for a saved graph is
             altered between saving and loading the graph, there are no guarantees about
             the loaded state; depending on the nature of the changes everything may

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -47,14 +47,14 @@ class StorageInterface:
             root.storage.save(backend=backend)
 
     def _save(self, backend: Literal["h5io", "tinybase"]):
+        if not self.node.import_ready:
+            raise TypeNotFoundError(
+                f"{self.node.label} cannot be saved with h5io because it (or one "
+                f"of its child nodes) has a type that cannot be imported. Did you "
+                f"dynamically define this node? Try using the node wrapper as a "
+                f"decorator instead."
+            )
         if backend == "h5io":
-            if not self.node.import_ready:
-                raise TypeNotFoundError(
-                    f"{self.node.label} cannot be saved with h5io because it (or one "
-                    f"of its child nodes) has a type that cannot be imported. Did you "
-                    f"dynamically define this node? Try using the node wrapper as a "
-                    f"decorator instead."
-                )
             h5io.write_hdf5(
                 fname=self._h5io_storage_file_path,
                 data=self.node,

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -382,6 +382,20 @@ class TestWorkflow(unittest.TestCase):
                 finally:
                     wf.storage.delete()
 
+        with self.subTest("No unimportable nodes for either back-end"):
+            try:
+                wf.import_type_mismatch = wf.create.demo.dynamic()
+                for backend in ["h5io", "tinybase"]:
+                    with self.subTest(backend):
+                        with self.assertRaises(
+                            TypeNotFoundError,
+                            msg="Imported object is function but node type is node -- "
+                                "should fail early on save"
+                        ):
+                            wf.save(backend=backend)
+            finally:
+                wf.remove_node(wf.import_type_mismatch)
+
         wf.add_node(PlusOne(label="local_but_importable"))
         try:
             wf.save(backend="h5io")


### PR DESCRIPTION
Just a patch to provide the same protection for a `"tinybase"` backend that we already give to the `"h5io"` backend when the imported type doesn't match the type of the object being saved, per [@niklassiemer's suggestion](https://github.com/pyiron/pyiron_workflow/pull/197/files#r1481020408). Also mentioning the issue in the docstring with the rest of the storage commentary.