### PR TITLE
[patch] Refactor static node

### DIFF
--- a/pyiron_workflow/composite.py
+++ b/pyiron_workflow/composite.py
@@ -247,31 +247,6 @@ class Composite(Node, SemanticParent, HasCreator, ABC):
         _, upstream_most_nodes = set_run_connections_according_to_dag(self.children)
         self.starting_nodes = upstream_most_nodes
 
-    @abstractmethod
-    def _get_linking_channel(
-        self,
-        child_reference_channel: InputData | OutputData,
-        composite_io_key: str,
-    ) -> InputData | OutputData:
-        """
-        Returns the channel that will be the link between the provided child channel,
-        and the composite's IO at the given key.
-
-        The returned channel should be fully compatible with the provided child channel,
-        i.e. same type, same type hint... (For instance, the child channel itself is a
-        valid return, which would create a composite IO panel that works by reference.)
-
-        Args:
-            child_reference_channel (InputData | OutputData): The child channel
-            composite_io_key (str): The key under which this channel will be stored on
-                the composite's IO.
-
-        Returns:
-            (Channel): A channel with the same type, type hint, etc. as the reference
-                channel passed in.
-        """
-        pass
-
     def add_child(
         self,
         child: Node,

--- a/pyiron_workflow/function.py
+++ b/pyiron_workflow/function.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Literal, Optional, TYPE_CHECKING
 
-from pyiron_workflow.channels import InputData
-from pyiron_workflow.injection import OutputDataWithInjection
-from pyiron_workflow.io import Inputs, Outputs
 from pyiron_workflow.io_preview import DecoratedNode, decorated_node_decorator_factory
 from pyiron_workflow.snippets.colors import SeabornColors
 
@@ -314,11 +311,7 @@ class Function(DecoratedNode, ABC):
             parent=parent,
             save_after_run=save_after_run,
             storage_backend=storage_backend,
-            # **kwargs,
         )
-
-        self._inputs = None
-        self._outputs = None
 
         self.set_input_values(*args, **kwargs)
 
@@ -336,39 +329,6 @@ class Function(DecoratedNode, ABC):
         preview = super(Function, cls).preview_outputs()
         return preview if len(preview) > 0 else {"None": type(None)}
         # If clause facilitates functions with no return value
-
-    @property
-    def outputs(self) -> Outputs:
-        if self._outputs is None:
-            self._outputs = Outputs(*self._build_output_channels())
-        return self._outputs
-
-    def _build_output_channels(self):
-        return [
-            OutputDataWithInjection(
-                label=label,
-                owner=self,
-                type_hint=hint,
-            )
-            for label, hint in self.preview_outputs().items()
-        ]
-
-    @property
-    def inputs(self) -> Inputs:
-        if self._inputs is None:
-            self._inputs = Inputs(*self._build_input_channels())
-        return self._inputs
-
-    def _build_input_channels(self):
-        return [
-            InputData(
-                label=label,
-                owner=self,
-                default=default,
-                type_hint=type_hint,
-            )
-            for label, (type_hint, default) in self.preview_inputs().items()
-        ]
 
     @property
     def on_run(self):

--- a/pyiron_workflow/injection.py
+++ b/pyiron_workflow/injection.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any, Optional, TYPE_CHECKING
 
-from pyiron_workflow.channels import OutputData, NOT_DATA, InputData
+from pyiron_workflow.channels import OutputData, NOT_DATA
 from pyiron_workflow.has_interface_mixins import HasChannel
 from pyiron_workflow.io import Outputs, HasIO
 
@@ -44,7 +44,7 @@ class OutputDataWithInjection(OutputData):
         default: Optional[Any] = NOT_DATA,
         type_hint: Optional[Any] = None,
         strict_hints: bool = True,
-        value_receiver: Optional[InputData] = None,
+        value_receiver: Optional[OutputData] = None,
     ):
         # Override parent method to give the new owner type hint
         super().__init__(

--- a/pyiron_workflow/io_preview.py
+++ b/pyiron_workflow/io_preview.py
@@ -328,14 +328,16 @@ class StaticNode(Node, HasIOPreview, ABC):
             ]
         )
 
-        self._outputs = OutputsWithInjection(*[
-            OutputDataWithInjection(
-                label=label,
-                owner=self,
-                type_hint=hint,
-            )
-            for label, hint in self.preview_outputs().items()
-        ])
+        self._outputs = OutputsWithInjection(
+            *[
+                OutputDataWithInjection(
+                    label=label,
+                    owner=self,
+                    type_hint=hint,
+                )
+                for label, hint in self.preview_outputs().items()
+            ]
+        )
 
     @property
     def inputs(self) -> Inputs:

