### PR TITLE
[patch] Don't let attribute injection work for private variables.

### DIFF
--- a/pyiron_workflow/injection.py
+++ b/pyiron_workflow/injection.py
@@ -111,6 +111,13 @@ class OutputDataWithInjection(OutputData):
                 "`hasattr('to_hdf')` check on us and accidentally injecting a new "
                 "getattr node."
             )
+        if name.startswith("_"):
+            raise AttributeError(
+                f"{OutputDataWithInjection.__name__} {self.label} tried to inject on "
+                f"the attribute {name}, but injecting on private attributes is "
+                f"forbidden -- if you really need it create a {GetAttr.__name__} node "
+                f"manually."
+            )
         return self._node_injection(GetAttr, name)
 
     def __getitem__(self, item):

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -521,6 +521,12 @@ class TestSingleValue(unittest.TestCase):
             msg="Should fall back to looking on the single value"
         )
 
+        with self.assertRaises(
+            AttributeError,
+            msg="Attribute injection should not work for private attributes"
+        ):
+            svn._some_nonexistant_private_var
+
     def test_repr(self):
         with self.subTest("Filled data"):
             svn = SingleValue(plus_one)


### PR DESCRIPTION
For compatibility with iPython, which runs around asking for `_ipython_canary_method_should_not_exist_` left, right, and center.

Closes #253 