### PR TITLE
:fire: :bug: Don't pull on input nodes

### DIFF
--- a/pyiron_workflow/for_loop.py
+++ b/pyiron_workflow/for_loop.py
@@ -273,7 +273,13 @@ class For(Composite, StaticNode, ABC):
                 # -- it will see data it can work with, but if that data happens to
                 # have the wrong length it may successfully auto-run on the wrong thing
                 # and throw an error!
-                self.children[label]()
+                self.children[label].run(
+                    run_data_tree=False,
+                    run_parent_trees_too=False,
+                    fetch_input=False
+                    # Data should simply be coming from the value link
+                    # We just want to refresh the output
+                )
         # TODO: Instead of deleting _everything_ each time, try and re-use stuff
 
     def _build_collector_node(self, row_number):

--- a/pyiron_workflow/for_loop.py
+++ b/pyiron_workflow/for_loop.py
@@ -276,7 +276,7 @@ class For(Composite, StaticNode, ABC):
                 self.children[label].run(
                     run_data_tree=False,
                     run_parent_trees_too=False,
-                    fetch_input=False
+                    fetch_input=False,
                     # Data should simply be coming from the value link
                     # We just want to refresh the output
                 )


### PR DESCRIPTION
A simple call invokes a pull, including pulling the parent tree -- this blows up when the loop is inside a parent scope instead of alone. Since we _know_ these are just user input nodes with direct value connections to the loop macro's scope, we never need to run the pull, or indeed even a fetch the value.

Before, this caused trouble, now it's fine:

```python
from pyiron_workflow import Workflow

@Workflow.wrap.as_macro_node()
def LoopInside(self, x, y):
    self.to_list = Workflow.create.transformer.inputs_to_list(
        3, y, y, y
    )
    self.loop = Workflow.create.for_node(
        Workflow.create.standard.Add,
        iter_on=("obj", "other",),
        obj=x,
        other=self.to_list
    )
    return self.loop

li = LoopInside([1, 2], 4)
li().loop
```