### PR TITLE
[patch] Scrape macro output

### DIFF
--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -314,6 +314,11 @@ class Macro(Composite, ABC):
         """
         graph_creator_returns = ParseOutput(cls.graph_creator).output
         output_labels = cls._get_output_labels()
+        if output_labels is not None and len(set(output_labels)) != len(output_labels):
+            raise ValueError(
+                f"{cls.__name__} must not have degenerate output labels: "
+                f"{output_labels}"
+            )
         if graph_creator_returns is not None or output_labels is not None:
             error_suffix = (
                 f"but {cls.__name__} macro class got return values: "

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -5,7 +5,7 @@ interface and are not intended to be internally modified after instantiation.
 
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 import inspect
 from typing import Any, get_args, get_type_hints, Literal, Optional, TYPE_CHECKING
 import warnings
@@ -297,6 +297,11 @@ class Macro(Composite, ABC):
         self._configure_graph_execution(remaining_ui_nodes)
 
         self.set_input_values(**kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def graph_creator(self, *args, **kwargs) -> callable:
+        """Build the graph the node will run."""
 
     @classmethod
     def _validate_output_labels(cls) -> tuple[str]:

--- a/tests/unit/test_macro.py
+++ b/tests/unit/test_macro.py
@@ -480,6 +480,17 @@ class TestMacro(unittest.TestCase):
             def MissingReturn(macro):
                 macro.foo = macro.create.standard.UserInput()
 
+        with self.assertRaises(
+            ValueError,
+            msg="Degenerate output labels should not be allowed"
+        ):
+            @as_macro_node()
+            def DegenerateOutput(macro):
+                macro.foo = macro.create.standard.UserInput()
+                macro.bar = macro.create.standard.UserInput(macro.foo)
+                bar = macro.foo
+                return bar, macro.bar
+
     def test_functionlike_io_parsing(self):
         """
         Check that various aspects of the IO are parsing from the function signature


### PR DESCRIPTION
Just like Function nodes do, but additionally implicitly left-strips the first argument `macro.` (or `self.` or `wf.` or whatever the `graph_creator`'s first self-like argument is called)

E.g. we now allow 

```python
from pyiron_workflow import Workflow

@Workflow.wrap.as_macro_node()
def Example(self, x):
    self.some_functionality = Workflow.create.standard.UserInput(x)
    return self.some_functionality

Example.preview_output_channels()
>>> {'some_functionality': None}
```