### PR TITLE
Make NodeJob compliant with the storage interface

### DIFF
--- a/notebooks/deepdive.ipynb
+++ b/notebooks/deepdive.ipynb
@@ -989,7 +989,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAGdCAYAAADAAnMpAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8g+/7EAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAfuklEQVR4nO3db0zd5f3/8dc5B+HUDo6hFTgWxo5d63okaoDQQdeYOcuoBtMbSzGurbq6jKrTrtOkTReRxoToopk6Ibr5J6bYEY3uJwlDuaXUfjcmtIl4TDQtG/1zkADxcPxDG8+5fjcYpEdAOadwrh7O85Fwgw+fA2/yScOzn+uc6ziMMUYAAACWOG0PAAAA0hsxAgAArCJGAACAVcQIAACwihgBAABWESMAAMAqYgQAAFhFjAAAAKsybA8wH9FoVGfOnFF2drYcDoftcQAAwDwYYxQOh3XFFVfI6Zz7/kdKxMiZM2dUVFRkewwAAJCAkydPqrCwcM6vp0SMZGdnS5r8ZXJycixPAwAA5mN8fFxFRUXTf8fnkhIxMrU0k5OTQ4wAAJBivuspFjyBFQAAWEWMAAAAq4gRAABgFTECAACsIkYAAIBVxAgAALCKGAEAAFYRIwAAwKqU2PQMS0skatQzMKbh8ITyst2q8OXK5eQ9hwAgXREjSKrO/qAa2wMKhiamj3k9bjXU+lVT4rU4GQDAFpZpkDSd/UHtOtgXEyKSNBSa0K6DfersD1qaDABgEzGCpIhEjRrbAzKzfG3qWGN7QJHobGcAAJYyYgRJ0TMwNuOOyPmMpGBoQj0DY8kbCgBwUSBGkBTD4blDJJHzAABLBzGCpMjLdi/oeQCApYMYQVJU+HLl9bg11wt4HZp8VU2FLzeZYwEALgLECJLC5XSoodYvSTOCZOrzhlo/+40AQBoiRpA0NSVetWwrVYEndimmwONWy7ZS9hkBgDTFpmdIqpoSrzb5C9iBFQAwjRhB0rmcDlWuXmF7DADARYJlGgAAYBUxAgAArCJGAACAVcQIAACwihgBAABWESMAAMAqYgQAAFhFjAAAAKuIEQAAYBUxAgAArCJGAACAVcQIAACwihgBAABWESMAAMAqYgQAAFhFjAAAAKuIEQAAYBUxAgAArCJGAACAVcQIAACwihgBAABWESMAAMAqYgQAAFhFjAAAAKsybA8AAEC6iESNegbGNByeUF62WxW+XLmcDttjWUeMAACQBJ39QTW2BxQMTUwf83rcaqj1q6bEa3Ey+xJapmlubpbP55Pb7VZZWZm6u7u/9fzW1lZde+21uvTSS+X1enXnnXdqdHQ0oYEBAEg1nf1B7TrYFxMikjQUmtCug33q7A9amuziEHeMtLW1affu3dq/f7+OHj2qjRs3avPmzRocHJz1/MOHD2vHjh3auXOnPvzwQ7366qv697//rbvuuuuChwcA4GIXiRo1tgdkZvna1LHG9oAi0dnOSA9xx8gTTzyhnTt36q677tK6dev0pz/9SUVFRWppaZn1/H/+85/6wQ9+oPvuu08+n08/+clP9Jvf/Ebvv//+BQ8PAMDFrmdgbMYdkfMZScHQhHoGxpI31EUmrhg5d+6cent7VV1dHXO8urpaR44cmfUxVVVVOnXqlDo6OmSM0aeffqrXXntNN99885w/5+zZsxofH4/5AAAgFQ2H5w6RRM5biuKKkZGREUUiEeXn58ccz8/P19DQ0KyPqaqqUmtrq+rq6pSZmamCggJddtllevrpp+f8OU1NTfJ4PNMfRUVF8YwJAMBFIy/bvaDnLUUJPYHV4Yh9GZIxZsaxKYFAQPfdd58eeugh9fb2qrOzUwMDA6qvr5/z++/bt0+hUGj64+TJk4mMCQCAdRW+XHk9bs31Al6HJl9VU+HLTeZYF5W4Xtq7cuVKuVyuGXdBhoeHZ9wtmdLU1KQNGzbowQcflCRdc801Wr58uTZu3KhHHnlEXu/MlzNlZWUpKysrntEAALgouZwONdT6tetgnxxSzBNZpwKlodaf1vuNxHVnJDMzU2VlZerq6oo53tXVpaqqqlkf8+WXX8rpjP0xLpdL0uQdFQAAlrqaEq9atpWqwBO7FFPgcatlW2na7zMS96Zne/bs0fbt21VeXq7Kyko999xzGhwcnF522bdvn06fPq2XX35ZklRbW6tf//rXamlp0c9//nMFg0Ht3r1bFRUVuuKKKxb2twEA4CJVU+LVJn8BO7DOIu4Yqaur0+joqA4cOKBgMKiSkhJ1dHSouLhYkhQMBmP2HLnjjjsUDof15z//Wb///e912WWX6YYbbtCjjz66cL8FAAApwOV0qHL1CttjXHQcJgXWSsbHx+XxeBQKhZSTk2N7HAAAMA/z/fvNu/YCAACriBEAAGAVMQIAAKwiRgAAgFXECAAAsIoYAQAAVhEjAADAKmIEAABYRYwAAACriBEAAGAVMQIAAKwiRgAAgFXECAAAsIoYAQAAVhEjAADAKmIEAABYRYwAAACriBEAAGAVMQIAAKwiRgAAgFXECAAAsIoYAQAAVhEjAADAqgzbA9gSiRr1DIxpODyhvGy3Kny5cjkdtscCACDtpGWMdPYH1dgeUDA0MX3M63GrodavmhKvxckAAEg/abdM09kf1K6DfTEhIklDoQntOtinzv6gpckAAEhPaRUjkahRY3tAZpavTR1rbA8oEp3tDAAAJv+W/N/xUf2/Y6f1f8dH+ZuxANJqmaZnYGzGHZHzGUnB0IR6BsZUuXpF8gYDAKQElvkXR1rdGRkOzx0iiZwHAEgfLPMvnrSKkbxs94KeBwBIDyzzL660ipEKX668HrfmegGvQ5O32yp8uckcCwBwkYtnmR/xS6sYcTkdaqj1S9KMIJn6vKHWz34jAIAYLPMvrrSKEUmqKfGqZVupCjyxSzEFHrdatpXyBCQAwAws8y+utHo1zZSaEq82+QvYgRUAMC9Ty/xDoYlZnzfi0OR/alnmT0xaxog0uWTDy3cBAPMxtcy/62CfHFJMkLDMf+HSbpkGAIBEsMy/eNL2zggAAPFimX9xECMAAMSBZf6FxzINAACwihgBAABWESMAAMAqYgQAAFhFjAAAAKuIEQAAYBUxAgAArCJGAACAVcQIAACwihgBAABWESMAAMAqYgQAAFhFjAAAAKt4117AskjU8HbkANIaMQJY1NkfVGN7QMHQxPQxr8ethlq/akq8FicDgORhmQawpLM/qF0H+2JCRJKGQhPadbBPnf1BS5MBQHIRI4AFkahRY3tAZpavTR1rbA8oEp3tDABYWogRwIKegbEZd0TOZyQFQxPqGRhL3lAAYAkxAlgwHJ47RBI5DwBSGTECWJCX7V7Q8wAglREjgAUVvlx5PW7N9QJehyZfVVPhy03mWABgBTECWOByOtRQ65ekGUEy9XlDrZ/9RgCkBWIEsKSmxKuWbaUq8MQuxRR43GrZVso+IwDSBpueARbVlHi1yV/ADqwA0hoxAljmcjpUuXqF7TEAwBqWaQAAgFXECAAAsIoYAQAAVhEjAADAKmIEAABYRYwAAACriBEAAGAVMQIAAKxKKEaam5vl8/nkdrtVVlam7u7ubz3/7Nmz2r9/v4qLi5WVlaXVq1frhRdeSGhgAACwtMS9A2tbW5t2796t5uZmbdiwQc8++6w2b96sQCCg73//+7M+ZuvWrfr000/1/PPP64c//KGGh4f19ddfX/DwAAAg9TmMMSaeB6xfv16lpaVqaWmZPrZu3Tpt2bJFTU1NM87v7OzUrbfeqhMnTig3N7G3Qx8fH5fH41EoFFJOTk5C3wMAACTXfP9+x7VMc+7cOfX29qq6ujrmeHV1tY4cOTLrY958802Vl5frscce06pVq7R27Vo98MAD+uqrr+b8OWfPntX4+HjMBwAAWJriWqYZGRlRJBJRfn5+zPH8/HwNDQ3N+pgTJ07o8OHDcrvdeuONNzQyMqK7775bY2Njcz5vpKmpSY2NjfGMBgAAUlRCT2B1OGLf3twYM+PYlGg0KofDodbWVlVUVOimm27SE088oZdeemnOuyP79u1TKBSa/jh58mQiYwIAgBQQ152RlStXyuVyzbgLMjw8PONuyRSv16tVq1bJ4/FMH1u3bp2MMTp16pTWrFkz4zFZWVnKysqKZzQAAJCi4rozkpmZqbKyMnV1dcUc7+rqUlVV1ayP2bBhg86cOaPPP/98+tjHH38sp9OpwsLCBEYGAABLSdzLNHv27NFf//pXvfDCC/roo4/0u9/9ToODg6qvr5c0ucSyY8eO6fNvu+02rVixQnfeeacCgYDeffddPfjgg/rVr36lZcuWLdxvAgAAUlLc+4zU1dVpdHRUBw4cUDAYVElJiTo6OlRcXCxJCgaDGhwcnD7/e9/7nrq6uvTb3/5W5eXlWrFihbZu3apHHnlk4X4LAACQsuLeZ8QG9hkBACD1LMo+IwAAAAuNGAEAAFYRIwAAwCpiBAAAWEWMAAAAq4gRAABgFTECAACsIkYAAIBVxAgAALCKGAEAAFYRIwAAwCpiBAAAWEWMAAAAq4gRAABgFTECAACsIkYAAIBVxAgAALCKGAEAAFYRIwAAwCpiBAAAWJVhewAsDZGoUc/AmIbDE8rLdqvClyuX02F7LABACiBGcME6+4NqbA8oGJqYPub1uNVQ61dNidfiZACAVMAyDS5IZ39Quw72xYSIJA2FJrTrYJ86+4OWJgMApApiBAmLRI0a2wMys3xt6lhje0CR6GxnAAAwiRhBwnoGxmbcETmfkRQMTahnYCx5QwEAUg4xgoQNh+cOkUTOAwCkJ2IECcvLdi/oeQCA9ESMIGEVvlx5PW7N9QJehyZfVVPhy03mWACAFEOMIGEup0MNtX5JmhEkU5831PrZbwQA8K2IEVyQmhKvWraVqsATuxRT4HGrZVsp+4wAAL4Tm57hgtWUeLXJX8AOrACAhBAjWBAup0OVq1fYHgMAkIJYpgEAAFYRIwAAwCpiBAAAWEWMAAAAq4gRAABgFTECAACsIkYAAIBVxAgAALCKGAEAAFYRIwAAwCpiBAAAWEWMAAAAq4gRAABgFTECAACsIkYAAIBVxAgAALCKGAEAAFYRIwAAwCpiBAAAWEWMAAAAq4gRAABgFTECAACsIkYAAIBVxAgAALCKGAEAAFYRIwAAwCpiBAAAWEWMAAAAq4gRAABgFTECAACsIkYAAIBVxAgAALCKGAEAAFYRIwAAwCpiBAAAWEWMAAAAq4gRAABgFTECAACsIkYAAIBVCcVIc3OzfD6f3G63ysrK1N3dPa/Hvffee8rIyNB1112XyI8FAABLUNwx0tbWpt27d2v//v06evSoNm7cqM2bN2twcPBbHxcKhbRjxw797Gc/S3hYAACw9DiMMSaeB6xfv16lpaVqaWmZPrZu3Tpt2bJFTU1Ncz7u1ltv1Zo1a+RyufT3v/9dx44dm/fPHB8fl8fjUSgUUk5OTjzjAgAAS+b79zuuOyPnzp1Tb2+vqqurY45XV1fryJEjcz7uxRdf1PHjx9XQ0DCvn3P27FmNj4/HfAAAgKUprhgZGRlRJBJRfn5+zPH8/HwNDQ3N+phPPvlEe/fuVWtrqzIyMub1c5qamuTxeKY/ioqK4hkTAACkkISewOpwOGI+N8bMOCZJkUhEt912mxobG7V27dp5f/99+/YpFApNf5w8eTKRMQEAQAqY362K/1m5cqVcLteMuyDDw8Mz7pZIUjgc1vvvv6+jR4/q3nvvlSRFo1EZY5SRkaG3335bN9xww4zHZWVlKSsrK57RAABAiorrzkhmZqbKysrU1dUVc7yrq0tVVVUzzs/JydEHH3ygY8eOTX/U19frqquu0rFjx7R+/foLmx4AAKS8uO6MSNKePXu0fft2lZeXq7KyUs8995wGBwdVX18vaXKJ5fTp03r55ZfldDpVUlIS8/i8vDy53e4ZxwEAQHqKO0bq6uo0OjqqAwcOKBgMqqSkRB0dHSouLpYkBYPB79xzBAAAYErc+4zYwD4jAACknkXZZwQAAGChESMAAMAqYgQAAFhFjAAAAKuIEQAAYBUxAgAArCJGAACAVcQIAACwihgBAABWESMAAMAqYgQAAFhFjAAAAKuIEQAAYBUxAgAArCJGAACAVcQIAACwihgBAABWESMAAMAqYgQAAFhFjAAAAKuIEQAAYBUxAgAArCJGAACAVcQIAACwihgBAABWESMAAMAqYgQAAFhFjAAAAKuIEQAAYBUxAgAArCJGAACAVcQIAACwKsP2AAAApLNI1KhnYEzD4QnlZbtV4cuVy+mwPVZSESMAAFjS2R9UY3tAwdDE9DGvx62GWr9qSrwWJ0sulmkAALCgsz+oXQf7YkJEkoZCE9p1sE+d/UFLkyUfMQIAQJJFokaN7QGZWb42dayxPaBIdLYzlh5iBACAJOsZGJtxR+R8RlIwNKGegbHkDWURMQIAQJINh+cOkUTOS3XECAAASZaX7V7Q81IdMQIAQJJV+HLl9bg11wt4HZp8VU2FLzeZY1lDjAAAkGQup0MNtX5JmhEkU5831PrTZr8RYgQAAAtqSrxq2VaqAk/sUkyBx62WbaVptc8Im54BAGBJTYlXm/wF7MBqewAAANKZy+lQ5eoVtsewimUaAABgFTECAACsIkYAAIBVxAgAALCKGAEAAFYRIwAAwCpiBAAAWEWMAAAAq9j0DACANBWJmoti91diBACANNTZH1Rje0DB0MT0Ma/HrYZaf9LfF4dlGgAA0kxnf1C7DvbFhIgkDYUmtOtgnzr7g0mdhxgBACCNRKJGje0BmVm+NnWssT2gSHS2MxYHMQIAQBrpGRibcUfkfEZSMDShnoGxpM1EjAAAkEaGw3OHSCLnLQRiBACANJKX7V7Q8xYCMQIAQBqp8OXK63FrrhfwOjT5qpoKX27SZiJGAABIIy6nQw21fkmaESRTnzfU+pO63wgxAgBAmqkp8aplW6kKPLFLMQUet1q2lSZ9nxE2PQMAIA3VlHi1yV/ADqwAAMAel9OhytUrbI/BMg0AALCLGAEAAFYRIwAAwCpiBAAAWEWMAAAAq4gRAABgFTECAACsSihGmpub5fP55Ha7VVZWpu7u7jnPff3117Vp0yZdfvnlysnJUWVlpd56662EBwYAAEtL3DHS1tam3bt3a//+/Tp69Kg2btyozZs3a3BwcNbz3333XW3atEkdHR3q7e3VT3/6U9XW1uro0aMXPDwAAEh9DmOMiecB69evV2lpqVpaWqaPrVu3Tlu2bFFTU9O8vsfVV1+turo6PfTQQ/M6f3x8XB6PR6FQSDk5OfGMCwAALJnv3++47oycO3dOvb29qq6ujjleXV2tI0eOzOt7RKNRhcNh5ebO/dbEZ8+e1fj4eMwHAABYmuKKkZGREUUiEeXn58ccz8/P19DQ0Ly+x+OPP64vvvhCW7dunfOcpqYmeTye6Y+ioqJ4xgQAACkkoSewOhyx7+hnjJlxbDaHDh3Sww8/rLa2NuXl5c153r59+xQKhaY/Tp48mciYAAAgBcT1rr0rV66Uy+WacRdkeHh4xt2Sb2pra9POnTv16quv6sYbb/zWc7OyspSVlRXPaAAAIEXFdWckMzNTZWVl6urqijne1dWlqqqqOR936NAh3XHHHXrllVd08803JzYpAABYkuK6MyJJe/bs0fbt21VeXq7Kyko999xzGhwcVH19vaTJJZbTp0/r5ZdfljQZIjt27NCTTz6pH//4x9N3VZYtWyaPx7OAvwoAAEhFccdIXV2dRkdHdeDAAQWDQZWUlKijo0PFxcWSpGAwGLPnyLPPPquvv/5a99xzj+65557p47fffrteeumlC/8NAABASot7nxEb2GcEAIDUsyj7jAAAACw0YgQAAFhFjAAAAKuIEQAAYBUxAgAArCJGAACAVcQIAACwihgBAABWxb0DK4CFE4ka9QyMaTg8obxstyp8uXI5v/sdsAFgKSFGAEs6+4NqbA8oGJqYPub1uNVQ61dNidfiZACQXCzTABZ09ge162BfTIhI0lBoQrsO9qmzP2hpMgBIPmIESLJI1KixPaDZ3hRq6lhje0CR6EX/tlEAsCCIESDJegbGZtwROZ+RFAxNqGdgLHlDAYBFxAiQZMPhuUMkkfMAINURI0CS5WW7F/Q8AEh1xAiQZBW+XHk9bs31Al6HJl9VU+HLTeZYAGANMQIkmcvpUEOtX5JmBMnU5w21fvYbAZA2iBHAgpoSr1q2larAE7sUU+Bxq2VbKfuMAEgrbHoGWFJT4tUmfwE7sAJIe8QIYJHL6VDl6hW2xwAAq1imAQAAVhEjAADAKmIEAABYRYwAAACriBEAAGAVMQIAAKwiRgAAgFXECAAAsIoYAQAAVhEjAADAKmIEAABYRYwAAACriBEAAGAVMQIAAKwiRgAAgFXECAAAsIoYAQAAVhEjAADAKmIEAABYRYwAAACriBEAAGBVhu0BgFQUiRr1DIxpODyhvGy3Kny5cjkdtscCgJREjABx6uwPqrE9oGBoYvqY1+NWQ61fNSVei5MBQGpimQaIQ2d/ULsO9sWEiCQNhSa062CfOvuDliYDgNRFjADzFIkaNbYHZGb52tSxxvaAItHZzgAAzIUYAeapZ2Bsxh2R8xlJwdCEegbGkjcUACwBxAgwT8PhuUMkkfMAAJOIEWCe8rLdC3oeAGASMQLMU4UvV16PW3O9gNehyVfVVPhykzkWAKQ8YgSYJ5fToYZavyTNCJKpzxtq/ew3AgBxIkaAONSUeNWyrVQFntilmAKPWy3bStlnBAASwKZnQJxqSrza5C9gB1YAWCDECJAAl9OhytUrbI8BAEsCyzQAAMAqYgQAAFhFjAAAAKuIEQAAYBUxAgAArCJGAACAVcQIAACwihgBAABWESMAAMCqlNiB1RgjSRofH7c8CQAAmK+pv9tTf8fnkhIxEg6HJUlFRUWWJwEAAPEKh8PyeDxzft1hvitXLgLRaFRnzpxRdna2HA7ejMyG8fFxFRUV6eTJk8rJybE9Dr4F1yp1cK1SB9cqMcYYhcNhXXHFFXI6535mSErcGXE6nSosLLQ9BiTl5OTwDzFFcK1SB9cqdXCt4vdtd0Sm8ARWAABgFTECAACsIkYwL1lZWWpoaFBWVpbtUfAduFapg2uVOrhWiyslnsAKAACWLu6MAAAAq4gRAABgFTECAACsIkYAAIBVxAimNTc3y+fzye12q6ysTN3d3XOe+/rrr2vTpk26/PLLlZOTo8rKSr311ltJnDa9xXOtzvfee+8pIyND11133eIOiGnxXquzZ89q//79Ki4uVlZWllavXq0XXnghSdOmt3ivVWtrq6699lpdeuml8nq9uvPOOzU6OpqkaZcYAxhj/va3v5lLLrnE/OUvfzGBQMDcf//9Zvny5ea///3vrOfff//95tFHHzU9PT3m448/Nvv27TOXXHKJ6evrS/Lk6SfeazXls88+M1deeaWprq421157bXKGTXOJXKtbbrnFrF+/3nR1dZmBgQHzr3/9y7z33ntJnDo9xXuturu7jdPpNE8++aQ5ceKE6e7uNldffbXZsmVLkidfGogRGGOMqaioMPX19THHfvSjH5m9e/fO+3v4/X7T2Ni40KPhGxK9VnV1deYPf/iDaWhoIEaSJN5r9Y9//MN4PB4zOjqajPFwnniv1R//+Edz5ZVXxhx76qmnTGFh4aLNuJSxTAOdO3dOvb29qq6ujjleXV2tI0eOzOt7RKNRhcNh5ebmLsaI+J9Er9WLL76o48ePq6GhYbFHxP8kcq3efPNNlZeX67HHHtOqVau0du1aPfDAA/rqq6+SMXLaSuRaVVVV6dSpU+ro6JAxRp9++qlee+013XzzzckYeclJiTfKw+IaGRlRJBJRfn5+zPH8/HwNDQ3N63s8/vjj+uKLL7R169bFGBH/k8i1+uSTT7R37151d3crI4N/8smSyLU6ceKEDh8+LLfbrTfeeEMjIyO6++67NTY2xvNGFlEi16qqqkqtra2qq6vTxMSEvv76a91yyy16+umnkzHyksOdEUxzOBwxnxtjZhybzaFDh/Twww+rra1NeXl5izUezjPfaxWJRHTbbbepsbFRa9euTdZ4OE88/66i0agcDodaW1tVUVGhm266SU888YReeukl7o4kQTzXKhAI6L777tNDDz2k3t5edXZ2amBgQPX19ckYdcnhv0nQypUr5XK5ZvwPYHh4eMb/FL6pra1NO3fu1Kuvvqobb7xxMceE4r9W4XBY77//vo4ePap7771X0uQfPGOMMjIy9Pbbb+uGG25IyuzpJpF/V16vV6tWrYp5y/V169bJGKNTp05pzZo1izpzukrkWjU1NWnDhg168MEHJUnXXHONli9fro0bN+qRRx6R1+td9LmXEu6MQJmZmSorK1NXV1fM8a6uLlVVVc35uEOHDumOO+7QK6+8wjppksR7rXJycvTBBx/o2LFj0x/19fW66qqrdOzYMa1fvz5Zo6edRP5dbdiwQWfOnNHnn38+fezjjz+W0+lUYWHhos6bzhK5Vl9++aWcztg/oS6XS9LkHRXEyd5zZ3ExmXpZ2/PPP28CgYDZvXu3Wb58ufnPf/5jjDFm7969Zvv27dPnv/LKKyYjI8M888wzJhgMTn989tlntn6FtBHvtfomXk2TPPFeq3A4bAoLC80vfvEL8+GHH5p33nnHrFmzxtx11122foW0Ee+1evHFF01GRoZpbm42x48fN4cPHzbl5eWmoqLC1q+Q0ogRTHvmmWdMcXGxyczMNKWlpeadd96Z/trtt99urr/++unPr7/+eiNpxsftt9+e/MHTUDzX6puIkeSK91p99NFH5sYbbzTLli0zhYWFZs+ePebLL79M8tTpKd5r9dRTTxm/32+WLVtmvF6v+eUvf2lOnTqV5KmXBocx3E8CAAD28JwRAABgFTECAACsIkYAAIBVxAgAALCKGAEAAFYRIwAAwCpiBAAAWEWMAAAAq4gRAABgFTECAACsIkYAAIBVxAgAALDq/wM44josBsaCygAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAioAAAGdCAYAAAA8F1jjAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8g+/7EAAAACXBIWXMAAA9hAAAPYQGoP6dpAAApxUlEQVR4nO3df3TUVX7/8dckITNIyXggkgwSY6SICaloJicxodTWH1nQwy7d9hhrDWqhNayKkWqXlB5jOJ6T7naXolsTZQU9FKQ5ilo5zbLOH7sYjC0lhJ5lY6uV2AScmCacnYmrSZbkfv+gmS/DJJjPkB+fmXk+zvmc49zcz8x7zj2eeXHv53M/DmOMEQAAgA0lzXQBAAAA4yGoAAAA2yKoAAAA2yKoAAAA2yKoAAAA2yKoAAAA2yKoAAAA2yKoAAAA20qZ6QImYmRkRJ999pnmzp0rh8Mx0+UAAIAJMMaov79fCxcuVFJSdHMjMRFUPvvsM2VlZc10GQAAIApdXV1atGhRVOfGRFCZO3eupPNfNC0tbYarAQAAExEMBpWVlRX6HY9GTASV0eWetLQ0ggoAADHmci7b4GJaAABgWwQVAABgWwQVAABgWwQVAABgWwQVAABgWwQVAABgWwQVAABgWwQVAABgWzGx4Rtg1fCI0dGOs+rpH9CCuS4V5cxTchLPiQKAWENQQdw5dNKv2oPt8gcGQm0et0s1a/K0Kt8zg5UBAKxi6Qdx5dBJvzbuPR4WUiSpOzCgjXuP69BJ/wxVBgCIBkEFcWN4xKj2YLvMGH8bbas92K7hkbF6AADsiKCCuHG042zETMqFjCR/YEBHO85OX1EAgMtCUEHc6OkfP6RE0w8AMPMIKogbC+a6JrUfAGDmEVQQN4py5snjdmm8m5AdOn/3T1HOvOksCwBwGQgqiBvJSQ7VrMmTpIiwMvq6Zk0e+6kAQAwhqCCurMr3qOH+AmW6w5d3Mt0uNdxfwD4qABBj2PANcWdVvkd35mWyMy0AxAGCCuJScpJDJYvnz3QZAIDLxNIPAACwLYIKAACwLYIKAACwLYIKAACwLYIKAACwLYIKAACwLYIKAACwLYIKAACwLYIKAACwLYIKAACwraiCSn19vXJycuRyueT1etXc3HzJ/vv27dPy5ct1xRVXyOPx6KGHHlJfX19UBQMAgMRhOag0NjaqqqpKW7duVVtbm1auXKnVq1ers7NzzP5HjhzRunXrtH79ev3yl7/U66+/rn//93/Xhg0bLrt4AAAQ3ywHle3bt2v9+vXasGGDcnNztWPHDmVlZamhoWHM/v/6r/+qa6+9Vps2bVJOTo5+93d/Vw8//LCOHTt22cUDAID4ZimoDA0NqbW1VWVlZWHtZWVlamlpGfOc0tJSnT59Wk1NTTLG6PPPP9cbb7yhu+++e9zPGRwcVDAYDDsAAEDisRRUent7NTw8rIyMjLD2jIwMdXd3j3lOaWmp9u3bp/LycqWmpiozM1NXXnmlfvSjH437OXV1dXK73aEjKyvLSpkAACBORHUxrcPhCHttjIloG9Xe3q5Nmzbp6aefVmtrqw4dOqSOjg5VVlaO+/7V1dUKBAKho6urK5oyAQDAJQyPGH3wSZ/++cQZffBJn4ZHzEyXFCHFSuf09HQlJydHzJ709PREzLKMqqur04oVK/TUU09Jkm688UbNmTNHK1eu1LPPPiuPxxNxjtPplNPptFIaAACw4NBJv2oPtssfGAi1edwu1azJ06r8yN/mmWJpRiU1NVVer1c+ny+s3efzqbS0dMxzvvzySyUlhX9McnKypPMzMQAAYHodOunXxr3Hw0KKJHUHBrRx73EdOumfocoiWV762bx5s15++WXt3r1bH374oZ544gl1dnaGlnKqq6u1bt26UP81a9bozTffVENDg06dOqX3339fmzZtUlFRkRYuXDh53wQAAHyt4RGj2oPtGmuqYLSt9mC7bZaBLC39SFJ5ebn6+vq0bds2+f1+5efnq6mpSdnZ2ZIkv98ftqfKgw8+qP7+fv3DP/yD/vIv/1JXXnmlbrvtNn3ve9+bvG8BAAAm5GjH2YiZlAsZSf7AgI52nFXJ4vnTV9g4HCYG1l+CwaDcbrcCgYDS0tJmuhwAAGLWP584o8f/6cTX9nvu3pv0rZuuvqzPmozfb571AwBAAlkw1zWp/aYaQQUAgARSlDNPHrdLY28qIjl0/u6fopx501nWuAgqAAAkkOQkh2rW5ElSRFgZfV2zJk/JSeNFmelFUAEAIMGsyveo4f4CZbrDl3cy3S413F9gq31ULN/1AwAAYt+qfI/uzMvU0Y6z6ukf0IK555d77DKTMoqgAgBAgkpOctjiFuRLYekHAADYFkEFAADYFkEFAADYFkEFAADYFkEFAADYFkEFAADYFkEFAADYFkEFAADYFkEFAADYFkEFAADYFkEFAADYFkEFAADYFkEFAADYFkEFAADYFkEFAADYVspMFwAA0RgeMTracVY9/QNaMNelopx5Sk5yzHRZACYZQQVAzDl00q/ag+3yBwZCbR63SzVr8rQq3zODlQGYbCz9AIgph076tXHv8bCQIkndgQFt3Htch076Z6gyAFOBoAIgZgyPGNUebJcZ42+jbbUH2zU8MlYPALGIoAIgZhztOBsxk3IhI8kfGNDRjrPTVxSAKUVQARAzevrHDynR9ANgfwQVADFjwVzXpPYDYH8EFQAxoyhnnjxul8a7Cdmh83f/FOXMm86yAEwhggqAmJGc5FDNmjxJiggro69r1uSxnwoQR6IKKvX19crJyZHL5ZLX61Vzc/O4fR988EE5HI6IY9myZVEXDSBxrcr3qOH+AmW6w5d3Mt0uNdxfwD4qQJxxGGMs3cfX2NioiooK1dfXa8WKFXrppZf08ssvq729Xddcc01E/0AgoK+++ir0+ty5c1q+fLkee+wxPfPMMxP6zGAwKLfbrUAgoLS0NCvlAohT7EwL2N9k/H5bDirFxcUqKChQQ0NDqC03N1dr165VXV3d157/9ttv69vf/rY6OjqUnZ09oc8kqAAAEHsm4/fb0tLP0NCQWltbVVZWFtZeVlamlpaWCb3Hrl27dMcdd1wypAwODioYDIYdAAAg8VgKKr29vRoeHlZGRkZYe0ZGhrq7u7/2fL/fr5/85CfasGHDJfvV1dXJ7XaHjqysLCtlAgCAOBHVxbQOR/g6sDEmom0sr776qq688kqtXbv2kv2qq6sVCARCR1dXVzRlAgCAGGfp6cnp6elKTk6OmD3p6emJmGW5mDFGu3fvVkVFhVJTUy/Z1+l0yul0WikNAADEIUszKqmpqfJ6vfL5fGHtPp9PpaWllzz38OHD+u///m+tX7/eepUAACAhWZpRkaTNmzeroqJChYWFKikp0c6dO9XZ2anKykpJ55dtzpw5oz179oSdt2vXLhUXFys/P39yKgcAAHHPclApLy9XX1+ftm3bJr/fr/z8fDU1NYXu4vH7/ers7Aw7JxAI6MCBA3ruuecmp2oAAJAQLO+jMhPYRwUAgNgz7fuoAAAATCeCCgAAsC2CCgAAsC2CCgAAsC2CCgAAsC2CCgAAsC2CCgAAsC2CCgAAsC2CCgAAsC2CCgAAsC2CCgAAsC2CCgAAsC2CCgAAsK2UmS5gpgyPGB3tOKue/gEtmOtSUc48JSc5ZrosAABwgYQMKodO+lV7sF3+wECozeN2qWZNnlble2awMgAAcKGEW/o5dNKvjXuPh4UUSeoODGjj3uM6dNI/Q5UBAICLJVRQGR4xqj3YLjPG30bbag+2a3hkrB4AAGC6JVRQOdpxNmIm5UJGkj8woKMdZ6evKAAAMK6ECio9/eOHlGj6AQCAqZVQQWXBXNek9gMAAFMroYJKUc48edwujXcTskPn7/4pypk3nWUBAIBxJFRQSU5yqGZNniRFhJXR1zVr8thPBQAAm0iooCJJq/I9ari/QJnu8OWdTLdLDfcXsI8KAAA2kpAbvq3K9+jOvEx2pgUAwOYSMqhI55eBShbPn+kyAADAJSTc0g8AAIgdBBUAAGBbBBUAAGBbBBUAAGBbBBUAAGBbUQWV+vp65eTkyOVyyev1qrm5+ZL9BwcHtXXrVmVnZ8vpdGrx4sXavXt3VAUDAIDEYfn25MbGRlVVVam+vl4rVqzQSy+9pNWrV6u9vV3XXHPNmOfcc889+vzzz7Vr1y799m//tnp6enTu3LnLLh4AAMQ3hzHGWDmhuLhYBQUFamhoCLXl5uZq7dq1qquri+h/6NAh3XvvvTp16pTmzYvuGTrBYFBut1uBQEBpaWlRvQcAAJhek/H7bWnpZ2hoSK2trSorKwtrLysrU0tLy5jnvPPOOyosLNT3v/99XX311br++uv15JNP6quvvhr3cwYHBxUMBsMOAACQeCwt/fT29mp4eFgZGRlh7RkZGeru7h7znFOnTunIkSNyuVx666231Nvbq+985zs6e/bsuNep1NXVqba21kppAAAgDkV1Ma3DEf5MHGNMRNuokZERORwO7du3T0VFRbrrrru0fft2vfrqq+POqlRXVysQCISOrq6uaMoEAAAxztKMSnp6upKTkyNmT3p6eiJmWUZ5PB5dffXVcrvdobbc3FwZY3T69GktWbIk4hyn0ymn02mlNAAAEIcszaikpqbK6/XK5/OFtft8PpWWlo55zooVK/TZZ5/piy++CLV99NFHSkpK0qJFi6IoGQAAJArLSz+bN2/Wyy+/rN27d+vDDz/UE088oc7OTlVWVko6v2yzbt26UP/77rtP8+fP10MPPaT29na99957euqpp/Rnf/Znmj179uR9EwAAEHcs76NSXl6uvr4+bdu2TX6/X/n5+WpqalJ2drYkye/3q7OzM9T/t37rt+Tz+fTYY4+psLBQ8+fP1z333KNnn3128r4FAACIS5b3UZkJ7KMCAEDsmfZ9VAAAAKYTQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANgWQQUAANhWVEGlvr5eOTk5crlc8nq9am5uHrfvz3/+czkcjojjP//zP6MuGgAAJAbLQaWxsVFVVVXaunWr2tratHLlSq1evVqdnZ2XPO+//uu/5Pf7Q8eSJUuiLhoAACQGy0Fl+/btWr9+vTZs2KDc3Fzt2LFDWVlZamhouOR5CxYsUGZmZuhITk6OumgAAJAYLAWVoaEhtba2qqysLKy9rKxMLS0tlzz35ptvlsfj0e23366f/exnl+w7ODioYDAYdgAAgMRjKaj09vZqeHhYGRkZYe0ZGRnq7u4e8xyPx6OdO3fqwIEDevPNN7V06VLdfvvteu+998b9nLq6Ornd7tCRlZVlpUwAABAnUqI5yeFwhL02xkS0jVq6dKmWLl0ael1SUqKuri794Ac/0O/93u+NeU51dbU2b94ceh0MBgkrAAAkIEszKunp6UpOTo6YPenp6YmYZbmUW265RR9//PG4f3c6nUpLSws7AABA4rEUVFJTU+X1euXz+cLafT6fSktLJ/w+bW1t8ng8Vj4aAAAkIMtLP5s3b1ZFRYUKCwtVUlKinTt3qrOzU5WVlZLOL9ucOXNGe/bskSTt2LFD1157rZYtW6ahoSHt3btXBw4c0IEDByb3mwAAgLhjOaiUl5err69P27Ztk9/vV35+vpqampSdnS1J8vv9YXuqDA0N6cknn9SZM2c0e/ZsLVu2TP/yL/+iu+66a/K+BQAAiEsOY4yZ6SK+TjAYlNvtViAQ4HoVAABixGT8fvOsHwAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFsEFQAAYFtRBZX6+nrl5OTI5XLJ6/Wqubl5Que9//77SklJ0U033RTNxwIAgARjOag0NjaqqqpKW7duVVtbm1auXKnVq1ers7PzkucFAgGtW7dOt99+e9TFAgCAxOIwxhgrJxQXF6ugoEANDQ2httzcXK1du1Z1dXXjnnfvvfdqyZIlSk5O1ttvv60TJ05M+DODwaDcbrcCgYDS0tKslAsAAGbIZPx+W5pRGRoaUmtrq8rKysLay8rK1NLSMu55r7zyij755BPV1NRM6HMGBwcVDAbDDgAAkHgsBZXe3l4NDw8rIyMjrD0jI0Pd3d1jnvPxxx9ry5Yt2rdvn1JSUib0OXV1dXK73aEjKyvLSpkAACBORHUxrcPhCHttjIlok6Th4WHdd999qq2t1fXXXz/h96+urlYgEAgdXV1d0ZQJAABi3MSmOP5Penq6kpOTI2ZPenp6ImZZJKm/v1/Hjh1TW1ubHn30UUnSyMiIjDFKSUnRu+++q9tuuy3iPKfTKafTaaU0AAAQhyzNqKSmpsrr9crn84W1+3w+lZaWRvRPS0vTL37xC504cSJ0VFZWaunSpTpx4oSKi4svr3oAABDXLM2oSNLmzZtVUVGhwsJClZSUaOfOners7FRlZaWk88s2Z86c0Z49e5SUlKT8/Pyw8xcsWCCXyxXRDgAAcDHLQaW8vFx9fX3atm2b/H6/8vPz1dTUpOzsbEmS3+//2j1VAAAAJsLyPiozgX1UAACIPdO+jwoAAMB0IqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbIqgAAADbiiqo1NfXKycnRy6XS16vV83NzeP2PXLkiFasWKH58+dr9uzZuuGGG/T3f//3URcMAAASR4rVExobG1VVVaX6+nqtWLFCL730klavXq329nZdc801Ef3nzJmjRx99VDfeeKPmzJmjI0eO6OGHH9acOXP0F3/xF5PyJQAAQHxyGGOMlROKi4tVUFCghoaGUFtubq7Wrl2rurq6Cb3Ht7/9bc2ZM0f/+I//OKH+wWBQbrdbgUBAaWlpVsoFAAAzZDJ+vy0t/QwNDam1tVVlZWVh7WVlZWppaZnQe7S1tamlpUW33nrruH0GBwcVDAbDDgAAkHgsBZXe3l4NDw8rIyMjrD0jI0Pd3d2XPHfRokVyOp0qLCzUI488og0bNozbt66uTm63O3RkZWVZKRMAAMSJqC6mdTgcYa+NMRFtF2tubtaxY8f04osvaseOHdq/f/+4faurqxUIBEJHV1dXNGUCAIAYZ+li2vT0dCUnJ0fMnvT09ETMslwsJydHkvQ7v/M7+vzzz/XMM8/oT/7kT8bs63Q65XQ6rZQGAADikKUZldTUVHm9Xvl8vrB2n8+n0tLSCb+PMUaDg4NWPhoAACQgy7cnb968WRUVFSosLFRJSYl27typzs5OVVZWSjq/bHPmzBnt2bNHkvTCCy/ommuu0Q033CDp/L4qP/jBD/TYY49N4tcAAADxyHJQKS8vV19fn7Zt2ya/36/8/Hw1NTUpOztbkuT3+9XZ2RnqPzIyourqanV0dCglJUWLFy/W3/7t3+rhhx+evG8BAADikuV9VGYC+6gAABB7pn0fFQAAgOlEUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALZFUAEAALaVMtMFwN6GR4yOdpxVT/+AFsx1qShnnpKTHDNdFgAgQRBUMK5DJ/2qPdguf2Ag1OZxu1SzJk+r8j0zWBkAIFGw9IMxHTrp18a9x8NCiiR1Bwa0ce9xHTrpn6HKAACJhKCCCMMjRrUH22XG+NtoW+3Bdg2PjNUDAIDJQ1BBhKMdZyNmUi5kJPkDAzracXb6igIAJCSCCiL09I8fUqLpBwBAtAgqiLBgrmtS+wEAEC2CCiIU5cyTx+3SeDchO3T+7p+inHnTWRYAIAFFFVTq6+uVk5Mjl8slr9er5ubmcfu++eabuvPOO3XVVVcpLS1NJSUl+ulPfxp1wZh6yUkO1azJk6SIsDL6umZNHvupAACmnOWg0tjYqKqqKm3dulVtbW1auXKlVq9erc7OzjH7v/fee7rzzjvV1NSk1tZW/cEf/IHWrFmjtra2yy4eU2dVvkcN9xco0x2+vJPpdqnh/gL2UQEATAuHMcbSPabFxcUqKChQQ0NDqC03N1dr165VXV3dhN5j2bJlKi8v19NPPz2h/sFgUG63W4FAQGlpaVbKxWViZ1oAQLQm4/fb0s60Q0NDam1t1ZYtW8Lay8rK1NLSMqH3GBkZUX9/v+bNG//6hsHBQQ0ODoZeB4NBK2ViEiUnOVSyeP5MlwEASFCWln56e3s1PDysjIyMsPaMjAx1d3dP6D1++MMf6te//rXuueeecfvU1dXJ7XaHjqysLCtlAgCAOBHVxbQOR/jUvzEmom0s+/fv1zPPPKPGxkYtWLBg3H7V1dUKBAKho6urK5oyAQBAjLO09JOenq7k5OSI2ZOenp6IWZaLNTY2av369Xr99dd1xx13XLKv0+mU0+m0UhoAAIhDlmZUUlNT5fV65fP5wtp9Pp9KS0vHPW///v168MEH9dprr+nuu++OrlIAAJBwLM2oSNLmzZtVUVGhwsJClZSUaOfOners7FRlZaWk88s2Z86c0Z49eySdDynr1q3Tc889p1tuuSU0GzN79my53e5J/CoAACDeWA4q5eXl6uvr07Zt2+T3+5Wfn6+mpiZlZ2dLkvx+f9ieKi+99JLOnTunRx55RI888kio/YEHHtCrr756+d8AAADELcv7qMwE9lEBACD2TMbvN8/6AQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtkVQAQAAtpUy0wUAAGAnwyNGRzvOqqd/QAvmulSUM0/JSY6ZLithEVQAAPg/h076VXuwXf7AQKjN43apZk2eVuV7ZrCyxMXSDwAAOh9SNu49HhZSJKk7MKCNe4/r0En/DFWW2AgqAICENzxiVHuwXWaMv4221R5s1/DIWD0wlQgqAICEd7TjbMRMyoWMJH9gQEc7zk5fUZBEUAEAQD3944eUaPph8hBUAAAJb8Fc16T2w+QhqAAAEl5Rzjx53C6NdxOyQ+fv/inKmTedZUEEFQAAlJzkUM2aPEmKCCujr2vW5LGfygwgqAAAIGlVvkcN9xco0x2+vJPpdqnh/gL2UZkhUQWV+vp65eTkyOVyyev1qrm5edy+fr9f9913n5YuXaqkpCRVVVVFWysAAFNqVb5HR757m/b/+S167t6btP/Pb9GR795GSJlBloNKY2OjqqqqtHXrVrW1tWnlypVavXq1Ojs7x+w/ODioq666Slu3btXy5csvu2AAAKZScpJDJYvn61s3Xa2SxfNZ7plhDmOMpd1riouLVVBQoIaGhlBbbm6u1q5dq7q6ukue+/u///u66aabtGPHDktFBoNBud1uBQIBpaWlWToXAADMjMn4/bY0ozI0NKTW1laVlZWFtZeVlamlpSWqAsYyODioYDAYdgAAgMRjKaj09vZqeHhYGRkZYe0ZGRnq7u6etKLq6urkdrtDR1ZW1qS9NwAAiB1RXUzrcISv1xljItouR3V1tQKBQOjo6uqatPcGAACxI8VK5/T0dCUnJ0fMnvT09ETMslwOp9Mpp9M5ae8HAABik6UZldTUVHm9Xvl8vrB2n8+n0tLSSS0MAADA0oyKJG3evFkVFRUqLCxUSUmJdu7cqc7OTlVWVko6v2xz5swZ7dmzJ3TOiRMnJElffPGF/vd//1cnTpxQamqq8vLyJudbAACAuGQ5qJSXl6uvr0/btm2T3+9Xfn6+mpqalJ2dLen8Bm8X76ly8803h/67tbVVr732mrKzs/Xpp59eXvVIWMMjRkc7zqqnf0AL5p5//gZ7HQBA/LG8j8pMYB8VXOjQSb9qD7bLH/j/j1v3uF2qWZPH7pEAYCPTvo8KMNMOnfRr497jYSFFkroDA9q497gOnfTPUGUAgKlAUEHMGB4xqj3YrrGmAEfbag+2a3jE9pOEAIAJIqggZhztOBsxk3IhI8kfGNDRjrPTVxQAYEoRVBAzevrHDynR9AMA2B9BBTFjwVzXpPYDANgfQQUxoyhnnjxul8a7Cdmh83f/FOXMm86yAABTiKCCmJGc5FDNmvObBF4cVkZf16zJYz8VAIgjBBXElFX5HjXcX6BMd/jyTqbbpYb7C9hHBQDijOWdaYGZtirfozvzMtmZFgASAEEFMSk5yaGSxfNnugwAwBRj6QcAANgWMyoI4UF/AAC7IahAEg/6AwDYE0s/4EF/AADbIqiMY3jE6INP+vTPJ87og0/64vZBdzzoDwBgZyz9jCGRlkGsPOiPu2wAANONGZWLJNoyCA/6A+JfoswQIz4xo3KBr1sGcej8MsideZlxczcMD/oD4lsizRAjPjGjcgEryyDxggf9AfEr0WaIEZ8IKhdIxGUQHvQHxCculEe8IKhcIFGXQXjQHxB/EnGGGPGJa1QuMLoM0h0YGPNfIQ6d//GOx2UQHvQHxJdEnCFGfCKoXGB0GWTj3uNySGFhJRGWQXjQHxA/EnWGGPGHpZ+LsAwCIB5woTziBTMqY2AZBECsS/QZYsQPhzHG9pd8B4NBud1uBQIBpaWlzXQ5ABAz2EcFM2kyfr+ZUQGAOMYMMWIdQQUA4hwXyiOWcTEtAACwLYIKAACwraiCSn19vXJycuRyueT1etXc3HzJ/ocPH5bX65XL5dJ1112nF198MapiAQBAYrEcVBobG1VVVaWtW7eqra1NK1eu1OrVq9XZ2Tlm/46ODt11111auXKl2tra9Nd//dfatGmTDhw4cNnFAwCA+Gb59uTi4mIVFBSooaEh1Jabm6u1a9eqrq4uov93v/tdvfPOO/rwww9DbZWVlfqP//gPffDBBxP6TG5PBgAg9kzG77elGZWhoSG1traqrKwsrL2srEwtLS1jnvPBBx9E9P/GN76hY8eO6Te/+Y3FcgEAQCKxdHtyb2+vhoeHlZGREdaekZGh7u7uMc/p7u4es/+5c+fU29srjydyw6HBwUENDg6GXgeDQStlAgCAOBHVxbQOR/hGQcaYiLav6z9W+6i6ujq53e7QkZWVFU2ZAAAgxlkKKunp6UpOTo6YPenp6YmYNRmVmZk5Zv+UlBTNnz/2BkTV1dUKBAKho6ury0qZAAAgTlha+klNTZXX65XP59Mf/uEfhtp9Pp++9a1vjXlOSUmJDh48GNb27rvvqrCwULNmzRrzHKfTKafTGXo9OgPDEhAAALFj9Hf7sh4raCz6p3/6JzNr1iyza9cu097ebqqqqsycOXPMp59+aowxZsuWLaaioiLU/9SpU+aKK64wTzzxhGlvbze7du0ys2bNMm+88caEP7Orq8vo/MM/OTg4ODg4OGLs6Orqsho3Qiw/66e8vFx9fX3atm2b/H6/8vPz1dTUpOzsbEmS3+8P21MlJydHTU1NeuKJJ/TCCy9o4cKFev755/VHf/RHE/7MhQsXqqurS3Pnzr3ktTCxKBgMKisrS11dXdx6HSMYs9jDmMUexiz2jDVmxhj19/dr4cKFUb+v5X1UMLnYIyb2MGaxhzGLPYxZ7JmqMeNZPwAAwLYIKgAAwLYIKjPM6XSqpqYm7C4n2BtjFnsYs9jDmMWeqRozrlEBAAC2xYwKAACwLYIKAACwLYIKAACwLYIKAACwLYLKNKivr1dOTo5cLpe8Xq+am5vH7fvmm2/qzjvv1FVXXaW0tDSVlJTopz/96TRWC8namF3o/fffV0pKim666aapLRARrI7Z4OCgtm7dquzsbDmdTi1evFi7d++epmohWR+zffv2afny5briiivk8Xj00EMPqa+vb5qqxXvvvac1a9Zo4cKFcjgcevvtt7/2nMOHD8vr9crlcum6667Tiy++aP2Do958HxMy+mykH//4x6a9vd08/vjjZs6cOeZ//ud/xuz/+OOPm+9973vm6NGj5qOPPjLV1dVm1qxZ5vjx49NceeKyOmajfvWrX5nrrrvOlJWVmeXLl09PsTDGRDdm3/zmN01xcbHx+Xymo6PD/Nu//Zt5//33p7HqxGZ1zJqbm01SUpJ57rnnzKlTp0xzc7NZtmyZWbt27TRXnriamprM1q1bzYEDB4wk89Zbb12y/+iz/h5//HHT3t5ufvzjH1t+1p8xxhBUplhRUZGprKwMa7vhhhvMli1bJvweeXl5pra2drJLwziiHbPy8nLzN3/zN6ampoagMs2sjtlPfvIT43a7TV9f33SUhzFYHbO/+7u/M9ddd11Y2/PPP28WLVo0ZTVifBMJKn/1V39lbrjhhrC2hx9+2Nxyyy2WPoulnyk0NDSk1tZWlZWVhbWXlZWppaVlQu8xMjKi/v5+zZs3bypKxEWiHbNXXnlFn3zyiWpqaqa6RFwkmjF75513VFhYqO9///u6+uqrdf311+vJJ5/UV199NR0lJ7xoxqy0tFSnT59WU1OTjDH6/PPP9cYbb+juu++ejpIRhQ8++CBijL/xjW/o2LFj+s1vfjPh97H89GRMXG9vr4aHh5WRkRHWnpGRoe7u7gm9xw9/+EP9+te/1j333DMVJeIi0YzZxx9/rC1btqi5uVkpKfwvNd2iGbNTp07pyJEjcrlceuutt9Tb26vvfOc7Onv2LNepTINoxqy0tFT79u1TeXm5BgYGdO7cOX3zm9/Uj370o+koGVHo7u4ec4zPnTun3t5eeTyeCb0PMyrTwOFwhL02xkS0jWX//v165pln1NjYqAULFkxVeRjDRMdseHhY9913n2pra3X99ddPV3kYg5X/z0ZGRuRwOLRv3z4VFRXprrvu0vbt2/Xqq68yqzKNrIxZe3u7Nm3apKefflqtra06dOiQOjo6VFlZOR2lIkpjjfFY7ZfCP/+mUHp6upKTkyP+hdDT0xORMi/W2Nio9evX6/XXX9cdd9wxlWXiAlbHrL+/X8eOHVNbW5seffRRSed/BI0xSklJ0bvvvqvbbrttWmpPVNH8f+bxeHT11VfL7XaH2nJzc2WM0enTp7VkyZIprTnRRTNmdXV1WrFihZ566ilJ0o033qg5c+Zo5cqVevbZZyf8r3NMn8zMzDHHOCUlRfPnz5/w+zCjMoVSU1Pl9Xrl8/nC2n0+n0pLS8c9b//+/XrwwQf12muvsf46zayOWVpamn7xi1/oxIkToaOyslJLly7ViRMnVFxcPF2lJ6xo/j9bsWKFPvvsM33xxRehto8++khJSUlatGjRlNaL6Mbsyy+/VFJS+E9WcnKypP//r3TYS0lJScQYv/vuuyosLNSsWbMm/kaWLr2FZaO34O3atcu0t7ebqqoqM2fOHPPpp58aY4zZsmWLqaioCPV/7bXXTEpKinnhhReM3+8PHb/61a9m6iskHKtjdjHu+pl+Vsesv7/fLFq0yPzxH/+x+eUvf2kOHz5slixZYjZs2DBTXyHhWB2zV155xaSkpJj6+nrzySefmCNHjpjCwkJTVFQ0U18h4fT395u2tjbT1tZmJJnt27ebtra20C3lF4/Z6O3JTzzxhGlvbze7du3i9mS7euGFF0x2drZJTU01BQUF5vDhw6G/PfDAA+bWW28Nvb711luNpIjjgQcemP7CE5iVMbsYQWVmWB2zDz/80Nxxxx1m9uzZZtGiRWbz5s3myy+/nOaqE5vVMXv++edNXl6emT17tvF4POZP//RPzenTp6e56sT1s5/97JK/T2ON2c9//nNz8803m9TUVHPttdeahoYGy5/rMIY5MwAAYE9cowIAAGyLoAIAAGyLoAIAAGyLoAIAAGyLoAIAAGyLoAIAAGyLoAIAAGyLoAIAAGyLoAIAAGyLoAIAAGyLoAIAAGyLoAIAAGzr/wFy8VSvF76pGgAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 640x480 with 1 Axes>"
       ]
