### PR TITLE
[patch] Use consistent and canonical cls/self for (non)classmethod

### DIFF
--- a/tests/unit/snippets/test_files.py
+++ b/tests/unit/snippets/test_files.py
@@ -5,11 +5,11 @@ import platform
 
 
 class TestFiles(unittest.TestCase):
-    def setUp(cls):
-        cls.directory = DirectoryObject("test")
+    def setUp(self):
+        self.directory = DirectoryObject("test")
 
-    def tearDown(cls):
-        cls.directory.delete()
+    def tearDown(self):
+        self.directory.delete()
 
     def test_directory_instantiation(self):
         directory = DirectoryObject(Path("test"))

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -41,10 +41,9 @@ class Dummy(HasIO):
 
 class TestDataIO(unittest.TestCase):
 
-    @classmethod
-    def setUp(cls) -> None:
+    def setUp(self) -> None:
         has_io = Dummy()
-        cls.inputs = [
+        self.inputs = [
             InputData(label="x", owner=has_io, default=0., type_hint=float),
             InputData(label="y", owner=has_io, default=1., type_hint=float)
         ]
@@ -52,10 +51,10 @@ class TestDataIO(unittest.TestCase):
             OutputData(label="a", owner=has_io, type_hint=float),
         ]
 
-        cls.post_facto_output = OutputData(label="b", owner=has_io, type_hint=float)
+        self.post_facto_output = OutputData(label="b", owner=has_io, type_hint=float)
 
-        cls.input = Inputs(*cls.inputs)
-        cls.output = Outputs(*outputs)
+        self.input = Inputs(*self.inputs)
+        self.output = Outputs(*outputs)
 
     def test_access(self):
         self.assertEqual(self.input.x, self.input["x"])


### PR DESCRIPTION
Just correcting some silly little accidents that slipped into the tests.