### PR TITLE
[patch] Revert warning and test for the graphviz call+windows combination

### DIFF
--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import sys
 from abc import ABC
 from concurrent.futures import Future
-import platform
 from typing import Any, Literal, Optional, TYPE_CHECKING
 import warnings
 
@@ -647,16 +646,8 @@ class Node(
         Returns:
             (graphviz.graphs.Digraph): The resulting graph object.
 
-        Warnings:
-            Rendering a PDF format appears to not be working on Windows right now.
         """
-        if format == "pdf" and platform.system() == "Windows":
-            warnings.warn(
-                "Graphviz does not appear to be playing well with Windows right now,"
-                "this will probably fail and you will need to try a different format."
-                "If it _doesn't_ fail, please contact the developers by raising an "
-                "issue at github.com/pyiron/pyiron_workflow"
-            )
+
         if size is not None:
             size = f"{size[0]},{size[1]}"
         graph = GraphvizNode(self, depth=depth, rankdir=rankdir, size=size).graph

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -1,7 +1,5 @@
 from concurrent.futures import Future
 import os
-import platform
-from subprocess import CalledProcessError
 import sys
 from typing import Literal, Optional
 import unittest
@@ -322,29 +320,17 @@ class TestNode(unittest.TestCase):
 
             for fmt in ["pdf", "png"]:
                 with self.subTest(f"Testing with format {fmt}"):
-                    if fmt == "pdf" and platform.system() == "Windows":
-                        with self.assertRaises(
-                            CalledProcessError,
-                            msg="Graphviz doesn't seem to be happy about the "
-                                "combindation PDF format and Windows right now. We "
-                                "throw a warning for it in `Node.draw`, so if this "
-                                "test ever fails and this combination _doesn't_ fail, "
-                                "remove this extra bit of testing and remove the "
-                                "warning."
-                        ):
-                            self.n1.draw(save=True, format=fmt)
-                    else:
-                        self.n1.draw(save=True, format=fmt)
-                        expected_name = self.n1.label + "_graph." + fmt
-                        # That name is just an implementation detail, update it as
-                        # needed
-                        self.assertTrue(
-                            self.n1.working_directory.path.joinpath(
-                                expected_name
-                            ).is_file(),
-                            msg="If `save` is called, expect the rendered image to "
-                                "exist in the working directory"
-                        )
+                    self.n1.draw(save=True, format=fmt)
+                    expected_name = self.n1.label + "_graph." + fmt
+                    # That name is just an implementation detail, update it as
+                    # needed
+                    self.assertTrue(
+                        self.n1.working_directory.path.joinpath(
+                            expected_name
+                        ).is_file(),
+                        msg="If `save` is called, expect the rendered image to "
+                            "exist in the working directory"
+                    )
 
             user_specified_name = "foo"
             self.n1.draw(filename=user_specified_name, format=fmt)


### PR DESCRIPTION
Whatever was broken in the upstream dependency or github image seems to be fixed.