### PR TITLE
[minor] Refactor channel

### DIFF
--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -13,7 +13,7 @@ from abc import ABC, abstractmethod
 import inspect
 from warnings import warn
 
-from pyiron_workflow.has_interface_mixins import HasChannel, UsesState
+from pyiron_workflow.has_interface_mixins import HasChannel, HasLabel, UsesState
 from pyiron_workflow.has_to_dict import HasToDict
 from pyiron_workflow.snippets.singleton import Singleton
 from pyiron_workflow.type_hinting import (
@@ -29,7 +29,7 @@ class ChannelConnectionError(Exception):
     pass
 
 
-class Channel(UsesState, HasChannel, HasToDict, ABC):
+class Channel(UsesState, HasChannel, HasLabel, HasToDict, ABC):
     """
     Channels facilitate the flow of information (data or control signals) into and
     out of nodes.
@@ -79,9 +79,13 @@ class Channel(UsesState, HasChannel, HasToDict, ABC):
             label (str): A name for the channel.
             node (pyiron_workflow.node.Node): The node to which the channel belongs.
         """
-        self.label: str = label
+        self._label = label
         self.node: Node = node
         self.connections: list[Channel] = []
+
+    @property
+    def label(self) -> str:
+        return self._label
 
     @abstractmethod
     def __str__(self):

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -339,8 +339,9 @@ class DataChannel(Channel, ABC):
             when this node is a value receiver. This can potentially be expensive, so
             consider deactivating strict hints everywhere for production runs. (Default
             is True, raise exceptions when type hints get violated.)
-        value_receiver (pyiron_workflow.node.Node|None): Another node of the same class
-            whose value will always get updated when this node's value gets updated.
+        value_receiver (pyiron_workflow.channel.DataChannel|None): Another channel of
+            the same class whose value will always get updated when this channel's
+            value gets updated.
     """
 
     def __init__(

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -537,7 +537,7 @@ class Composite(Node, SemanticParent, ABC):
         the name is protected.
         """
         return [
-            ((inp.node.label, inp.label), (out.node.label, out.label))
+            ((inp.owner.label, inp.label), (out.owner.label, out.label))
             for child in self
             for inp in panel_getter(child)
             for out in inp.connections

--- a/pyiron_workflow/function.py
+++ b/pyiron_workflow/function.py
@@ -458,7 +458,7 @@ class Function(Node):
                 channels.append(
                     InputData(
                         label=label,
-                        node=self,
+                        owner=self,
                         default=default,
                         type_hint=type_hint,
                     )
@@ -497,7 +497,7 @@ class Function(Node):
             channels.append(
                 OutputData(
                     label=label,
-                    node=self,
+                    owner=self,
                     type_hint=hint,
                 )
             )

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -458,7 +458,7 @@ class Macro(Composite):
         """
         composite_channel = child_reference_channel.__class__(
             label=composite_io_key,
-            node=self,
+            owner=self,
             default=child_reference_channel.default,
             type_hint=child_reference_channel.type_hint,
         )
@@ -565,7 +565,7 @@ class Macro(Composite):
         the name is protected.
         """
         return [
-            (c.label, (c.value_receiver.node.label, c.value_receiver.label))
+            (c.label, (c.value_receiver.owner.label, c.value_receiver.label))
             for c in self.inputs
         ]
 
@@ -579,7 +579,7 @@ class Macro(Composite):
         the name is protected.
         """
         return [
-            ((c.node.label, c.label), c.value_receiver.label)
+            ((c.owner.label, c.label), c.value_receiver.label)
             for child in self
             for c in child.outputs
             if c.value_receiver is not None

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -923,7 +923,7 @@ class Node(HasToDict, Semantic, Runnable, ABC, metaclass=AbstractHasPost):
         # Channels don't store their own node in their state, so repopulate it
         for io_panel in self._owned_io_panels:
             for channel in io_panel:
-                channel.node = self
+                channel.owner = self
 
     @property
     def _owned_io_panels(self) -> list[IO]:

--- a/pyiron_workflow/workflow.py
+++ b/pyiron_workflow/workflow.py
@@ -282,7 +282,7 @@ class Workflow(Composite, ParentMost):
             for inp_label, inp in node.inputs.items():
                 for conn in inp.connections:
                     data_connections.append(
-                        ((node.label, inp_label), (conn.node.label, conn.label))
+                        ((node.label, inp_label), (conn.owner.label, conn.label))
                     )
         return data_connections
 
@@ -305,7 +305,7 @@ class Workflow(Composite, ParentMost):
             for inp_label, inp in node.signals.input.items():
                 for conn in inp.connections:
                     signal_connections.append(
-                        ((node.label, inp_label), (conn.node.label, conn.label))
+                        ((node.label, inp_label), (conn.owner.label, conn.label))
                     )
         return signal_connections
 

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -21,14 +21,14 @@ class TestDataIO(unittest.TestCase):
     def setUp(self) -> None:
         node = DummyNode()
         self.inputs = [
-            InputData(label="x", node=node, default=0., type_hint=float),
-            InputData(label="y", node=node, default=1., type_hint=float)
+            InputData(label="x", owner=node, default=0., type_hint=float),
+            InputData(label="y", owner=node, default=1., type_hint=float)
         ]
         outputs = [
-            OutputData(label="a", node=node, type_hint=float),
+            OutputData(label="a", owner=node, type_hint=float),
         ]
 
-        self.post_facto_output = OutputData(label="b", node=node, type_hint=float)
+        self.post_facto_output = OutputData(label="b", owner=node, type_hint=float)
 
         self.input = Inputs(*self.inputs)
         self.output = Outputs(*outputs)

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -422,7 +422,7 @@ class TestMacro(unittest.TestCase):
             )
             self.assertIs(
                 n_not_used,
-                n2.signals.input.run.connections[0].node,
+                n2.signals.input.run.connections[0].owner,
                 msg="Original connections should get restored on upstream failure"
             )
 


### PR DESCRIPTION
This re-parents `Channel` onto `HasLabel` (patch) and renames the `Channel.node` attribute to `Channel.owner` (minor). As we move to composition mixins (#243), this will help break apart where channels depend on their owner being something that "has IO" and where they really depend on it being a node (basically only necessary for node injection on `OutputData`).