@@ -1581,7 +1581,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x112cccd50>"
+       "<graphviz.graphs.Digraph at 0x12ad3d550>"
       ]
      },
      "execution_count": 41,
@@ -1618,7 +1618,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "378652557fef4e3e945db1f49236d114",
+       "model_id": "e8ae157d636644b183f97332649d5076",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1637,7 +1637,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "09d110c4b0224a4586f39121ab594118",
+       "model_id": "e564a4c3ac734deab79b0f1fb25e5893",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1651,7 +1651,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.PathCollection at 0x13d6feed0>"
+       "<matplotlib.collections.PathCollection at 0x139a15d90>"
       ]
      },
      "execution_count": 42,
@@ -1911,7 +1911,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x1397c4b90>"
+       "<graphviz.graphs.Digraph at 0x1365a7ad0>"
       ]
      },
      "execution_count": 43,
@@ -3100,7 +3100,7 @@
        "</svg>\n"
       ],
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x13915bdd0>"
+       "<graphviz.graphs.Digraph at 0x1391bbf10>"
       ]
      },
      "execution_count": 49,
@@ -3128,7 +3128,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a11221f6a85c4ebd8e05052f719e0236",
+       "model_id": "2e9cbb2070c345a1add65ee3cc6ab714",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3149,7 +3149,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "82e56419b1594fecbf9c19a2745709c6",
+       "model_id": "89cb51049ead4bd8a6b3acccdca821ab",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3197,7 +3197,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1000698e2eb147f28c59cd4e2382348c",
+       "model_id": "485138d8b7d5459fbd7da596eb120f91",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3218,7 +3218,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c6f6b36355da488d801dfeb7b25b8260",
+       "model_id": "e0c24f219db0451091dabaa3b7d3bd2a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3316,7 +3316,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b160a5c60936418988d5cc94c3e63640",
+       "model_id": "c2945dbf0d7c497494b4680c1d6d955b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3337,7 +3337,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e72528ca94c84f0f815a3a428bd1395b",
+       "model_id": "1711894637154100a71d43404d42a464",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3386,7 +3386,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "87f030b7c77f495ca364f1123d2cd1c7",
+       "model_id": "843ec24931b9442b99bf6755c70203c4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3407,7 +3407,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9f8f038b79a4437aa12965f2b9364e3f",
+       "model_id": "6d3d0e83271f4ec78445d2a8c0a545ab",
        "version_major": 2,
        "version_minor": 0
       },
