### PR TITLE
pyiron_base's wrapper doesn't use storage

### DIFF
--- a/pyiron_workflow/job.py
+++ b/pyiron_workflow/job.py
@@ -214,9 +214,6 @@ def create_job_with_python_wrapper(project, node):
     """
         + _WARNINGS_STRING
     )
-    if sys.version_info < (3, 11):
-        raise NotImplementedError("Node jobs are only available in python 3.11+")
-
     job = project.wrap_python_function(_run_node)
     job.input["node"] = node
     return job

--- a/pyiron_workflow/job.py
+++ b/pyiron_workflow/job.py
@@ -29,11 +29,8 @@ from pyiron_base import TemplateJob, JOB_CLASS_DICT
 from pyiron_workflow.node import Node
 from h5io._h5io import _import_class
 
-_WARNINGS_STRING = """    
-    Warnings:
-        Node jobs rely on storing the node to file, which means these are also only 
-        available for python >= 3.11.
-        
+_WARNINGS_STRING = """
+
         The job can be run with `run_mode="non_modal"`, but _only_ if all the nodes
         being run are defined in an importable file location -- i.e. copying and
         pasting the example above into a jupyter notebook works fine in modal mode, but
@@ -85,6 +82,12 @@ class NodeJob(TemplateJob):
 
         >>> pr.remove_jobs(recursive=True, silently=True)
         >>> pr.remove(enable=True)
+        
+    Warnings:
+        Node jobs rely on storing the node to file, which means these are also only 
+        available for python >= 3.11.
+        
+        
 
     """
         + _WARNINGS_STRING
@@ -210,7 +213,8 @@ def create_job_with_python_wrapper(project, node):
 
         >>> pr.remove_jobs(recursive=True, silently=True)
         >>> pr.remove(enable=True)
-        
+    
+    Warnings:
     """
         + _WARNINGS_STRING
     )

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -138,7 +138,6 @@ class TestWrapperFunction(_WithAJob):
     def make_a_job_from_node(self, node):
         return create_job_with_python_wrapper(self.pr, node)
 
-    @unittest.skipIf(sys.version_info >= (3, 11), "Storage should only work in 3.11+")
     def test_clean_failure(self):
         with self.assertRaises(
             NotImplementedError,
@@ -148,7 +147,6 @@ class TestWrapperFunction(_WithAJob):
             node = Workflow.create.standard.UserInput(42)
             self.make_a_job_from_node(node)
 
-    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_modal(self):
         modal_wf = Workflow("modal_wf")
         modal_wf.sleep = Sleep(0)
@@ -179,7 +177,6 @@ class TestWrapperFunction(_WithAJob):
             msg="The loaded job should still have all the same values"
         )
 
-    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_nonmodal(self):
         nonmodal_node = Workflow("non_modal")
         nonmodal_node.out = Workflow.create.standard.UserInput(42)
@@ -211,7 +208,6 @@ class TestWrapperFunction(_WithAJob):
             msg="The loaded job should have the finished values"
         )
 
-    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_node(self):
         node = Workflow.create.standard.UserInput(42)
         nj = self.make_a_job_from_node(node)

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -138,15 +138,6 @@ class TestWrapperFunction(_WithAJob):
     def make_a_job_from_node(self, node):
         return create_job_with_python_wrapper(self.pr, node)
 
-    def test_clean_failure(self):
-        with self.assertRaises(
-            NotImplementedError,
-            msg="Storage, and therefore node jobs, are only available in python 3.11+, "
-                "so we should fail hard and clean here"
-        ):
-            node = Workflow.create.standard.UserInput(42)
-            self.make_a_job_from_node(node)
-
     def test_modal(self):
         modal_wf = Workflow("modal_wf")
         modal_wf.sleep = Sleep(0)


### PR DESCRIPTION
It serializes the entire node to bytestream directly, so we should be able to run this job type on all supported python versions not just 3.11+.