### PR TITLE
Add error message for return item without `channel`

### DIFF
--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -412,9 +412,8 @@ class Macro(Composite):
             "outputs",
         )
 
-    @staticmethod
     def _whitelist_map(
-        io_map: bidict, new_labels: tuple[str], has_channel_objects: tuple[HasChannel]
+        self, io_map: bidict, new_labels: tuple[str], has_channel_objects: tuple[HasChannel]
     ) -> bidict:
         """
         Update an IO map to give new labels to the channels of a bunch of :class:`HasChannel`
@@ -422,6 +421,13 @@ class Macro(Composite):
         """
         io_map = bidict({}) if io_map is None else io_map
         for new_label, ui_node in zip(new_labels, has_channel_objects):
+            if not hasattr(ui_node, "channel"):
+                raise TypeError(
+                    f"Your node `{new_label}` does not have `channel`. There"
+                    + " are following nodes that can be returned:"
+                    + f" {self.node_labels}. More can be found from this page:"
+                    + " https://github.com/pyiron/pyiron_workflow"
+                )
             # White-list everything not already in the map
             if ui_node.channel.scoped_label not in io_map.keys():
                 io_map[ui_node.channel.scoped_label] = new_label

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -319,9 +319,7 @@ class Macro(Composite):
         if returned_has_channel_objects is not None:
             if not isinstance(returned_has_channel_objects, tuple):
                 returned_has_channel_objects = (returned_has_channel_objects,)
-            self._whitelist_outputs_map(
-                output_labels, *returned_has_channel_objects
-            )
+            self._whitelist_outputs_map(output_labels, *returned_has_channel_objects)
 
         self._inputs: Inputs = self._build_inputs()
         self._outputs: Outputs = self._build_outputs()

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -600,7 +600,10 @@ class TestMacro(unittest.TestCase):
                     macro.storage.delete()
 
     def test_wrong_return(self):
-        with self.assertRaises(TypeError):
+        with self.assertRaises(
+            TypeError,
+            msg="Macro returning object without channel did not raise an error"
+        ):
             Macro(wrong_return_macro)
 
 

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -27,6 +27,11 @@ def add_three_macro(macro):
     # although these are more thoroughly tested in Workflow tests
 
 
+def wrong_return_macro(macro):
+    macro.one = SingleValue(add_one)
+    return 3
+
+
 class TestMacro(unittest.TestCase):
 
     def test_static_input(self):
@@ -593,6 +598,10 @@ class TestMacro(unittest.TestCase):
                         raise ValueError(f"Unexpected backend {backend}?")
                 finally:
                     macro.storage.delete()
+
+    def test_wrong_return(self):
+        with self.assertRaises(TypeError):
+            Macro(wrong_return_macro)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I keep making a mistake like this:


```python
@single_value_node("sum")
def addition(a, b):
    return a + b

@single_value_node("product")
def multiplication(a, b):
    return a * b

@macro_node("result")
def add_and_multiply(macro):
    macro.addition = addition(1, 2)
    macro.multiplication = multiplication(macro.addition, 5)
    return macro.multiplication.outputs.product.value

node = add_and_multiply()
```

The main problem is that in the current implementation it only says `NOT_DATA` does not have `channel`, which doesn't immediately make me understand where the error is coming from.