@@ -3473,7 +3473,7 @@
      "output_type": "stream",
      "text": [
       "None 1\n",
-      "<Future at 0x139db2590 state=pending> NOT_DATA\n"
+      "<Future at 0x1395ede90 state=pending> NOT_DATA\n"
      ]
     }
    ],
@@ -3555,7 +3555,7 @@
      "output_type": "stream",
      "text": [
       "None 1\n",
-      "<Future at 0x139e76dd0 state=running> NOT_DATA\n",
+      "<Future at 0x139a56110 state=running> NOT_DATA\n",
       "Finally 5\n",
       "b (Add) output single-value: 6\n"
      ]
@@ -3617,7 +3617,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "6.011244249995798\n"
+      "6.02082441499806\n"
      ]
     }
    ],
@@ -3649,7 +3649,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.496095469017746\n"
+      "2.4505110399986734\n"
      ]
     }
    ],
@@ -3715,7 +3715,7 @@
    "source": [
     "## Saving and loading\n",
     "\n",
-    "Graphs can be saved and loaded on request -- either by manually invoking the `.save()` method, or by setting the `save_after_run` attribute to `True` (on the object or at instantiation by kwarg). This creates a save file (currently using HDF5 as a format) in the parent-most node's working directory.\n",
+    "For python >= 3.11, graphs can be saved and loaded on request -- either by manually invoking the `.save()` method, or by setting the `save_after_run` attribute to `True` (on the object or at instantiation by kwarg). This creates a save file (currently using HDF5 as a format) in the parent-most node's working directory.\n",
     "\n",
     "Subsequently instantiating a node with the same name in the same place will attempt to reload the saved graph automatically. \n",
     "\n",
@@ -3741,33 +3741,33 @@
   {
    "cell_type": "code",
    "execution_count": 62,
-   "id": "ffd741a3-b086-4ed0-9a62-76143a3705b2",
+   "id": "c8196054-aff3-4d39-a872-b428d329dac9",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'out__user_input': 42}"
-      ]
-     },
-     "execution_count": 62,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "wf = Workflow(\"save_demo\")\n",
-    "wf.inp = wf.create.standard.UserInput(42)\n",
-    "wf.middle = 2 * wf.inp\n",
-    "wf.end = wf.middle - 42\n",
-    "wf.out = wf.create.standard.UserInput(wf.end, save_after_run=True)\n",
-    "wf()\n",
-    "# wf.save()  # Not needed, since `wf.out` saves after running"
+    "import sys"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 63,
+   "id": "ffd741a3-b086-4ed0-9a62-76143a3705b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if sys.version_info >= (3, 11):\n",
+    "    wf = Workflow(\"save_demo\")\n",
+    "    wf.inp = wf.create.standard.UserInput(42)\n",
+    "    wf.middle = 2 * wf.inp\n",
+    "    wf.end = wf.middle - 42\n",
+    "    wf.out = wf.create.standard.UserInput(wf.end, save_after_run=True)\n",
+    "    wf()\n",
+    "    # wf.save()  # Not needed, since `wf.out` saves after running"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
    "id": "3a22c622-f8c1-449b-a910-c52beb6a09c3",
    "metadata": {},
    "outputs": [
@@ -3775,24 +3775,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/node.py:370: UserWarning: A saved file was found for the node save_demo -- attempting to load it...(To delete the saved file instead, use `overwrite_save=True`)\n",
+      "/Users/huber/work/pyiron/pyiron_workflow/pyiron_workflow/node.py:372: UserWarning: A saved file was found for the node save_demo -- attempting to load it...(To delete the saved file instead, use `overwrite_save=True`)\n",
       "  warnings.warn(\n"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 63,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "reloaded = Workflow(\"save_demo\")\n",
-    "reloaded.out.value == wf.out.value"
+    "if sys.version_info >= (3, 11):\n",
+    "    reloaded = Workflow(\"save_demo\")\n",
+    "    reloaded.out.value == wf.out.value"
    ]
   },
   {
@@ -3807,12 +3798,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 65,
    "id": "0999d3e8-3a5a-451d-8667-a01dae7c1193",
    "metadata": {},
    "outputs": [],
    "source": [
-    "reloaded.storage.delete()"
+    "if sys.version_info >= (3, 11):\n",
+    "    reloaded.storage.delete()"
    ]
   },
   {
@@ -3838,7 +3830,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 66,
    "id": "0b373764-b389-4c24-8086-f3d33a4f7fd7",
    "metadata": {},
    "outputs": [
@@ -3852,7 +3844,7 @@
        " 17.230249999999995]"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3889,7 +3881,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 67,
    "id": "0dd04b4c-e3e7-4072-ad34-58f2c1e4f596",
    "metadata": {},
    "outputs": [
@@ -3948,7 +3940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 68,
    "id": "2dfb967b-41ac-4463-b606-3e315e617f2a",
    "metadata": {},
    "outputs": [
@@ -3972,7 +3964,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 69,
    "id": "2e87f858-b327-4f6b-9237-c8a557f29aeb",
    "metadata": {},
    "outputs": [
@@ -3980,12 +3972,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.325 > 0.2\n",
-      "0.481 > 0.2\n",
-      "0.635 > 0.2\n",
-      "0.286 > 0.2\n",
-      "0.153 <= 0.2\n",
-      "Finally 0.153\n"
+      "0.834 > 0.2\n",
+      "0.186 <= 0.2\n",
+      "Finally 0.186\n"
      ]
     }
    ],

--- a/pyiron_workflow/job.py
+++ b/pyiron_workflow/job.py
@@ -23,6 +23,7 @@ leveraged.
 from __future__ import annotations
 
 import os
+import sys
 
 from pyiron_base import TemplateJob, JOB_CLASS_DICT
 from pyiron_workflow.node import Node
@@ -87,6 +88,9 @@ class NodeJob(TemplateJob):
     )
 
     def __init__(self, project, job_name):
+        if sys.version_info < (3, 11):
+            raise NotImplementedError("Node jobs are only available in python 3.11+")
+
         super().__init__(project, job_name)
         self._python_only_job = True
         self._write_work_dir_warnings = False
@@ -209,6 +213,9 @@ def create_job_with_python_wrapper(project, node):
     """
         + _WARNINGS_STRING
     )
+    if sys.version_info < (3, 11):
+        raise NotImplementedError("Node jobs are only available in python 3.11+")
+
     job = project.wrap_python_function(_run_node)
     job.input["node"] = node
     return job

--- a/pyiron_workflow/job.py
+++ b/pyiron_workflow/job.py
@@ -31,6 +31,9 @@ from h5io._h5io import _import_class
 
 _WARNINGS_STRING = """    
     Warnings:
+        Node jobs rely on storing the node to file, which means these are also only 
+        available for python >= 3.11.
+        
         The job can be run with `run_mode="non_modal"`, but _only_ if all the nodes
         being run are defined in an importable file location -- i.e. copying and
         pasting the example above into a jupyter notebook works fine in modal mode, but

--- a/pyiron_workflow/job.py
+++ b/pyiron_workflow/job.py
@@ -140,9 +140,7 @@ class NodeJob(TemplateJob):
     def _load_node(self):
         here = os.getcwd()
         os.chdir(self.working_directory)
-        self._node = _import_class(
-            self.input._class_type
-        )(
+        self._node = _import_class(self.input._class_type)(
             label=self.input._label,
             storage_backend=self.input._storage_backend,
         )

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -152,7 +152,7 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
             context when you're done with them; we give a convenience method for this.
     - Nodes created from a registered package store their package identifier as a class
         attribute.
-    - [ALPHA FEATURE] Nodes can be saved to and loaded from file.
+    - [ALPHA FEATURE] Nodes can be saved to and loaded from file if python >= 3.11.
         - Saving is triggered manually, or by setting a flag to save after the nodes
             runs.
         - On instantiation, nodes will load automatically if they find saved content.

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -7,6 +7,7 @@ The workhorse class for the entire concept.
 
 from __future__ import annotations
 
+import sys
 import warnings
 from abc import ABC, abstractmethod
 from concurrent.futures import Executor as StdLibExecutor, Future
@@ -355,11 +356,11 @@ class Node(HasToDict, ABC, metaclass=AbstractHasPost):
         run_after_init: bool = False,
         **kwargs,
     ):
-        if overwrite_save:
+        if overwrite_save and sys.version_info >= (3, 11):
             self.storage.delete()
             do_load = False
         else:
-            do_load = self.storage.has_contents
+            do_load = sys.version_info >= (3, 11) and self.storage.has_contents
 
         if do_load and run_after_init:
             raise ValueError(

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -32,6 +32,8 @@ class StorageInterface:
     _H5IO_STORAGE_FILE_NAME = "h5io.h5"
 
     def __init__(self, node: Node):
+        if sys.version_info < (3, 11):
+            raise NotImplementedError("Storage is only available in python 3.11+")
         self.node = node
 
     def save(self, backend: Literal["h5io", "tinybase"]):

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -1,5 +1,6 @@
 import doctest
 import pkgutil
+import sys
 import unittest
 
 import pyiron_workflow
@@ -10,6 +11,8 @@ def load_tests(loader, tests, ignore):
         pyiron_workflow.__path__, pyiron_workflow.__name__ + '.'
     ):
         if "node_library" in name:
+            continue
+        if sys.version_info >= (3, 11) and "job" in name:
             continue
         tests.addTests(doctest.DocTestSuite(name))
     return tests

--- a/tests/unit/test_docs.py
+++ b/tests/unit/test_docs.py
@@ -12,7 +12,7 @@ def load_tests(loader, tests, ignore):
     ):
         if "node_library" in name:
             continue
