### PR TITLE
[patch] Honest graph properties

### DIFF
--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -351,19 +351,16 @@ class Node(
     @property
     def graph_path(self) -> str:
         """
-        The path of node labels from the graph root (parent-most node) down to this
-        node.
+        The path of node labels from the graph root (parent-most node in this semantic
+        path) down to this node.
         """
-        # If non-node objects come up in the semantic path, we'll need early stopping
-        # to make this docstring true, but those don't exist right now.
-        return self.semantic_path
+        prefix = self.parent.semantic_path if isinstance(self.parent, Node) else ""
+        return prefix + self.semantic_delimiter + self.label
 
     @property
     def graph_root(self) -> Node:
-        """The parent-most node in this graph."""
-        # If non-node objects come up in the semantic path, we'll need early stopping
-        # to make this docstring true, but those don't exist right now.
-        return self.semantic_root
+        """The parent-most node in this semantic path."""
+        return self.parent.graph_root if isinstance(self.parent, Node) else self
 
     def data_input_locked(self):
         return self.running

--- a/pyiron_workflow/semantics.py
+++ b/pyiron_workflow/semantics.py
@@ -82,13 +82,13 @@ class Semantic(UsesState, HasLabel, HasParent, ABC):
         The path of node labels from the graph root (parent-most node) down to this
         node.
         """
-        prefix = "" if self.parent is None else self.parent.semantic_path
+        prefix = self.parent.semantic_path if isinstance(self.parent, Semantic) else ""
         return prefix + self.semantic_delimiter + self.label
 
     @property
     def semantic_root(self) -> Semantic:
         """The parent-most object in this semantic path; may be self."""
-        return self if self.parent is None else self.parent.semantic_root
+        return self.parent.semantic_root if isinstance(self.parent, Semantic) else self
 
     def __getstate__(self):
         state = super().__getstate__()


### PR DESCRIPTION
Right now, practically, the parent-most graph object is the parent-most semantic object is a `Node`. There is no reason this needs to be so. These changes make it so that `(semantic/graph)_(root/path)` operate up to the parent-most `Semantic` and `Node` objects respectively -- i.e. a "graph" is a semantic tree whose parent-most object is also a `Node`.