### PR TITLE
[patch] Use the branched version of pyiron/actions

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   codeql:
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@main
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@v1.1.0
     secrets: inherit
     with:
       tests-in-python-path: true

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/dependabot-pr.yml@main
+    uses: pyiron/actions/.github/workflows/dependabot-pr.yml@v1.1.0
     secrets: inherit

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-labeled.yml@main
+    uses: pyiron/actions/.github/workflows/pr-labeled.yml@v1.1.0
     secrets: inherit

--- a/.github/workflows/pr-target-opened.yml
+++ b/.github/workflows/pr-target-opened.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-target-opened.yml@main
+    uses: pyiron/actions/.github/workflows/pr-target-opened.yml@v1.1.0
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull-main.yml@main
+    uses: pyiron/actions/.github/workflows/push-pull-main.yml@v1.1.0
     secrets: inherit
     with:
       docs-env-files: .ci_support/environment.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/release.yml@main
+    uses: pyiron/actions/.github/workflows/release.yml@v1.1.0
     secrets: inherit

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   codeql:
-    uses: pyiron/actions/.github/workflows/codeql.yml@main
+    uses: pyiron/actions/.github/workflows/codeql.yml@v1.1.0
     secrets: inherit


### PR DESCRIPTION
Since pyiron actions internally references itself, it's not enough to point to a branch there, that branch needs to internally point to itself! That change was just made, so let's try pointing to such a self-referential branch here.

@pmrv also of interest to you.