-        if sys.version_info >= (3, 11) and "job" in name:
+        if sys.version_info < (3, 11) and "job" in name:
             continue
         tests.addTests(doctest.DocTestSuite(name))
     return tests

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import sys
 from time import sleep
 import unittest
 
@@ -33,6 +34,7 @@ class TestNodeJob(_WithAJob):
         job.node = node
         return job
 
+    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_modal(self):
         modal_wf = Workflow("modal_wf")
         modal_wf.sleep = Sleep(0)
@@ -63,6 +65,7 @@ class TestNodeJob(_WithAJob):
             msg="The loaded job should still have all the same values"
         )
 
+    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_nonmodal(self):
         nonmodal_node = Workflow("non_modal")
         nonmodal_node.out = Workflow.create.standard.UserInput(42)
@@ -94,6 +97,7 @@ class TestNodeJob(_WithAJob):
             msg="The loaded job should have the finished values"
         )
 
+    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_bad_workflow(self):
         has_wd_wf = Workflow("not_empty")
         try:
@@ -113,6 +117,7 @@ class TestWrapperFunction(_WithAJob):
     def make_a_job_from_node(self, node):
         return create_job_with_python_wrapper(self.pr, node)
 
+    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_modal(self):
         modal_wf = Workflow("modal_wf")
         modal_wf.sleep = Sleep(0)
