### PR TITLE
[minor] Function selflessly

### DIFF
--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -242,6 +242,19 @@ class TestFunction(unittest.TestCase):
         self.assertFalse(n.running)
         self.assertTrue(n.failed)
 
+    def test_protected_name(self):
+        @as_function_node()
+        def Selfish(self, x):
+            return x
+
+        n = Selfish()
+        with self.assertRaises(
+            ValueError,
+            msg="When we try to build inputs, we should run into the fact that inputs "
+                "can't overlap with __init__ signature terms"
+        ):
+            n.inputs
+
     def test_call(self):
         node = function_node(no_default, output_labels="output")
 

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -242,62 +242,6 @@ class TestFunction(unittest.TestCase):
         self.assertFalse(n.running)
         self.assertTrue(n.failed)
 
-    def test_with_self(self):
-        def with_self(self, x: float) -> float:
-            # Note: Adding internal state to the node like this goes against the best
-            #  practice of keeping nodes "functional". Following python's paradigm of
-            #  giving users lots of power, we want to guarantee that this behaviour is
-            #  _possible_.
-            if "some_counter" in self._user_data:
-                self._user_data["some_counter"] += 1
-            else:
-                self._user_data["some_counter"] = 1
-            return x + 0.1
-
-        node = function_node(with_self, output_labels="output")
-        self.assertTrue(
-            "x" in node.inputs.labels,
-            msg=f"Expected to find function input 'x' in the node input but got "
-                f"{node.inputs.labels}"
-        )
-        self.assertFalse(
-            "self" in node.inputs.labels,
-            msg="Expected 'self' to be filtered out of node input, but found it in the "
-                "input labels"
-        )
-        node.inputs.x = 1.0
-        node.run()
-        self.assertEqual(
-            node.outputs.output.value,
-            1.1,
-            msg="Basic node functionality appears to have failed"
-        )
-        self.assertEqual(
-            node._user_data["some_counter"],
-            1,
-            msg="node_function should be able to modify attributes on the node "
-                "object."
-        )
-
-        node.executor = Executor()
-        with self.assertRaises(
-            ValueError,
-            msg="We haven't implemented any way to update a function node's `self` when"
-                "it runs on an executor, so trying to do so should fail hard"
-        ):
-            node.run()
-            node.executor_shutdown()  # Shouldn't get this far, but if we do shutdown
-        node.executor = None
-
-        def with_messed_self(x: float, self) -> float:
-            return x + 0.1
-
-        with warnings.catch_warnings(record=True) as warning_list:
-            node = function_node(with_messed_self)
-            self.assertTrue("self" in node.inputs.labels)
-
-        self.assertEqual(len(warning_list), 1)
-
     def test_call(self):
         node = function_node(no_default, output_labels="output")
 


### PR DESCRIPTION
Currently, we jump through some hoops to let users pass `self` as a special argument for `Function` nodes. This didn't show up in the node input, and under the hood the node instance got passed in for that argument. You could do things like this:

```python
from pyiron_workflow import Workflow

@Workflow.wrap_as.function_node()
def Selfish(self, x):
    self.some_attribute = 5
    return x

n = Selfish()
print(n.inputs.labels)
>>> ["x"]

n(x=42)
print(n.some_attribute)
>>> 5
```

Now we don't, and `self` is treated just like any other `Function` node argument, which means it bumps right into the protection we have in place to stop people from using terms already in the `Function.__init__` signature (this protection allows input to be set as `**kwargs`)

```python
from pyiron_workflow import Workflow

@Workflow.wrap.as_function_node()
def Selfish(self, x):
    self.some_attribute = 5
    return x

n = Selfish()
print(n.inputs.labels)
>>> ValueError: The Input channel name self is not valid. Please choose a name _not_ among ['self', 'args', 'label', 'parent', 'overwrite_save', 'run_after_init', 'storage_backend', 'save_after_run', 'kwargs']
```

I like for a bunch of reasons:
- Function nodes should behave functionally, so let's not explicitly give the user tools to break that
- The `self` argument didn't play well with executors, so there were special exceptions to fail early and non-universal behaviour
- Accommodating this took extra special-case code and increased maintenance cost
- It seems very in line with @JNmpi's sentiment at the last meeting about how nodes should not be having extra properties

I.e. if you want state, use a state-ful `Macro` node and hold the state as IO of one of its children.

Non-goals: 
- Failing early, like when the node class is defined, instead of waiting for the `input` to be accessed. I want this, and it should be easy, but it pertains to _all_ protected signature items and is out of scope here.


EDIT: python syntax highlighting on the examples