### PR TITLE
Make DirectoryObject recognize various init variables

### DIFF
--- a/pyiron_workflow/snippets/files.py
+++ b/pyiron_workflow/snippets/files.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from pathlib import Path
 
 
@@ -36,8 +37,13 @@ def categorize_folder_items(folder_path):
 
 
 class DirectoryObject:
-    def __init__(self, directory):
-        self.path = Path(directory)
+    def __init__(self, directory: str | Path | DirectoryObject):
+        if isinstance(directory, str):
+            self.path = Path(directory)
+        elif isinstance(directory, Path):
+            self.path = directory
+        elif isinstance(directory, DirectoryObject):
+            self.path = directory.path
         self.create()
 
     def create(self):

--- a/tests/unit/snippets/test_files.py
+++ b/tests/unit/snippets/test_files.py
@@ -10,6 +10,12 @@ class TestFiles(unittest.TestCase):
     def tearDown(cls):
         cls.directory.delete()
 
+    def test_directory_instantiation(self):
+        directory = DirectoryObject(Path("test"))
+        self.assertEqual(directory.path, self.directory.path)
+        directory = DirectoryObject(self.directory)
+        self.assertEqual(directory.path, self.directory.path)
+
     def test_directory_exists(self):
         self.assertTrue(Path("test").exists() and Path("test").is_dir())
 


### PR DESCRIPTION
I think it's straightforward enough, but this PR is to make `DirectoryObject` recognise `str`, `Path` and `DirectoryObject` for the directory instantiation.

I guess this is the first one to be merged. Sorry for going back and forth all the time!