@@ -143,6 +148,7 @@ class TestWrapperFunction(_WithAJob):
             msg="The loaded job should still have all the same values"
         )
 
+    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_node(self):
         node = Workflow.create.standard.UserInput(42)
         nj = self.make_a_job_from_node(node)
@@ -153,6 +159,7 @@ class TestWrapperFunction(_WithAJob):
             msg="A single node should run just as well as a workflow"
         )
 
+    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_nonmodal(self):
         nonmodal_node = Workflow("non_modal")
         nonmodal_node.out = Workflow.create.standard.UserInput(42)
@@ -184,6 +191,7 @@ class TestWrapperFunction(_WithAJob):
             msg="The loaded job should have the finished values"
         )
 
+    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_node(self):
         node = Workflow.create.standard.UserInput(42)
         nj = self.make_a_job_from_node(node)

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -35,6 +35,17 @@ class TestNodeJob(_WithAJob):
         return job
 
     @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
+    def test_node(self):
+        node = Workflow.create.standard.UserInput(42)
+        nj = self.make_a_job_from_node(node)
+        nj.run()
+        self.assertEqual(
+            42,
+            nj.node.outputs.user_input.value,
+            msg="A single node should run just as well as a workflow"
+        )
+
+    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_modal(self):
         modal_wf = Workflow("modal_wf")
         modal_wf.sleep = Sleep(0)
