### PR TITLE
[patch] Rely on the base class to not mangle names by default

### DIFF
--- a/pyiron_workflow/job.py
+++ b/pyiron_workflow/job.py
@@ -80,9 +80,6 @@ class NodeOutputJob(PythonFunctionContainerJob):
             raise NotImplementedError("Node jobs are only available in python 3.11+")
         super().__init__(project, job_name)
         self._function = _node_out
-        self._mangle_name_on_save = False  # This class is expected to be accessed from
-        # the regular job creation, not via a wrapper function, so we can rely on users
-        # to provide a job name just like usual.
         self.input.update(get_function_parameter_dict(funct=_node_out))
         self._executor_type = None
 


### PR DESCRIPTION
This reverts #226 in the event that [`pyiron_base` 1358](https://github.com/pyiron/pyiron_base/pull/1358) gets merged and the whole process is handled upstream.