--- a/pyiron_workflow/io_preview.py
+++ b/pyiron_workflow/io_preview.py
@@ -17,12 +17,17 @@ import warnings
 from abc import ABC, abstractmethod
 from textwrap import dedent
 from types import FunctionType
-from typing import Any, get_args, get_type_hints
+from typing import Any, get_args, get_type_hints, Literal, Optional, TYPE_CHECKING
 
-from pyiron_workflow.channels import NOT_DATA
+from pyiron_workflow.channels import InputData, NOT_DATA
+from pyiron_workflow.injection import OutputDataWithInjection, OutputsWithInjection
+from pyiron_workflow.io import Inputs
 from pyiron_workflow.node import Node
 from pyiron_workflow.output_parser import ParseOutput
 from pyiron_workflow.snippets.dotdict import DotDict
+
+if TYPE_CHECKING:
+    from pyiron_workflow.composite import Composite
 
 
 class HasIOPreview(ABC):
@@ -287,7 +292,58 @@ class OutputLabelsNotValidated(Warning):
 
 
 class StaticNode(Node, HasIOPreview, ABC):
-    """A node whose IO specification is available at the class level."""
+    """
+    A node whose IO specification is available at the class level.
+
+    Actual IO is then constructed from the preview at instantiation.
+    """
+
+    def __init__(
+        self,
+        label: str,
+        *args,
+        parent: Optional[Composite] = None,
+        overwrite_save: bool = False,
+        run_after_init: bool = False,
+        storage_backend: Optional[Literal["h5io", "tinybase"]] = None,
+        save_after_run: bool = False,
+        **kwargs,
+    ):
+        super().__init__(
+            label=label,
+            parent=parent,
+            save_after_run=save_after_run,
+            storage_backend=storage_backend,
+        )
+
+        self._inputs = Inputs(
+            *[
+                InputData(
+                    label=label,
+                    owner=self,
+                    default=default,
+                    type_hint=type_hint,
+                )
+                for label, (type_hint, default) in self.preview_inputs().items()
+            ]
+        )
+
+        self._outputs = OutputsWithInjection(*[
+            OutputDataWithInjection(
+                label=label,
+                owner=self,
+                type_hint=hint,
+            )
+            for label, hint in self.preview_outputs().items()
+        ])
+
+    @property
+    def inputs(self) -> Inputs:
+        return self._inputs
+
+    @property
+    def outputs(self) -> OutputsWithInjection:
+        return self._outputs
 
 
 class DecoratedNode(StaticNode, ScrapesIO, ABC):

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -9,7 +9,6 @@ from abc import ABC, abstractmethod
 import re
 from typing import Literal, Optional, TYPE_CHECKING
 
