### PR TITLE
Allow return None

### DIFF
--- a/pyiron_workflow/function.py
+++ b/pyiron_workflow/function.py
@@ -398,7 +398,7 @@ class Function(Node):
         dot-accessible.
         """
         parsed_outputs = ParseOutput(self.node_function).output
-        return [] if parsed_outputs is None else parsed_outputs
+        return [None] if parsed_outputs is None else parsed_outputs
 
     @property
     def _input_args(self):


### PR DESCRIPTION
Currently the following function fails:

```python
@single_value_node()
def my_test(a=0):
    return None

test = my_test()
test
```

I'm actually not sure if we should make a distinction between returning `None` and not having `return` in the first place, but anyway the current error cannot be understood, so as long as we don't have a more explicit answer, I think we should allow any functions returning `None`.