@@ -146,17 +157,6 @@ class TestWrapperFunction(_WithAJob):
             nj.output["result"].outputs.out__user_input.value,
             lj.output["result"].outputs.out__user_input.value,
             msg="The loaded job should still have all the same values"
-        )
-
-    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
-    def test_node(self):
-        node = Workflow.create.standard.UserInput(42)
-        nj = self.make_a_job_from_node(node)
-        nj.run()
-        self.assertEqual(
-            42,
-            nj.node.outputs.user_input,
-            msg="A single node should run just as well as a workflow"
         )
 
     @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -34,6 +34,16 @@ class TestNodeJob(_WithAJob):
         job.node = node
         return job
 
+    @unittest.skipIf(sys.version_info >= (3, 11), "Storage should only work in 3.11+")
+    def test_clean_failure(self):
+        with self.assertRaises(
+            NotImplementedError,
+            msg="Storage, and therefore node jobs, are only available in python 3.11+, "
+                "so we should fail hard and clean here"
+        ):
+            node = Workflow.create.standard.UserInput(42)
+            self.make_a_job_from_node(node)
+
     @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_node(self):
         node = Workflow.create.standard.UserInput(42)
@@ -127,6 +137,16 @@ class TestNodeJob(_WithAJob):
 class TestWrapperFunction(_WithAJob):
     def make_a_job_from_node(self, node):
         return create_job_with_python_wrapper(self.pr, node)
