### PR TITLE
[patch] Exploit the mangling flag

### DIFF
--- a/pyiron_workflow/job.py
+++ b/pyiron_workflow/job.py
@@ -80,6 +80,9 @@ class NodeOutputJob(PythonFunctionContainerJob):
             raise NotImplementedError("Node jobs are only available in python 3.11+")
         super().__init__(project, job_name)
         self._function = _node_out
+        self._mangle_name_on_save = False  # This class is expected to be accessed from
+        # the regular job creation, not via a wrapper function, so we can rely on users
+        # to provide a job name just like usual.
         self.input.update(get_function_parameter_dict(funct=_node_out))
         self._executor_type = None
 


### PR DESCRIPTION
This depends on [`pyiron_base` 1356](https://github.com/pyiron/pyiron_base/pull/1356), and turns off the automatic name mangling for `NodeJob`. There is certainly not a large corpus of workflow jobs depending on the old naming scheme, so this can be a patch.

@jan-janssen @srmnitc, I don't know what the timetable is for the DPG or whether base releases can get made sufficiently quickly to utilize this, but it is far and away preferable to #225, which is wrongly patching a problem in `_base` but only inside `_workflow`.