### PR TITLE
Post-facto provenance

### DIFF
--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -6,6 +6,7 @@ sub-graph
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from time import sleep
 from typing import Literal, Optional, TYPE_CHECKING
 
 from pyiron_workflow.create import HasCreator
@@ -16,7 +17,9 @@ from pyiron_workflow.snippets.colors import SeabornColors
 from pyiron_workflow.snippets.dotdict import DotDict
 
 if TYPE_CHECKING:
-    from pyiron_workflow.channels import Channel, InputData, OutputData
+    from pyiron_workflow.channels import (
+        Channel, InputData, OutputData, InputSignal, OutputSignal
+    )
     from pyiron_workflow.create import Creator, Wrappers
 
 
@@ -69,6 +72,12 @@ class Composite(Node, SemanticParent, HasCreator, ABC):
          with an index and the assignment proceeds. (Default is true: disallow assigning
          to existing labels.)
         create (Creator): A tool for adding new nodes to this subgraph.
+        provenance_by_completion (list[str]): The child nodes (by label) in the order
+            that they completed on the last :meth:`run` call.
+        provenance_by_execution (list[str]): The child nodes (by label) in the order
+            that they started executing on the last :meth:`run` call.
+        running_children (list[str]): The names of children who are currently running.
+        signal_queue (list[
         starting_nodes (None | list[pyiron_workflow.node.Node]): A subset
          of the owned nodes to be used on running. Only necessary if the execution graph
          has been manually specified with `run` signals. (Default is an empty list.)
@@ -107,6 +116,12 @@ class Composite(Node, SemanticParent, HasCreator, ABC):
             **kwargs,
         )
         self.starting_nodes: list[Node] = []
+        self.provenance_by_execution: list[str] = []
+        self.provenance_by_completion: list[str] = []
+        self.running_children: list[str] = []
+        self.signal_queue: list[tuple] = []
+        self._child_sleep_interval = 0.01  # How long to wait when the signal_queue is
+        # empty but the running_children list is not
 
     def activate_strict_hints(self):
         super().activate_strict_hints()
@@ -130,9 +145,69 @@ class Composite(Node, SemanticParent, HasCreator, ABC):
 
     @staticmethod
     def run_graph(_composite: Composite):
+        # Reset provenance and run status trackers
+        _composite.provenance_by_execution = []
+        _composite.provenance_by_completion = []
+        _composite.running_children = []
+        _composite.signal_queue = []
+
         for node in _composite.starting_nodes:
             node.run()
+
+        while (
+            len(_composite.running_children) > 0
+            or len(_composite.signal_queue) > 0
+        ):
+            try:
+                ran_signal, receiver = _composite.signal_queue.pop(0)
+                receiver(ran_signal)
+            except IndexError:
+                # The signal queue is empty, but there is still someone running...
+                sleep(_composite._child_sleep_interval)
+
         return _composite
+
+    def register_child_starting(self, child: Node) -> None:
+        """
+        To be called by children when they start their run cycle.
+
+        Args:
+            child [Node]: The child that is finished and would like to fire its `ran`
+                signal. Should always be a child of `self`, but this is not explicitly
+                verified at runtime.
+        """
+        self.provenance_by_execution.append(child.label)
+        self.running_children.append(child.label)
+
+    def register_child_finished(self, child: Node) -> None:
+        """
+        To be called by children when they are finished their run.
+
+        Args:
+            child [Node]: The child that is finished and would like to fire its `ran`
+                signal. Should always be a child of `self`, but this is not explicitly
+                verified at runtime.
+        """
+        try:
+            self.running_children.remove(child.label)
+            self.provenance_by_completion.append(child.label)
+        except ValueError as e:
+            raise KeyError(
+                f"No element {child.label} to remove while {self.running_children}, "
+                f"{self.provenance_by_execution}, {self.provenance_by_completion}"
+            ) from e
+
+    def register_child_emitting_ran(self, child: Node) -> None:
+        """
+        To be called by children when they want to emit their `ran` signal.
+
+        Args:
+            child [Node]: The child that is finished and would like to fire its `ran`
+                signal. Should always be a child of `self`, but this is not explicitly
+                verified at runtime.
+        """
+        for conn in child.signals.output.ran.connections:
+            self.signal_queue.append((child.signals.output.ran, conn))
 
     @property
     def run_args(self) -> dict:

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -493,7 +493,7 @@ class Node(
             disconnected_pairs, starters = set_run_connections_according_to_linear_dag(
                 nodes
             )
-            starter = starters[0]
+            data_tree_starters = set(starters).intersection(data_tree_nodes)
         except Exception as e:
             # If the dag setup fails it will repair any connections it breaks before
             # raising the error, but we still need to repair our label changes
@@ -507,8 +507,9 @@ class Node(
         try:
             # If you're the only one in the data tree, there's nothing upstream to run
             # Otherwise...
-            if starter is not self:
-                starter.run()  # Now push from the top
+            for starter in data_tree_starters:
+                if starter is not self:
+                    starter.run()  # Now push from the top
         finally:
             # No matter what, restore the original connections and labels afterwards
             for modified_label, node in nodes.items():

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -493,7 +493,7 @@ class Node(
             disconnected_pairs, starters = set_run_connections_according_to_linear_dag(
                 nodes
             )
-            data_tree_starters = set(starters).intersection(data_tree_nodes)
+            data_tree_starters = list(set(starters).intersection(data_tree_nodes))
         except Exception as e:
             # If the dag setup fails it will repair any connections it breaks before
             # raising the error, but we still need to repair our label changes
@@ -502,7 +502,7 @@ class Node(
             raise e
 
         try:
-            if len(data_tree_starters) == 1 and list(data_tree_starters)[0] is self:
+            if len(data_tree_starters) == 1 and data_tree_starters[0] is self:
                 # If you're the only one in the data tree, there's nothing upstream to
                 # run.
                 pass
@@ -515,8 +515,12 @@ class Node(
                 self.signals.disconnect_run()
                 # Don't let anything upstream trigger _this_ node
 
+                # if self.parent is None:
                 for starter in data_tree_starters:
                     starter.run()  # Now push from the top
+                # else:
+                #     parent_starting_nodes = self.parent.starting_nodes
+                #     self.parent.starting_nodes =
         finally:
             # No matter what, restore the original connections and labels afterwards
             for modified_label, node in nodes.items():

--- a/tests/integration/test_provenance.py
+++ b/tests/integration/test_provenance.py
@@ -1,0 +1,108 @@
+from concurrent.futures import ThreadPoolExecutor
+from time import sleep
+import unittest
+
+from pyiron_workflow.workflow import Workflow
+
+
+class TestProvenance(unittest.TestCase):
+    """
+    Verify that the post-facto provenance record works, even under complex conditions
+    like nested composites and executors.
+    """
+
+    def setUp(self) -> None:
+        @Workflow.wrap.as_function_node()
+        def Slow(t):
+            sleep(t)
+            return t
+
+        @Workflow.wrap.as_macro_node()
+        def Provenance(self, t):
+            self.fast = Workflow.create.standard.UserInput(t)
+            self.slow = Slow(t)
+            self.double = self.fast + self.slow
+            return self.double
+
+        wf = Workflow("provenance")
+        wf.time = Workflow.create.standard.UserInput(2)
+        wf.prov = Provenance(t=wf.time)
+        wf.post = wf.prov + 2
+        self.wf = wf
+        self.expected_post = {
+            wf.post.scoped_label: (2 * wf.time.inputs.user_input.value) + 2
+        }
+
+    def test_executed_provenance(self):
+        with ThreadPoolExecutor() as exe:
+            self.wf.prov.executor = exe
+            out = self.wf()
+
+        self.assertDictEqual(
+            self.expected_post,
+            out,
+            msg="Sanity check that the graph is executing ok"
+        )
+
+        self.assertListEqual(
+            ['time', 'prov', 'post'],
+            self.wf.provenance_by_execution,
+            msg="Even with a child running on an executor, provenance should log"
+        )
+
+        self.assertListEqual(
+            self.wf.provenance_by_execution,
+            self.wf.provenance_by_completion,
+            msg="The workflow itself is serial and these should be identical."
+        )
+
+        self.assertListEqual(
+            ['t', 'slow', 'fast', 'double'],
+            self.wf.prov.provenance_by_execution,
+            msg="Later connections get priority over earlier connections, so we expect "
+                "the t-node to trigger 'slow' before 'fast'"
+        )
+
+        self.assertListEqual(
+            self.wf.prov.provenance_by_execution,
+            self.wf.prov.provenance_by_completion,
+            msg="The macro is running on an executor, but its children are in serial,"
+                "so completion and execution order should be the same"
+        )
+
+    def test_execution_vs_completion(self):
+
+        with ThreadPoolExecutor(max_workers=2) as exe:
+            self.wf.prov.fast.executor = exe
+            self.wf.prov.slow.executor = exe
+            out = self.wf()
+
+        self.assertDictEqual(
+            self.expected_post,
+            out,
+            msg="Sanity check that the graph is executing ok"
+        )
+
+        self.assertListEqual(
+            ['t', 'slow', 'fast', 'double'],
+            self.wf.prov.provenance_by_execution,
+            msg="Later connections get priority over earlier connections, so we expect "
+                "the t-node to trigger 'slow' before 'fast'"
+        )
+
+        self.assertListEqual(
+            ['t', 'fast', 'slow', 'double'],
+            self.wf.prov.provenance_by_completion,
+            msg="Since 'slow' is slow it shouldn't _finish_ until after 'fast' (but "
+                "still before 'double' since 'double' depends on 'slow')"
+        )
+
+        self.assertListEqual(
+            self.wf.provenance_by_execution,
+            self.wf.provenance_by_completion,
+            msg="The workflow itself is serial and these should be identical."
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This introduces post-facto provenance to executed composites (both macros and workflows) in the form of child label lists. @JNmpi, this closes a feature gap we had with other workflow managers.

There are separate lists for the _execution_ order and the _completion_ order, since these can differ under certain conditions where an executor is used for parallelism and the time required for different children differs significantly. this feature and the basic syntax are shown below:

```python
from time import sleep

from pyiron_workflow import Workflow

@Workflow.wrap.as_function_node()
def Slow(t):
    sleep(t)
    return t

@Workflow.wrap.as_macro_node()
def Provenance(self, t):
    self.fast = Workflow.create.standard.UserInput(t)
    self.slow = Slow(t)
    self.double = self.fast + self.slow
    return self.double
    

wf = Workflow("provenance")
wf.time = Workflow.create.standard.UserInput(2)
wf.prov = Provenance(t=wf.time)
wf.post = wf.prov + 2
        
with Workflow.create.Executor(max_workers=2) as exe:
    wf.prov.fast.executor = exe
    wf.prov.slow.executor = exe
    wf()

print("wf by execution", wf.provenance_by_execution)
print("wf by completion", wf.provenance_by_completion)
print("macro by execution", wf.prov.provenance_by_execution)
print("macro by completion", wf.prov.provenance_by_completion)
>>> wf by execution ['time', 'prov', 'post']
>>> wf by completion ['time', 'prov', 'post']
>>> macro by execution ['t', 'slow', 'fast', 'double']
>>> macro by completion ['t', 'fast', 'slow', 'double']
```

Under the hood, nodes without parents behave just like they always did: when they finish, they emit their `ran` signal, which triggers downstream nodes. However, nodes _with_ parents now allow their parent to manage execution by interacting with the parent's `register_child_starting`, `register_child_finished`, and `register_child_emitting_ran` interfaces, which control the provenance lists as well as lists of nodes currently running and of signal pairs waiting to be fired. Running a composite then has a `while` loop over both running nodes and signal pairs having lengths >0.

This has a nice side-effect of shortening the stack when an error is encountered during the run, since children always just go up to their parent and then stop, instead of having to trace back through every node. This resolves the recursion limit bug with while-loops and closes #247. (The provenance for while-nodes is sensible, but not super informative -- just their children again and again and again.)

The only thing I really don't like is `Node.pull` in the presence of a `Workflow` parent required some nasty hacking to get `Workflow` to stop automating the flow and ruining the careful orchestration of execution signals that `pull` uses to run only the relevant portion of the upstream graph. I don't see a more clever solution right now, and so I'm very open to suggestions for improvement, but am willing to tolerate a few lines of ugliness in `Node.pull` to get the entire feature off the ground.

Non-goals:
- A nice graphical representation of the post-facto provenance. In principle this should be possible by modifying `Composite.draw` to (depending on a flag) pass in one of the provenance lists and use it to draw some extra arrows.