### PR TITLE
Synchronized dependency bumps

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -7,9 +7,9 @@ dependencies:
 - cloudpickle =3.0.0
 - graphviz =8.1.0
 - h5io =0.2.2
-- h5io_browser =0.0.9
-- matplotlib =3.8.2
-- pyiron_base =0.7.8
+- h5io_browser =0.0.10
+- matplotlib =3.8.3
+- pyiron_base =0.7.10
 - pyiron_contrib =0.1.15
 - pympipool =0.7.13
 - python-graphviz =0.20.1
@@ -18,7 +18,7 @@ dependencies:
 - ase =3.22.1
 - atomistics =0.1.23
 - lammps
-- phonopy =2.21.0
-- pyiron_atomistics =0.4.15
-- pyiron-data =0.0.27
+- phonopy =2.21.2
+- pyiron_atomistics =0.4.17
+- pyiron-data =0.0.29
 - numpy =1.26.4

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - h5io =0.2.2
 - h5io_browser =0.0.10
 - matplotlib =3.8.3
-- pyiron_base =0.7.10
+- pyiron_base =0.7.9
 - pyiron_contrib =0.1.15
 - pympipool =0.7.13
 - python-graphviz =0.20.1

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - cloudpickle =3.0.0
 - graphviz =8.1.0
 - h5io =0.2.2
-- h5io_browser =0.0.10
+- h5io_browser =0.0.9
 - matplotlib =3.8.3
 - pyiron_base =0.7.9
 - pyiron_contrib =0.1.15

--- a/.ci_support/environment-notebooks.yml
+++ b/.ci_support/environment-notebooks.yml
@@ -5,6 +5,6 @@ dependencies:
   - atomistics =0.1.23
   - lammps
   - phonopy =2.21.0
-  - pyiron_atomistics =0.4.15
+  - pyiron_atomistics =0.4.17
   - pyiron-data =0.0.27
   - numpy =1.26.4

--- a/.ci_support/environment-notebooks.yml
+++ b/.ci_support/environment-notebooks.yml
@@ -6,5 +6,5 @@ dependencies:
   - lammps
   - phonopy =2.21.0
   - pyiron_atomistics =0.4.17
-  - pyiron-data =0.0.27
+  - pyiron-data =0.0.29
   - numpy =1.26.4

--- a/.ci_support/environment-notebooks.yml
+++ b/.ci_support/environment-notebooks.yml
@@ -4,7 +4,7 @@ dependencies:
   - ase =3.22.1
   - atomistics =0.1.23
   - lammps
-  - phonopy =2.21.0
+  - phonopy =2.21.2
   - pyiron_atomistics =0.4.17
   - pyiron-data =0.0.29
   - numpy =1.26.4

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - h5io =0.2.2
 - h5io_browser =0.0.10
 - matplotlib =3.8.3
-- pyiron_base =0.7.10
+- pyiron_base =0.7.9
 - pyiron_contrib =0.1.15
 - pympipool =0.7.13
 - python-graphviz =0.20.1

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - cloudpickle =3.0.0
 - graphviz =8.1.0
 - h5io =0.2.2
-- h5io_browser =0.0.9
+- h5io_browser =0.0.10
 - matplotlib =3.8.2
 - pyiron_base =0.7.10
 - pyiron_contrib =0.1.15

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -9,7 +9,7 @@ dependencies:
 - h5io =0.2.2
 - h5io_browser =0.0.9
 - matplotlib =3.8.2
-- pyiron_base =0.7.8
+- pyiron_base =0.7.10
 - pyiron_contrib =0.1.15
 - pympipool =0.7.13
 - python-graphviz =0.20.1

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - cloudpickle =3.0.0
 - graphviz =8.1.0
 - h5io =0.2.2
-- h5io_browser =0.0.10
+- h5io_browser =0.0.9
 - matplotlib =3.8.3
 - pyiron_base =0.7.9
 - pyiron_contrib =0.1.15

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -8,7 +8,7 @@ dependencies:
 - graphviz =8.1.0
 - h5io =0.2.2
 - h5io_browser =0.0.10
-- matplotlib =3.8.2
+- matplotlib =3.8.3
 - pyiron_base =0.7.10
 - pyiron_contrib =0.1.15
 - pympipool =0.7.13

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - cloudpickle =3.0.0
 - graphviz =8.1.0
 - h5io =0.2.2
-- h5io_browser =0.0.10
+- h5io_browser =0.0.9
 - matplotlib =3.8.3
 - pyiron_base =0.7.9
 - pyiron_contrib =0.1.15

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - h5io =0.2.2
 - h5io_browser =0.0.10
 - matplotlib =3.8.3
-- pyiron_base =0.7.10
+- pyiron_base =0.7.9
 - pyiron_contrib =0.1.15
 - pympipool =0.7.13
 - python-graphviz =0.20.1

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,9 +12,9 @@ dependencies:
 - cloudpickle =3.0.0
 - graphviz =8.1.0
 - h5io =0.2.2
-- h5io_browser =0.0.9
-- matplotlib =3.8.2
-- pyiron_base =0.7.8
+- h5io_browser =0.0.10
+- matplotlib =3.8.3
+- pyiron_base =0.7.10
 - pyiron_contrib =0.1.15
 - pympipool =0.7.13
 - python-graphviz =0.20.1

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'h5io==0.2.2',
         'h5io_browser==0.0.10',
         'matplotlib==3.8.3',
-        'pyiron_base==0.7.10',
+        'pyiron_base==0.7.9',
         'pyiron_contrib==0.1.15',
         'pympipool==0.7.13',
         'toposort==1.10',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'h5io==0.2.2',
         'h5io_browser==0.0.9',
         'matplotlib==3.8.2',
-        'pyiron_base==0.7.8',
+        'pyiron_base==0.7.10',
         'pyiron_contrib==0.1.15',
         'pympipool==0.7.13',
         'toposort==1.10',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'graphviz==0.20.1',
         'h5io==0.2.2',
         'h5io_browser==0.0.10',
-        'matplotlib==3.8.2',
+        'matplotlib==3.8.3',
         'pyiron_base==0.7.10',
         'pyiron_contrib==0.1.15',
         'pympipool==0.7.13',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'cloudpickle==3.0.0',
         'graphviz==0.20.1',
         'h5io==0.2.2',
-        'h5io_browser==0.0.10',
+        'h5io_browser==0.0.9',
         'matplotlib==3.8.3',
         'pyiron_base==0.7.9',
         'pyiron_contrib==0.1.15',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'cloudpickle==3.0.0',
         'graphviz==0.20.1',
         'h5io==0.2.2',
-        'h5io_browser==0.0.9',
+        'h5io_browser==0.0.10',
         'matplotlib==3.8.2',
         'pyiron_base==0.7.10',
         'pyiron_contrib==0.1.15',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
             'ase==3.22.1',
             'atomistics==0.1.23',
             'numpy==1.26.4',
-            'phonopy==2.21.0',
+            'phonopy==2.21.2',
             'pyiron_atomistics==0.4.17',
         ],
     },


### PR DESCRIPTION
So I don't need to think about who's dependency is whose or what is upper-limit locked, and since my bots are not updating the notebook env yaml anyway. Avoids running the whole CI suite N times.