### PR TITLE
Simpler name access

### DIFF
--- a/pyiron_workflow/job.py
+++ b/pyiron_workflow/job.py
@@ -126,6 +126,16 @@ class NodeOutputJob(PythonFunctionContainerJob):
 JOB_CLASS_DICT[NodeOutputJob.__name__] = NodeOutputJob.__module__
 
 
+class NodeJob(NodeOutputJob):
+    # Just to expose it under the simpler name per @JNmpi's request
+    # This is a temporary change ahead of the 2024 DPG conference,
+    # in the long run these job names are likely to take on different meanings
+    pass
+
+
+JOB_CLASS_DICT[NodeJob.__name__] = NodeJob.__module__
+
+
 class StoredNodeJob(TemplateJob):
     """
     This job is an intermediate feature for accessing pyiron's queue submission

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -28,7 +28,7 @@ class _WithAJob(unittest.TestCase, ABC):
         self.pr.remove(enable=True)
 
 
-class TestNodeNodeOutputJobJob(_WithAJob):
+class TestNodeOutputJob(_WithAJob):
     def make_a_job_from_node(self, node):
         job = self.pr.create.job.NodeOutputJob(node.label)
         job.input["node"] = node

--- a/tests/unit/test_job.py
+++ b/tests/unit/test_job.py
@@ -154,6 +154,11 @@ class TestNodeNodeOutputJobJob(_WithAJob):
         ):
             self.pr.load(nj.job_name)
 
+    def test_shorter_name(self):
+        j1 = self.pr.create.job.NodeOutputJob("foo")
+        j2 = self.pr.create.job.NodeOutputJob("bar")
+        self.assertIsInstance(j2, j1.__class__)
+
 
 class TestStoredNodeJob(_WithAJob):
     def make_a_job_from_node(self, node):


### PR DESCRIPTION
Expose the wrapper-based node job under `NodeJob` as well as `NodeOutputJob`, per Joerg's request ahead of the DPG.

The original name is still there, so this is completely backwards compatible.