### PR TITLE
Rename NodeJob to StoredNodeJob

### DIFF
--- a/pyiron_workflow/job.py
+++ b/pyiron_workflow/job.py
@@ -45,7 +45,7 @@ _WARNINGS_STRING = """
 """
 
 
-class NodeJob(TemplateJob):
+class StoredNodeJob(TemplateJob):
     __doc__ = (
         """
     This job is an intermediate feature for accessing pyiron's queue submission
@@ -72,7 +72,7 @@ class NodeJob(TemplateJob):
         >>> 
         >>> pr = Project("test")
         >>> 
-        >>> nj = pr.create.job.NodeJob("my_node")
+        >>> nj = pr.create.job.StoredNodeJob("my_node")
         >>> nj.node = wf
         >>> nj.run()  # doctest:+ELLIPSIS
         The job my_node was saved and received the ID: ...
@@ -165,7 +165,7 @@ class NodeJob(TemplateJob):
         self.status.finished = True
 
 
-JOB_CLASS_DICT[NodeJob.__name__] = NodeJob.__module__
+JOB_CLASS_DICT[StoredNodeJob.__name__] = StoredNodeJob.__module__
 
 
 def _run_node(node):

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -28,9 +28,9 @@ class _WithAJob(unittest.TestCase, ABC):
         self.pr.remove(enable=True)
 
 
-class TestNodeJob(_WithAJob):
+class TestStoredNodeJob(_WithAJob):
     def make_a_job_from_node(self, node):
-        job = self.pr.create.job.NodeJob(node.label)
+        job = self.pr.create.job.StoredNodeJob(node.label)
         job.node = node
         return job
 


### PR DESCRIPTION
To clear room for a simpler NodeJob that _doesn't_ lean on pyiron_workflow's storage implementation