-from pyiron_workflow.channels import InputData, OutputData
 from pyiron_workflow.composite import Composite
 from pyiron_workflow.has_interface_mixins import HasChannel
 from pyiron_workflow.io import Outputs, Inputs

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -271,12 +271,12 @@ class Macro(Composite, DecoratedNode, ABC):
         elif isinstance(returned_has_channel_objects, HasChannel):
             returned_has_channel_objects = (returned_has_channel_objects,)
         self._inputs = Inputs(
-            *(self._get_linking_channel(n.inputs.user_input, n.label) for n in ui_nodes)
+            *(self._build_value_linking_channel(n.inputs.user_input, n.label) for n in ui_nodes)
         )
 
         self._outputs = Outputs(
             *(
-                self._get_linking_channel(c.channel, label)
+                self._build_value_linking_channel(c.channel, label)
                 for (c, label) in zip(
                     (
                         ()
@@ -339,7 +339,7 @@ class Macro(Composite, DecoratedNode, ABC):
             for label, (type_hint, default) in self.preview_inputs().items()
         )
 
-    def _get_linking_channel(
+    def _build_value_linking_channel(
         self,
         child_reference_channel: InputData | OutputData,
         composite_io_key: str,

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -275,7 +275,7 @@ class Macro(Composite, DecoratedNode, ABC):
 
         for node, output_channel_label in zip(
             returned_has_channel_objects,
-            () if self._output_labels is None else self._output_labels
+            () if self._output_labels is None else self._output_labels,
         ):
             node.channel.value_receiver = self.outputs[output_channel_label]
 

--- a/pyiron_workflow/macro.py
+++ b/pyiron_workflow/macro.py
@@ -270,23 +270,15 @@ class Macro(Composite, DecoratedNode, ABC):
             returned_has_channel_objects = ()
         elif isinstance(returned_has_channel_objects, HasChannel):
             returned_has_channel_objects = (returned_has_channel_objects,)
-        self._inputs = Inputs(
-            *(self._build_value_linking_channel(n.inputs.user_input, n.label) for n in ui_nodes)
-        )
 
-        self._outputs = Outputs(
-            *(
-                self._build_value_linking_channel(c.channel, label)
-                for (c, label) in zip(
-                    (
-                        ()
-                        if returned_has_channel_objects is None
-                        else returned_has_channel_objects
-                    ),
-                    (() if self._output_labels is None else self._output_labels),
-                )
-            )
-        )
+        for node in ui_nodes:
+            self.inputs[node.label].value_receiver = node.inputs.user_input
+
+        for node, output_channel_label in zip(
+            returned_has_channel_objects,
+            () if self._output_labels is None else self._output_labels
+        ):
+            node.channel.value_receiver = self.outputs[output_channel_label]
 
         remaining_ui_nodes = self._purge_single_use_ui_nodes(ui_nodes)
         self._configure_graph_execution(remaining_ui_nodes)
@@ -338,37 +330,6 @@ class Macro(Composite, DecoratedNode, ABC):
             )
             for label, (type_hint, default) in self.preview_inputs().items()
         )
-
-    def _build_value_linking_channel(
-        self,
-        child_reference_channel: InputData | OutputData,
-        composite_io_key: str,
-    ) -> InputData | OutputData:
-        """
-        Build IO by value: create a new channel just like the child's channel.
-
-        In the case of input data, we also form a value link from the composite channel
-        down to the child channel, so that the child will stay up-to-date.
-        """
-        composite_channel = child_reference_channel.__class__(
-            label=composite_io_key,
-            owner=self,
-            default=child_reference_channel.default,
-            type_hint=child_reference_channel.type_hint,
-        )
-        composite_channel.value = child_reference_channel.value
-
-        if isinstance(composite_channel, InputData):
-            composite_channel.strict_hints = child_reference_channel.strict_hints
-            composite_channel.value_receiver = child_reference_channel
-        elif isinstance(composite_channel, OutputData):
-            child_reference_channel.value_receiver = composite_channel
-        else:
-            raise TypeError(
-                "This should not be an accessible state, please contact the developers"
-            )
-
-        return composite_channel
 
     def _purge_single_use_ui_nodes(self, ui_nodes):
         """

--- a/pyiron_workflow/workflow.py
+++ b/pyiron_workflow/workflow.py
@@ -261,16 +261,6 @@ class Workflow(Composite, ParentMost):
                 if v is None:
                     some_map[k] = (None, f"{k} disabled")
 
-    def _get_linking_channel(
-        self,
-        child_reference_channel: InputData | OutputData,
-        composite_io_key: str,
-    ) -> InputData | OutputData:
-        """
-        Build IO by reference: just return the child's channel itself.
-        """
-        return child_reference_channel
-
     @property
     def inputs(self) -> Inputs:
         return self._build_inputs()
@@ -318,14 +308,10 @@ class Workflow(Composite, ParentMost):
                         # Tuples indicate that the channel has been deactivated
                         # This is a necessary misdirection to keep the bidict working,
                         # as we can't simply map _multiple_ keys to `None`
-                        io[io_panel_key] = self._get_linking_channel(
-                            channel, io_panel_key
-                        )
+                        io[io_panel_key] = channel
                 except KeyError:
                     if not channel.connected:
-                        io[channel.scoped_label] = self._get_linking_channel(
-                            channel, channel.scoped_label
-                        )
+                        io[channel.scoped_label] = channel
         return io
 
     def run(


### PR DESCRIPTION
`StaticNode` guarantees that the node's IO specification is available at the class level; here we pull up the IO construction in `Function` to this parent class level, and leverage it also in `Macro` (currently the only other child in the `DecoratedNode(StaticNode)` inheritance tree). The somewhat complex node creation in `Macro` is then simplified to creating value links between the child graph and the macro's IO (already created by the `StaticNode` portion of the `super().__init__` call). As a side effect I got to remove a handful of methods on related classes. This is all purely under-the hood streamlining and required no test modification or UI changes.