### PR TITLE
[patch] State mixin

### DIFF
--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -13,7 +13,7 @@ from abc import ABC, abstractmethod
 import inspect
 from warnings import warn
 
-from pyiron_workflow.has_interface_mixins import HasChannel
+from pyiron_workflow.has_interface_mixins import HasChannel, UsesState
 from pyiron_workflow.has_to_dict import HasToDict
 from pyiron_workflow.snippets.singleton import Singleton
 from pyiron_workflow.type_hinting import (
@@ -29,7 +29,7 @@ class ChannelConnectionError(Exception):
     pass
 
 
-class Channel(HasChannel, HasToDict, ABC):
+class Channel(UsesState, HasChannel, HasToDict, ABC):
     """
     Channels facilitate the flow of information (data or control signals) into and
     out of nodes.
@@ -217,7 +217,7 @@ class Channel(HasChannel, HasToDict, ABC):
         }
 
     def __getstate__(self):
-        state = dict(self.__dict__)
+        state = super().__getstate__()
         # To avoid cyclic storage and avoid storing complex objects, purge some
         # properties from the state
         state["node"] = None
@@ -226,11 +226,6 @@ class Channel(HasChannel, HasToDict, ABC):
         # It is the responsibility of the owning node's parent to store and restore
         # connections (if any)
         return state
-
-    def __setstate__(self, state):
-        # Update instead of overriding in case some other attributes were added on the
-        # main process while a remote process was working away
-        self.__dict__.update(**state)
 
 
 class NotData(metaclass=Singleton):

--- a/pyiron_workflow/create.py
+++ b/pyiron_workflow/create.py
@@ -146,12 +146,6 @@ class Creator(metaclass=Singleton):
                 f"Could not find the package {item} -- are you sure it's registered?"
             ) from e
 
-    def __getstate__(self):
-        return dict(self.__dict__)
-
-    def __setstate__(self, state):
-        self.__dict__.update(**state)
-
     def register(self, package_identifier: str, domain: Optional[str] = None) -> None:
         """
         Add a new package of nodes from the provided identifier.

--- a/pyiron_workflow/has_interface_mixins.py
+++ b/pyiron_workflow/has_interface_mixins.py
@@ -24,6 +24,7 @@ class UsesState(ABC):
     Guarantees that `super()` can always be called in these methods to return a copy
     of the state dict or to update it, respectively.
     """
+
     def __getstate__(self):
         # Make a shallow(! careful!) copy of the state so any modifications don't
         # immediately impact the object we're getting the state from)

--- a/pyiron_workflow/has_interface_mixins.py
+++ b/pyiron_workflow/has_interface_mixins.py
@@ -17,6 +17,22 @@ if TYPE_CHECKING:
     from pyiron_workflow.channels import Channel
 
 
+class UsesState(ABC):
+    """
+    A mixin for any class using :meth:`__getstate__` or :meth:`__setstate__`.
+
+    Guarantees that `super()` can always be called in these methods to return a copy
+    of the state dict or to update it, respectively.
+    """
+    def __getstate__(self):
+        # Make a shallow(! careful!) copy of the state so any modifications don't
+        # immediately impact the object we're getting the state from)
+        return dict(self.__dict__)
+
+    def __setstate__(self, state):
+        self.__dict__.update(**state)
+
+
 class HasLabel(ABC):
     """
     A mixin to guarantee the label interface exists.

--- a/pyiron_workflow/run.py
+++ b/pyiron_workflow/run.py
@@ -9,7 +9,7 @@ from abc import ABC, abstractmethod
 from concurrent.futures import Executor as StdLibExecutor, Future
 from typing import Any, Optional
 
-from pyiron_workflow.has_interface_mixins import HasLabel, HasRun
+from pyiron_workflow.has_interface_mixins import HasLabel, HasRun, UsesState
 
 
 def manage_status(status_managed_method):
@@ -45,7 +45,7 @@ class ReadinessError(ValueError):
     """
 
 
-class Runnable(HasLabel, HasRun, ABC):
+class Runnable(UsesState, HasLabel, HasRun, ABC):
     """
     An abstract class for interfacing with executors, etc.
 
@@ -229,11 +229,7 @@ class Runnable(HasLabel, HasRun, ABC):
             raise e
 
     def __getstate__(self):
-        try:
-            state = super().__getstate__()
-            state = dict(state) if state is self.__dict__ else state
-        except AttributeError:
-            state = dict(self.__dict__)
+        state = super().__getstate__()
         state["future"] = None
         # Don't pass the future -- with the future in the state things work fine for
         # the simple pyiron_workflow.executors.CloudpickleProcessPoolExecutor, but for

--- a/pyiron_workflow/semantics.py
+++ b/pyiron_workflow/semantics.py
@@ -18,11 +18,11 @@ from typing import Optional
 
 from bidict import bidict
 
-from pyiron_workflow.has_interface_mixins import HasLabel
+from pyiron_workflow.has_interface_mixins import HasLabel, UsesState
 from pyiron_workflow.snippets.logger import logger
 
 
-class Semantic(HasLabel, ABC):
+class Semantic(UsesState, HasLabel, ABC):
     """
     An object with a unique semantic path.
 
@@ -91,11 +91,7 @@ class Semantic(HasLabel, ABC):
         return self if self.parent is None else self.parent.semantic_root
 
     def __getstate__(self):
-        try:
-            state = super().__getstate__()
-            state = dict(state) if state is self.__dict__ else state
-        except AttributeError:
-            state = dict(self.__dict__)
+        state = super().__getstate__()
         state["_parent"] = None
         # Comment on moving this to semantics)
         # Basically we want to avoid recursion during (de)serialization; when the
@@ -124,12 +120,6 @@ class Semantic(HasLabel, ABC):
         # may cause me/us headaches in the future.
         # -Liam
         return state
-
-    def __setstate__(self, state):
-        try:
-            super().__setstate__(state)
-        except AttributeError:
-            self.__dict__.update(**state)
 
 
 class CyclicPathError(ValueError):


### PR DESCRIPTION
Just a new parent class to guarantee that `super().__get/setstate__` can always be called. Reduces code duplication. Contributes to #243.