### PR TITLE
Replace the wrapper job with a more robust job subclass

### DIFF
--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -601,7 +601,13 @@ class OutputData(DataChannel):
 
     def __getattr__(self, name):
         from pyiron_workflow.node_library.standard import GetAttr
-
+        if name == "to_hdf":
+            raise AttributeError(
+                "This is just a failsafe to protect us against other elements of the "
+                "pyiron ecosystem (pyiron_base's DataContainer) running a "
+                "`hasattr('to_hdf')` check on us and accidentally injecting a new "
+                "getattr node."
+            )
         return self._node_injection(GetAttr, name)
 
     def __getitem__(self, item):

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -6,7 +6,7 @@ import unittest
 from pyiron_base import Project
 from pyiron_workflow import Workflow
 from pyiron_workflow.channels import NOT_DATA
-from pyiron_workflow.job import create_job_with_python_wrapper
+import pyiron_workflow.job  # To get the job classes registered
 
 
 @Workflow.wrap_as.single_value_node("t")
@@ -244,92 +244,3 @@ class TestStoredNodeJob(_WithAJob):
                 self.make_a_job_from_node(has_wd_wf)
         finally:
             has_wd_wf.working_directory.delete()
-
-
-class TestWrapperFunction(_WithAJob):
-    def make_a_job_from_node(self, node):
-        return create_job_with_python_wrapper(self.pr, node)
-
-    @unittest.skipIf(sys.version_info >= (3, 11), "Storage should only work in 3.11+")
-    def test_clean_failure(self):
-        with self.assertRaises(
-            NotImplementedError,
-            msg="Storage, and therefore node jobs, are only available in python 3.11+, "
-                "so we should fail hard and clean here"
-        ):
-            node = Workflow.create.standard.UserInput(42)
-            self.make_a_job_from_node(node)
-
-    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
-    def test_modal(self):
-        modal_wf = Workflow("modal_wf")
-        modal_wf.sleep = Sleep(0)
-        modal_wf.out = modal_wf.create.standard.UserInput(modal_wf.sleep)
-        nj = self.make_a_job_from_node(modal_wf)
-
-        nj.run()
-        self.assertTrue(
-            nj.status.finished,
-            msg="The interpreter should not release until the job is done"
-        )
-        self.assertEqual(
-            0,
-            nj.output["result"].outputs.out__user_input.value,
-            msg="The node should have run, and since it's modal there's no need to "
-                "update the instance"
-        )
-
-        lj = self.pr.load(nj.job_name)
-        self.assertIsNot(
-            lj,
-            nj,
-            msg="The loaded job should be a new instance."
-        )
-        self.assertEqual(
-            nj.output["result"].outputs.out__user_input.value,
-            lj.output["result"].outputs.out__user_input.value,
-            msg="The loaded job should still have all the same values"
-        )
-
-    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
-    def test_nonmodal(self):
-        nonmodal_node = Workflow("non_modal")
-        nonmodal_node.out = Workflow.create.standard.UserInput(42)
-
-        nj = self.make_a_job_from_node(nonmodal_node)
-        nj.run(run_mode="non_modal")
-        self.assertFalse(
-            nj.status.finished,
-            msg=f"The local process should released immediately per non-modal "
-                f"style, but got status {nj.status}"
-        )
-        while not nj.status.finished:
-            sleep(0.1)
-        self.assertTrue(
-            nj.status.finished,
-            msg="The job status should update on completion"
-        )
-        with self.assertRaises(
-            KeyError,
-            msg="As usual with remote processes, we expect to require a data read "
-                "before the local instance reflects its new state."
-        ):
-            nj.output["result"]
-
-        lj = self.pr.load(nj.job_name)
-        self.assertEqual(
-            42,
-            lj.output["result"].outputs.out__user_input.value,
-            msg="The loaded job should have the finished values"
-        )
-
-    @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
-    def test_node(self):
-        node = Workflow.create.standard.UserInput(42)
-        nj = self.make_a_job_from_node(node)
-        with self.assertRaises(
-            AttributeError,
-            msg="The wrapping routine doesn't interact well with getattr overrides on "
-                "node state elements (output data)"
-        ):
-            nj.run()


### PR DESCRIPTION
Still, this leans directly on the storage provided by `pyiron_base.jobs.flex.PythonFunctionContainerJob`