+
+    @unittest.skipIf(sys.version_info >= (3, 11), "Storage should only work in 3.11+")
+    def test_clean_failure(self):
+        with self.assertRaises(
+            NotImplementedError,
+            msg="Storage, and therefore node jobs, are only available in python 3.11+, "
+                "so we should fail hard and clean here"
+        ):
+            node = Workflow.create.standard.UserInput(42)
+            self.make_a_job_from_node(node)
 
     @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_modal(self):

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -1,3 +1,4 @@
+import sys
 from concurrent.futures import Future
 from functools import partialmethod
 
@@ -520,6 +521,7 @@ class TestMacro(unittest.TestCase):
         self.assertListEqual(override_io_maps.inputs.labels, ["my_lin"])
         self.assertDictEqual(override_io_maps(), {"the_input_list": [1, 2, 3, 4]})
 
+    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_storage_for_modified_macros(self):
         ensure_tests_in_python_path()
         Macro.register("static.demo_nodes", domain="demo")

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -1,5 +1,6 @@
 from concurrent.futures import Future
 import os
+import sys
 from typing import Literal, Optional
 import unittest
 
@@ -372,6 +373,7 @@ class TestNode(unittest.TestCase):
                 "above."
         )
 
+    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_storage(self):
         self.assertIs(
             self.n1.outputs.y.value,

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -439,6 +439,7 @@ class TestNode(unittest.TestCase):
                     msg="Destroying the save should allow immediate re-running"
                 )
 
