### PR TITLE
[patch] Refactor the storage interface

### DIFF
--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -669,10 +669,10 @@ class Composite(Node, SemanticParent, ABC):
     def import_ready(self) -> bool:
         return super().import_ready and all(node.import_ready for node in self)
 
-    def _report_import_readiness(self, tabs=0, report_so_far=""):
-        report = super()._report_import_readiness(
+    def report_import_readiness(self, tabs=0, report_so_far=""):
+        report = super().report_import_readiness(
             tabs=tabs, report_so_far=report_so_far
         )
         for node in self:
-            report = node._report_import_readiness(tabs=tabs + 1, report_so_far=report)
+            report = node.report_import_readiness(tabs=tabs + 1, report_so_far=report)
         return report

--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -670,9 +670,7 @@ class Composite(Node, SemanticParent, ABC):
         return super().import_ready and all(node.import_ready for node in self)
 
     def report_import_readiness(self, tabs=0, report_so_far=""):
-        report = super().report_import_readiness(
-            tabs=tabs, report_so_far=report_so_far
-        )
+        report = super().report_import_readiness(tabs=tabs, report_so_far=report_so_far)
         for node in self:
             report = node.report_import_readiness(tabs=tabs + 1, report_so_far=report)
         return report

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -8,11 +8,10 @@ The workhorse class for the entire concept.
 from __future__ import annotations
 
 import sys
-import warnings
 from abc import ABC
 from concurrent.futures import Future
-from importlib import import_module
 from typing import Any, Literal, Optional, TYPE_CHECKING
+import warnings
 
 from pyiron_workflow.draw import Node as GraphvizNode
 from pyiron_workflow.has_to_dict import HasToDict
@@ -20,14 +19,14 @@ from pyiron_workflow.injection import HasIOWithInjection
 from pyiron_workflow.run import Runnable, ReadinessError
 from pyiron_workflow.semantics import Semantic
 from pyiron_workflow.single_output import ExploitsSingleOutput
-from pyiron_workflow.storage import StorageInterface
+from pyiron_workflow.storage import HasH5ioStorage, HasTinybaseStorage
 from pyiron_workflow.topology import (
     get_nodes_in_data_tree,
     set_run_connections_according_to_linear_dag,
 )
-from pyiron_workflow.working import HasWorkingDirectory
 from pyiron_workflow.snippets.colors import SeabornColors
 from pyiron_workflow.snippets.has_post import AbstractHasPost
+from pyiron_workflow.working import HasWorkingDirectory
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -35,6 +34,7 @@ if TYPE_CHECKING:
     import graphviz
 
     from pyiron_workflow.composite import Composite
+    from pyiron_workflow.snippets.files import DirectoryObject
 
 
 class Node(
@@ -44,6 +44,8 @@ class Node(
     HasIOWithInjection,
     ExploitsSingleOutput,
     HasWorkingDirectory,
+    HasH5ioStorage,
+    HasTinybaseStorage,
     ABC,
     metaclass=AbstractHasPost,
 ):
@@ -287,7 +289,7 @@ class Node(
         parent: Optional[Composite] = None,
         overwrite_save: bool = False,
         run_after_init: bool = False,
-        storage_backend: Optional[Literal["h5io", "tinybase"]] = None,
+        storage_backend: Literal["h5io", "tinybase"] | None = "h5io",
         save_after_run: bool = False,
         **kwargs,
     ):
@@ -306,11 +308,9 @@ class Node(
             *args,
             label=label,
             parent=parent,
+            storage_backend=storage_backend,
             **kwargs,
         )
-        self._working_directory = None
-        self._storage_backend = None
-        self.storage_backend = storage_backend
         self.save_after_run = save_after_run
         self._user_data = {}  # A place for power-users to bypass node-injection
 
@@ -322,7 +322,7 @@ class Node(
         **kwargs,
     ):
         if overwrite_save and sys.version_info >= (3, 11):
-            self.storage.delete()
+            self.delete_storage()
             do_load = False
         else:
             do_load = sys.version_info >= (3, 11) and self.storage.has_contents
@@ -351,19 +351,16 @@ class Node(
     @property
     def graph_path(self) -> str:
         """
-        The path of node labels from the graph root (parent-most node) down to this
-        node.
+        The path of node labels from the graph root (parent-most node in this semantic
+        path) down to this node.
         """
-        # If non-node objects come up in the semantic path, we'll need early stopping
-        # to make this docstring true, but those don't exist right now.
-        return self.semantic_path
+        prefix = self.parent.semantic_path if isinstance(self.parent, Node) else ""
+        return prefix + self.semantic_delimiter + self.label
 
     @property
     def graph_root(self) -> Node:
-        """The parent-most node in this graph."""
-        # If non-node objects come up in the semantic path, we'll need early stopping
-        # to make this docstring true, but those don't exist right now.
-        return self.semantic_root
+        """The parent-most node in this semantic path."""
+        return self.parent.graph_root if isinstance(self.parent, Node) else self
 
     def data_input_locked(self):
         return self.running
@@ -691,15 +688,19 @@ class Node(
             warnings.warn(f"Could not replace_child {self.label}, as it has no parent.")
 
     @property
-    def class_name(self) -> str:
-        """The class name of the node"""
-        # Since we want this directly in storage, put it in an attribute so it is
-        # guaranteed not to conflict with a child node label
-        return self.__class__.__name__
+    def storage_directory(self) -> DirectoryObject:
+        return self.working_directory
+
+    @property
+    def storage_path(self) -> str:
+        return self.graph_path
+
+    def tidy_storage_directory(self):
+        self.tidy_working_directory()
 
     def to_storage(self, storage):
         storage["package_identifier"] = self.package_identifier
-        storage["class_name"] = self.class_name
+        storage["class_name"] = self.__class__.__name__
         storage["label"] = self.label
         storage["running"] = self.running
         storage["failed"] = self.failed
@@ -725,111 +726,3 @@ class Node(
         data_outputs = storage["outputs"]
         for label in data_outputs.list_groups():
             self.outputs[label].from_storage(data_outputs[label])
-
-    _save_load_warnings = """
-        HERE BE DRAGONS!!!
-        
-        Warning:
-            This almost certainly only fails for subclasses of :class:`Node` that don't
-            override `node_function` or `macro_creator` directly, as these are expected 
-            to be part of the class itself (and thus already present on our instantiated 
-            object) and are never stored. Nodes created using the provided decorators 
-            should all work.
-            
-        Warning:
-            If you modify a `Macro` class in any way (changing its IO maps, rewiring 
-            internal connections, or replacing internal nodes), don't expect 
-            saving/loading to work.
-            
-        Warning:
-            If the underlying source code has changed since saving (i.e. the node doing 
-            the loading does not use the same code as the node doing the saving, or the 
-            nodes in some node package have been modified), then all bets are off.
-            
-        Note:
-            Saving and loading `Workflows` only works when all child nodes were created 
-            via the creator (and thus have a `package_identifier`). Right now, this is 
-            not a big barrier to custom nodes as all you need to do is move them into a 
-            .py file, make sure it's in your python path, and :func:`register` it as 
-            usual.
-    """
-
-    def save(self):
-        """
-        Writes the node to file (using HDF5) such that a new node instance of the same
-        type can :meth:`load()` the data to return to the same state as the save point,
-        i.e. the same data IO channel values, the same flags, etc.
-        """
-        backend = "h5io" if self.storage_backend is None else self.storage_backend
-        self.storage.save(backend=backend)
-
-    save.__doc__ += _save_load_warnings
-
-    def load(self):
-        """
-        Loads the node file (from HDF5) such that this node restores its state at time
-        of loading.
-
-        Raises:
-            TypeError) when the saved node has a different class name.
-        """
-        backend = "h5io" if self.storage_backend is None else self.storage_backend
-        self.storage.load(backend=backend)
-
-    save.__doc__ += _save_load_warnings
-
-    @property
-    def storage_backend(self):
-        if self.parent is None:
-            return self._storage_backend
-        else:
-            return self.graph_root.storage_backend
-
-    @storage_backend.setter
-    def storage_backend(self, new_backend):
-        if (
-            new_backend is not None
-            and self.parent is not None
-            and new_backend != self.graph_root.storage_backend
-        ):
-            raise ValueError(
-                f"Storage backends should only be set on the graph root "
-                f"({self.graph_root.label}), not on child ({self.label})"
-            )
-        else:
-            self._storage_backend = new_backend
-
-    @property
-    def storage(self):
-        return StorageInterface(self)
-
-    @property
-    def import_ready(self) -> bool:
-        """
-        Checks whether `importlib` can find this node's class, and if so whether the
-        imported object matches the node's type.
-
-        Returns:
-            (bool): Whether the imported module and name of this node's class match
-                its type.
-        """
-        try:
-            module = self.__class__.__module__
-            class_ = getattr(import_module(module), self.__class__.__name__)
-            if module == "__main__":
-                warnings.warn(f"{self.label} is only defined in __main__")
-            return type(self) is class_
-        except (ModuleNotFoundError, AttributeError):
-            return False
-
-    @property
-    def import_readiness_report(self):
-        print(self._report_import_readiness())
-
-    def _report_import_readiness(self, tabs=0, report_so_far=""):
-        newline = "\n" if len(report_so_far) > 0 else ""
-        tabspace = tabs * "\t"
-        return (
-            report_so_far + f"{newline}{tabspace}{self.label}: "
-            f"{'ok' if self.import_ready else 'NOT IMPORTABLE'}"
-        )

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -5,18 +5,17 @@ back ends.
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
+from importlib import import_module
 import os
 import sys
-from typing import Literal, TYPE_CHECKING
+from typing import Optional
+import warnings
 
 import h5io
 
-from pyiron_workflow.snippets.files import FileObject
-
-if TYPE_CHECKING:
-    from pyiron_workflow.node import Node
-
-ALLOWED_BACKENDS = ["h5io", "tinybase"] if sys.version_info >= (3, 11) else ["h5io"]
+from pyiron_workflow.has_interface_mixins import HasLabel, HasParent
+from pyiron_workflow.snippets.files import FileObject, DirectoryObject
 
 
 class TypeNotFoundError(ImportError):
@@ -27,112 +26,126 @@ class TypeNotFoundError(ImportError):
 
 
 class StorageInterface:
-
-    _TINYBASE_STORAGE_FILE_NAME = "project.h5"
-    _H5IO_STORAGE_FILE_NAME = "h5io.h5"
-
-    def __init__(self, node: Node):
+    def __init__(self, owner: HasStorage):
         if sys.version_info < (3, 11):
             raise NotImplementedError("Storage is only available in python 3.11+")
-        self.node = node
+        self._owner = owner
 
-    def save(self, backend: Literal["h5io", "tinybase"]):
-        if backend not in ALLOWED_BACKENDS:
-            raise ValueError(
-                f"Backend {backend} not recognized, please use one of "
-                f"{ALLOWED_BACKENDS}."
-            )
+    @property
+    def owner(self) -> HasStorage:
+        # Property access is just to allow children to override the type hint
+        return self._owner
 
-        if self.node.parent is None:
-            self._save(backend=backend)
-        else:
-            root = self.node.graph_root
-            root.storage.save(backend=backend)
-
-    def _save(self, backend: Literal["h5io", "tinybase"]):
-        if not self.node.import_ready:
+    def save(self):
+        root = self.owner.storage_root
+        if not root.import_ready:
             raise TypeNotFoundError(
-                f"{self.node.label} cannot be saved because it (or one "
-                f"of its child nodes) has a type that cannot be imported. Did you "
-                f"dynamically define this node? Try using the node wrapper as a "
-                f"decorator instead. \n"
+                f"{self.owner.label} cannot be saved with the "
+                f"{self.owner.storage_backend} because it (or one of its children) has "
+                f"a type that cannot be imported. Did you dynamically define this "
+                f"object? \n"
                 f"Import readiness report: \n"
-                f"{self.node._report_import_readiness()}"
+                f"{self.owner.report_import_readiness()}"
             )
-        if backend == "h5io":
-            h5io.write_hdf5(
-                fname=self._h5io_storage_file_path,
-                data=self.node,
-                title=self.node.label,
-                use_state=True,
-                overwrite=True,  # Don't worry about efficiency or updating yet
-            )
-        elif backend == "tinybase":
-            os.makedirs(
-                os.path.dirname(self._tinybase_storage_file_path), exist_ok=True
-            )  # Make sure the path to the storage location exists
-            self.node.to_storage(self._tinybase_storage)
-        else:
-            raise ValueError(
-                f"Backend {backend} not recognized, please use 'h5io' or 'tinybase'."
-            )
+        root_storage = self if root is self.owner else root.storage
+        root_storage._save()
 
-    def load(self, backend: Literal["h5io", "tinybase"]):
-        if backend not in ALLOWED_BACKENDS:
-            raise ValueError(
-                f"Backend {backend} not recognized, please use one of "
-                f"{ALLOWED_BACKENDS}."
-            )
-        elif backend == "h5io":
-            inst = h5io.read_hdf5(
-                fname=self._h5io_storage_file_path, title=self.node.label
-            )
-            self.node.__setstate__(inst.__getstate__())
-        elif backend == "tinybase":
-            tinybase_storage = self._tinybase_storage
-            if tinybase_storage["class_name"] != self.node.class_name:
-                raise TypeError(
-                    f"{self.node.label} cannot load, as it has type "
-                    f"{self.node.class_name},  but the saved node has type "
-                    f"{tinybase_storage['class_name']}"
-                )
-            self.node.from_storage(tinybase_storage)
+    @abstractmethod
+    def _save(self):
+        pass
+
+    def load(self):
+        # Misdirection is strictly for symmetry with _save, so child classes define the
+        # private method in both cases
+        return self._load()
+
+    @abstractmethod
+    def _load(self):
+        pass
 
     @property
     def has_contents(self) -> bool:
-        has_contents = self._tinybase_storage_is_there or self._h5io_storage_is_there
-        self.node.tidy_working_directory()
+        has_contents = self._has_contents
+        self.owner.tidy_storage_directory()
         return has_contents
 
+    @property
+    @abstractmethod
+    def _has_contents(self) -> bool:
+        """Whether a save file exists for this backend"""
+
     def delete(self):
-        if self._tinybase_storage_is_there:
-            up = self._tinybase_storage.close()
-            del up[self.node.label]
-            if self.node.parent is None:
-                FileObject(
-                    self._TINYBASE_STORAGE_FILE_NAME, self.node.working_directory
-                ).delete()
-        if self._h5io_storage_is_there:
-            FileObject(
-                self._H5IO_STORAGE_FILE_NAME, self.node.working_directory
-            ).delete()
-        self.node.tidy_working_directory()
+        if self.has_contents:
+            self._delete()
+        self.owner.tidy_storage_directory()
+
+    @abstractmethod
+    def _delete(self):
+        """Remove an existing save-file for this backend"""
+
+
+class H5ioStorage(StorageInterface):
+
+    _H5IO_STORAGE_FILE_NAME = "h5io.h5"
+
+    def __init__(self, owner: HasH5ioStorage):
+        super().__init__(owner=owner)
+
+    @property
+    def owner(self) -> HasH5ioStorage:
+        return self._owner
 
     @property
     def _h5io_storage_file_path(self) -> str:
         return str(
-            (self.node.working_directory.path / self._H5IO_STORAGE_FILE_NAME).resolve()
+            (self.owner.storage_directory.path / self._H5IO_STORAGE_FILE_NAME).resolve()
         )
 
+    def _save(self):
+        os.makedirs(
+            os.path.dirname(self._h5io_storage_file_path), exist_ok=True
+        )  # Make sure the path to the storage location exists
+        h5io.write_hdf5(
+            fname=self._h5io_storage_file_path,
+            data=self.owner,
+            title=self.owner.label,
+            use_state=True,
+            overwrite=True,  # Don't worry about efficiency or updating yet
+        )
+
+    def _load(self):
+        inst = h5io.read_hdf5(
+            fname=self._h5io_storage_file_path, title=self.owner.label
+        )
+        self.owner.__setstate__(inst.__getstate__())
+
+    def _delete(self):
+        if self.has_contents:
+            FileObject(
+                self._H5IO_STORAGE_FILE_NAME, self.owner.storage_directory
+            ).delete()
+
     @property
-    def _h5io_storage_is_there(self) -> bool:
+    def _has_contents(self) -> bool:
         return os.path.isfile(self._h5io_storage_file_path)
+
+
+class TinybaseStorage(StorageInterface):
+
+    _TINYBASE_STORAGE_FILE_NAME = "project.h5"
+
+    def __init__(self, owner: HasTinybaseStorage):
+        super().__init__(owner=owner)
+
+    @property
+    def owner(self) -> HasTinybaseStorage:
+        return self._owner
 
     @property
     def _tinybase_storage_file_path(self) -> str:
         return str(
             (
-                self.node.graph_root.working_directory.path
+                self.owner.storage_root.storage_directory.path
                 / self._TINYBASE_STORAGE_FILE_NAME
             ).resolve()
         )
@@ -143,14 +156,239 @@ class StorageInterface:
         from h5io_browser import Pointer
 
         return H5ioStorage(
-            Pointer(self._tinybase_storage_file_path, h5_path=self.node.graph_path),
+            Pointer(self._tinybase_storage_file_path, h5_path=self.owner.storage_path),
             None,
         )
 
+    def _save(self):
+        os.makedirs(
+            os.path.dirname(self._tinybase_storage_file_path), exist_ok=True
+        )  # Make sure the path to the storage location exists
+        self.owner.to_storage(self._tinybase_storage)
+
+    def _load(self) -> HasTinybaseStorage:
+        tinybase_storage = self._tinybase_storage
+        if tinybase_storage["class_name"] != self.owner.__class__.__name__:
+            raise TypeError(
+                f"{self.owner.label} cannot load, as it has type "
+                f"{self.owner.__class__.__name__},  but the saved node has type "
+                f"{tinybase_storage['class_name']}"
+            )
+        self.owner.from_storage(tinybase_storage)
+
+    def _delete(self):
+        if self.has_contents:
+            up = self._tinybase_storage.close()
+            del up[self.owner.label]
+            if self.owner.parent is None:
+                FileObject(
+                    self._TINYBASE_STORAGE_FILE_NAME, self.owner.storage_directory
+                ).delete()
+
     @property
-    def _tinybase_storage_is_there(self) -> bool:
+    def _has_contents(self) -> bool:
         if os.path.isfile(self._tinybase_storage_file_path):
             storage = self._tinybase_storage
             return (len(storage.list_groups()) + len(storage.list_nodes())) > 0
         else:
             return False
+
+
+class HasStorage(HasLabel, HasParent, ABC):
+    @classmethod
+    def allowed_backends(cls):
+        return tuple(cls._storage_interfaces().keys())
+
+    @classmethod
+    def _storage_interfaces(cls):
+        return {}
+
+    @classmethod
+    def default_backend(cls):
+        raise NotImplementedError("Exactly one child must define a preferred backend")
+
+    def __init__(self, *args, storage_backend: Optional[str] = None, **kwargs):
+        self._storage_backend = None
+        super().__init__(*args, **kwargs)
+        self.storage_backend = storage_backend
+
+    @property
+    @abstractmethod
+    def storage_directory(self) -> DirectoryObject:
+        # Effectively the working directory, but I want to avoid inheriting from that
+        # Clearly there is some bad architecture here, but we'll deal with it later
+        pass
+
+    @property
+    @abstractmethod
+    def storage_path(self) -> str:
+        # Effectively the graph path, but I want to avoid inheriting from that
+        # Clearly there is some bad architecture here, but we'll deal with it later
+        pass
+
+    @abstractmethod
+    def tidy_storage_directory(self):
+        # Effectively tidy working directory, but I want to avoid inheriting from that
+        # Clearly there is some bad architecture here, but we'll deal with it later
+        pass
+
+    _save_load_warnings = """
+            HERE BE DRAGONS!!!
+
+            Warning:
+                This almost certainly only fails for subclasses of :class:`Node` that don't
+                override `node_function` or `macro_creator` directly, as these are expected 
+                to be part of the class itself (and thus already present on our instantiated 
+                object) and are never stored. Nodes created using the provided decorators 
+                should all work.
+
+            Warning:
+                If you modify a `Macro` class in any way (changing its IO maps, rewiring 
+                internal connections, or replacing internal nodes), don't expect 
+                saving/loading to work.
+
+            Warning:
+                If the underlying source code has changed since saving (i.e. the node doing 
+                the loading does not use the same code as the node doing the saving, or the 
+                nodes in some node package have been modified), then all bets are off.
+
+            Note:
+                Saving and loading `Workflows` only works when all child nodes were created 
+                via the creator (and thus have a `package_identifier`). Right now, this is 
+                not a big barrier to custom nodes as all you need to do is move them into a 
+                .py file, make sure it's in your python path, and :func:`register` it as 
+                usual.
+        """
+
+    def save(self):
+        """
+        Writes the node to file (using HDF5) such that a new node instance of the same
+        type can :meth:`load()` the data to return to the same state as the save point,
+        i.e. the same data IO channel values, the same flags, etc.
+        """
+        self.storage.save()
+
+    save.__doc__ += _save_load_warnings
+
+    def load(self):
+        """
+        Loads the node file (from HDF5) such that this node restores its state at time
+        of loading.
+
+        Raises:
+            TypeError: when the saved node has a different class name.
+        """
+        self.storage.load()
+
+    save.__doc__ += _save_load_warnings
+
+    def delete_storage(self):
+        """Remove save files for _all_ available backends."""
+        for backend in self.allowed_backends():
+            interface = self._storage_interfaces()[backend](self)
+            try:
+                interface.delete()
+            except FileNotFoundError:
+                pass
+
+    @property
+    def storage_root(self):
+        """The parent-most object that has storage."""
+        parent = self.parent
+        if isinstance(parent, HasStorage):
+            return parent.storage_root
+        else:
+            return self
+
+    @property
+    def storage_backend(self):
+        storage_root = self.storage_root
+        if storage_root is self:
+            backend = self._storage_backend
+        else:
+            backend = storage_root.storage_backend
+        return self.default_backend() if backend is None else backend
+
+    @storage_backend.setter
+    def storage_backend(self, new_backend):
+        storage_root = self.storage_root
+        if new_backend is not None:
+            if new_backend not in self.allowed_backends():
+                raise ValueError(
+                    f"{self.label} got the storage backend {new_backend}, but only "
+                    f"{self.allowed_backends()} are permitted."
+                )
+            elif (
+                storage_root is not self
+                and new_backend != storage_root.storage_backend
+            ):
+                raise ValueError(
+                    f"Storage backends should only be set on the storage root "
+                    f"({self.storage_root.label}), not on child ({self.label})"
+                )
+        self._storage_backend = new_backend
+
+    @property
+    def storage(self) -> StorageInterface:
+        if self.storage_backend is None:
+            raise ValueError(f"{self.label} does not have a storage backend set")
+        return self._storage_interfaces()[self.storage_backend](self)
+
+    @property
+    def import_ready(self) -> bool:
+        """
+        Checks whether `importlib` can find this node's class, and if so whether the
+        imported object matches the node's type.
+
+        Returns:
+            (bool): Whether the imported module and name of this node's class match
+                its type.
+        """
+        try:
+            module = self.__class__.__module__
+            class_ = getattr(import_module(module), self.__class__.__name__)
+            if module == "__main__":
+                warnings.warn(f"{self.label} is only defined in __main__")
+            return type(self) is class_
+        except (ModuleNotFoundError, AttributeError):
+            return False
+
+    @property
+    def import_readiness_report(self):
+        print(self.report_import_readiness())
+
+    def report_import_readiness(self, tabs=0, report_so_far=""):
+        newline = "\n" if len(report_so_far) > 0 else ""
+        tabspace = tabs * "\t"
+        return (
+            report_so_far + f"{newline}{tabspace}{self.label}: "
+                            f"{'ok' if self.import_ready else 'NOT IMPORTABLE'}"
+        )
+
+
+class HasH5ioStorage(HasStorage, ABC):
+    @classmethod
+    def _storage_interfaces(cls):
+        interfaces = super(HasH5ioStorage, cls)._storage_interfaces()
+        interfaces["h5io"] = H5ioStorage
+        return interfaces
+
+    @classmethod
+    def default_backend(cls):
+        return "h5io"
+
+
+class HasTinybaseStorage(HasStorage, ABC):
+    @classmethod
+    def _storage_interfaces(cls):
+        interfaces = super(HasTinybaseStorage, cls)._storage_interfaces()
+        interfaces["tinybase"] = TinybaseStorage
+        return interfaces
+
+    @abstractmethod
+    def to_storage(self, storage: TinybaseStorage):
+        pass
+
+    @abstractmethod
+    def from_storage(self, storage: TinybaseStorage):
+        pass

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -319,8 +319,7 @@ class HasStorage(HasLabel, HasParent, ABC):
                     f"{self.allowed_backends()} are permitted."
                 )
             elif (
-                storage_root is not self
-                and new_backend != storage_root.storage_backend
+                storage_root is not self and new_backend != storage_root.storage_backend
             ):
                 raise ValueError(
                     f"Storage backends should only be set on the storage root "
@@ -362,7 +361,7 @@ class HasStorage(HasLabel, HasParent, ABC):
         tabspace = tabs * "\t"
         return (
             report_so_far + f"{newline}{tabspace}{self.label}: "
-                            f"{'ok' if self.import_ready else 'NOT IMPORTABLE'}"
+            f"{'ok' if self.import_ready else 'NOT IMPORTABLE'}"
         )
 
 

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -10,7 +10,6 @@ from pyiron_workflow._tests import ensure_tests_in_python_path
 from pyiron_workflow.channels import NOT_DATA
 from pyiron_workflow.function import Function
 from pyiron_workflow.macro import Macro, macro_node
-from pyiron_workflow.storage import ALLOWED_BACKENDS
 from pyiron_workflow.topology import CircularDataFlowError
 
 
@@ -531,7 +530,7 @@ class TestMacro(unittest.TestCase):
         ensure_tests_in_python_path()
         Macro.register("static.demo_nodes", domain="demo")
 
-        for backend in ALLOWED_BACKENDS:
+        for backend in Macro.allowed_backends():
             with self.subTest(backend):
                 try:
                     macro = Macro.create.demo.AddThree(
@@ -569,7 +568,7 @@ class TestMacro(unittest.TestCase):
                     )  # Note that this snags the _new_ one in the case of h5io!
                     self.assertEqual(
                         Macro.create.demo.AddThree.__name__,
-                        reloaded.class_name,
+                        reloaded.__class__.__name__,
                         msg=f"LOOK OUT! This all (de)serialized nicely, but what we "
                             f"loaded is _falsely_ claiming to be an "
                             f"{Macro.create.demo.AddThree.__name__}. This is "

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -7,7 +7,7 @@ from pyiron_workflow._tests import ensure_tests_in_python_path
 from pyiron_workflow.channels import NOT_DATA
 from pyiron_workflow.semantics import ParentMostError
 from pyiron_workflow.snippets.dotdict import DotDict
-from pyiron_workflow.storage import TypeNotFoundError, ALLOWED_BACKENDS
+from pyiron_workflow.storage import TypeNotFoundError
 from pyiron_workflow.workflow import Workflow
 
 
@@ -348,7 +348,7 @@ class TestWorkflow(unittest.TestCase):
 
     @unittest.skipIf(sys.version_info < (3, 11), "Storage will only work in 3.11+")
     def test_storage_values(self):
-        for backend in ALLOWED_BACKENDS:
+        for backend in Workflow.allowed_backends():
             with self.subTest(backend):
                 wf = Workflow("wf", storage_backend=backend)
                 try:
@@ -385,7 +385,7 @@ class TestWorkflow(unittest.TestCase):
         # Note that the type hint `Optional[int]` from OptionallyAdd defines a custom
         # reconstructor, which borks h5io
 
-        for backend in ALLOWED_BACKENDS:
+        for backend in Workflow.allowed_backends():
             with self.subTest(backend):
                 try:
                     wf.storage_backend = backend
@@ -397,7 +397,7 @@ class TestWorkflow(unittest.TestCase):
         with self.subTest("No unimportable nodes for either back-end"):
             try:
                 wf.import_type_mismatch = wf.create.demo.dynamic()
-                for backend in ALLOWED_BACKENDS:
+                for backend in Workflow.allowed_backends():
                     with self.subTest(backend):
                         with self.assertRaises(
                             TypeNotFoundError,
@@ -409,7 +409,7 @@ class TestWorkflow(unittest.TestCase):
             finally:
                 wf.remove_child(wf.import_type_mismatch)
 
-        if "h5io" in ALLOWED_BACKENDS:
+        if "h5io" in Workflow.allowed_backends():
             wf.add_child(PlusOne(label="local_but_importable"))
             try:
                 wf.storage_backend = "h5io"
@@ -418,7 +418,7 @@ class TestWorkflow(unittest.TestCase):
             finally:
                 wf.storage.delete()
 
-        if "tinybase" in ALLOWED_BACKENDS:
+        if "tinybase" in Workflow.allowed_backends():
             with self.assertRaises(
                 NotImplementedError,
                 msg="Storage docs for tinybase claim all children must be registered "
@@ -427,7 +427,7 @@ class TestWorkflow(unittest.TestCase):
                 wf.storage_backend = "tinybase"
                 wf.save()
 
-        if "h5io" in ALLOWED_BACKENDS:
+        if "h5io" in Workflow.allowed_backends():
             with self.subTest("Instanced node"):
                 wf.direct_instance = Workflow.create.Function(plus_one)
                 try:
@@ -449,7 +449,7 @@ class TestWorkflow(unittest.TestCase):
 
             wf.unimportable_scope = UnimportableScope()
 
-            if "h5io" in ALLOWED_BACKENDS:
+            if "h5io" in Workflow.allowed_backends():
                 try:
                     with self.assertRaises(
                         TypeNotFoundError,


### PR DESCRIPTION

There are some public-facing methods that are removed, but honestly I'm so confident they weren't used anywhere but the plumbing that I'm still labelling this as a "patch":
- I got rid of the `class_name` attribute and just use `__class__.__name__` directly
- I got rid of the global `pyiron_workflow.storage.ALLOWED_BACKENDS` -- this is now created dynamically as a class attribute based on what mixins are used and can be accessed from `Node.allowed_backends()`

And there are a couple of new interfaces:
- There's some extra public facing methods around `storage_directory`, `storage_path`, etc. which are there to avoid `HasStorage` from inheriting from `Semantic` or `HasWorkingDirectory` but are just re-directions
- `delete_storage` now gives an easy way to delete save files for _all_ backends

But other than renaming for `ALLOWED_BACKENDS` and `class_name`, the tests required zero modifications, so this really is just a refactoring. (`test_node` has a bigger diff, but that's just because I added a cleanup failsafe that gives QoL if those tests happen to fail, which they did during development.)

This refactoring isn't perfect, for instance the fact that `storage_directory`, `storage_path` are simple re-directs to `HasWorkingDirectory.working_directory` and `Node.graph_path`, respectively (and similar redirects) is a smell that something is off in the mixin encapsulation. But I don't want to make the perfect the enemy of the good here, and this PR very nicely breaks apart the storage interfaces so that the different backends are disentangled into their own classes, which I like a lot.

Contributes to #243 