### PR TITLE
Fix registration

### DIFF
--- a/pyiron_workflow/interfaces.py
+++ b/pyiron_workflow/interfaces.py
@@ -243,9 +243,11 @@ class Creator(metaclass=Singleton):
             if domain is not None:
                 if domain not in container.keys():
                     container[domain] = DotDict()
-                subcontainer = container[domain]
+                container = container[domain]
             else:
-                subcontainer = None
+                container = None
+            subcontainer = container
+
             for _, submodule_name, _ in pkgutil.walk_packages(
                 module.__path__, module.__name__ + "."
             ):
@@ -260,9 +262,14 @@ class Creator(metaclass=Singleton):
                             submodule, subdomain, subcontainer
                         )
                 else:
-                    if subdomain not in container.keys():
-                        subcontainer[subdomain] = DotDict()
-                    subcontainer = subcontainer[subdomain]
+                    relative_path = submodule.__name__.replace(
+                        module.__name__ + ".", ""
+                    )
+                    subcontainer = container
+                    for step in relative_path.split("."):
+                        if step not in subcontainer.keys():
+                            subcontainer[step] = DotDict()
+                        subcontainer = subcontainer[subdomain]
         else:
             self._register_package_from_module(module, domain, container)
 

--- a/tests/static/nodes_subpackage/subsub_sibling/demo_nodes.py
+++ b/tests/static/nodes_subpackage/subsub_sibling/demo_nodes.py
@@ -1,0 +1,16 @@
+"""
+A demo node package for the purpose of testing node package registration.
+"""
+
+from typing import Optional
+
+from pyiron_workflow import Workflow
+
+
+@Workflow.wrap_as.single_value_node("sum")
+def OptionallyAdd(x: int, y: Optional[int] = None) -> int:
+    y = 0 if y is None else y
+    return x + y
+
+
+nodes = [OptionallyAdd]

--- a/tests/unit/test_interfaces.py
+++ b/tests/unit/test_interfaces.py
@@ -44,6 +44,7 @@ class TestCreator(unittest.TestCase):
         self.creator.register("static.nodes_subpackage", "sub")
         self.assertIsInstance(self.creator.sub.demo_nodes, NodePackage)
         self.assertIsInstance(self.creator.sub.subsub_package.demo_nodes, NodePackage)
+        self.assertIsInstance(self.creator.sub.subsub_sibling.demo_nodes, NodePackage)
 
         with self.subTest("Test re-registration"):
             self.creator.register("static.demo_nodes", "demo")


### PR DESCRIPTION
So that the node package access tree has the same topology as the registered module. There was just a bug. Closes #205 