+    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_save_after_run(self):
         for backend in ALLOWED_BACKENDS:
             with self.subTest(backend):

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -373,6 +373,15 @@ class TestNode(unittest.TestCase):
                 "above."
         )
 
+    @unittest.skipIf(sys.version_info >= (3, 11), "Storage should only work in 3.11+")
+    def test_storage_failure(self):
+        with self.assertRaises(
+            NotImplementedError,
+            msg="Storage is only available in python 3.11+, so we should fail hard and "
+                "clean here"
+        ):
+            self.n1.storage
+
     @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_storage(self):
         self.assertIs(

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -1,5 +1,5 @@
 from concurrent.futures import Future
-
+import sys
 from time import sleep
 import unittest
 
@@ -337,6 +337,7 @@ class TestWorkflow(unittest.TestCase):
         wf.m.two.pull(run_parent_trees_too=False)
         wf.executor_shutdown()
 
+    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_storage_values(self):
         for backend in ALLOWED_BACKENDS:
             with self.subTest(backend):
@@ -364,7 +365,8 @@ class TestWorkflow(unittest.TestCase):
                 finally:
                     # Clean up after ourselves
                     wf.storage.delete()
-                
+
+    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_storage_scopes(self):
         wf = Workflow("wf")
         wf.register("static.demo_nodes", "demo")


### PR DESCRIPTION
What happened is that I merged the `NodeJob` branch into its parent `storage` branch before making sure the `NodeJob` branch had pulled in its most-up-to-date parent. I didn't notice the incompatibility because the CI was broken due to missing dependencies. Obviously with broken CI I should have been more careful, but also this is sort of a chance I took when I chose to merge _anything_ to _anywhere else_ when the CI was not passing.