### PR TITLE
Explicitly depend on base

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - h5io =0.2.2
 - h5io_browser =0.0.9
 - matplotlib =3.8.2
-- pyiron_base =0.7.8,
+- pyiron_base =0.7.8
 - pyiron_contrib =0.1.15
 - pympipool =0.7.13
 - python-graphviz =0.20.1

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -9,6 +9,7 @@ dependencies:
 - h5io =0.2.2
 - h5io_browser =0.0.9
 - matplotlib =3.8.2
+- pyiron_base =0.7.8,
 - pyiron_contrib =0.1.15
 - pympipool =0.7.13
 - python-graphviz =0.20.1

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - h5io =0.2.2
 - h5io_browser =0.0.9
 - matplotlib =3.8.2
-- pyiron_base =0.7.8,
+- pyiron_base =0.7.8
 - pyiron_contrib =0.1.15
 - pympipool =0.7.13
 - python-graphviz =0.20.1

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -9,6 +9,7 @@ dependencies:
 - h5io =0.2.2
 - h5io_browser =0.0.9
 - matplotlib =3.8.2
+- pyiron_base =0.7.8,
 - pyiron_contrib =0.1.15
 - pympipool =0.7.13
 - python-graphviz =0.20.1

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - h5io =0.2.2
 - h5io_browser =0.0.9
 - matplotlib =3.8.2
-- pyiron_base =0.7.8,
+- pyiron_base =0.7.8
 - pyiron_contrib =0.1.15
 - pympipool =0.7.13
 - python-graphviz =0.20.1

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,6 +14,7 @@ dependencies:
 - h5io =0.2.2
 - h5io_browser =0.0.9
 - matplotlib =3.8.2
+- pyiron_base =0.7.8,
 - pyiron_contrib =0.1.15
 - pympipool =0.7.13
 - python-graphviz =0.20.1

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'h5io==0.2.2',
         'h5io_browser==0.0.9',
         'matplotlib==3.8.2',
+        'pyiron_base==0.7.8',
         'pyiron_contrib==0.1.15',
         'pympipool==0.7.13',
         'toposort==1.10',


### PR DESCRIPTION
We explicitly depend on it in the job module. We got away without this because the atomistics and contrib dependencies pull base in anyhow.