### PR TITLE
[patch] Bump CI target

### DIFF
--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -24,7 +24,6 @@ if [ -d "${HOME}/pyiron_workflow" ]; then
             ${HOME}/CONTRIBUTING.rst \
             ${HOME}/LICENSE \
             ${HOME}/MANIFEST.in \
-            ${HOME}/setup.cfg \
             ${HOME}/setup.py \
             ${HOME}/versioneer.py
 fi

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   codeql:
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-3.1.0
+    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-3.2.0
     secrets: inherit
     with:
       extra-python-paths: tests tests/benchmark tests/integration tests/static tests/unit  # For pympipool

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/dependabot-pr.yml@actions-3.1.0
+    uses: pyiron/actions/.github/workflows/dependabot-pr.yml@actions-3.2.0
     secrets: inherit

--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-labeled.yml@actions-3.1.0
+    uses: pyiron/actions/.github/workflows/pr-labeled.yml@actions-3.2.0
     secrets: inherit

--- a/.github/workflows/pr-target-opened.yml
+++ b/.github/workflows/pr-target-opened.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-target-opened.yml@hotfix_binder_button
+    uses: pyiron/actions/.github/workflows/pr-target-opened.yml@actions-3.2.0
     secrets: inherit

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-3.1.0
+    uses: pyiron/actions/.github/workflows/push-pull.yml@actions-3.2.0
     secrets: inherit
     with:
       docs-env-files: .ci_support/environment.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pyproject-release.yml@actions-3.1.0
+    uses: pyiron/actions/.github/workflows/pyproject-release.yml@actions-3.2.0
     secrets: inherit
     with:
       semantic-upper-bound: 'minor'

--- a/.github/workflows/test-latest-release.yml
+++ b/.github/workflows/test-latest-release.yml
@@ -35,13 +35,13 @@ jobs:
           echo -e "channels:\n- conda-forge\ndependencies:\n- ${{ github.event.repository.name }}" > ./just_this_package_environment.yml
           cat ./just_this_package_environment.yml
           echo `pwd`
-      - uses: pyiron/actions/cached-miniforge@main
+      - uses: pyiron/actions/cached-miniforge@actions-3.2.0
         with:
           python-version: '3.12'
           env-files: ./just_this_package_environment.yml
           local-code-directory: ''
-      - uses: pyiron/actions/pyiron-config@main
-      - uses: pyiron/actions/add-to-python-path@main
+      - uses: pyiron/actions/pyiron-config@actions-3.2.0
+      - uses: pyiron/actions/add-to-python-path@actions-3.2.0
         with:  # This is specific to getting the pympipool tests to work
           path-dirs: tests tests/benchmark tests/integration tests/static tests/unit
       - name: Test

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   codeql:
-    uses: pyiron/actions/.github/workflows/codeql.yml@actions-3.1.0
+    uses: pyiron/actions/.github/workflows/codeql.yml@actions-3.2.0
     secrets: inherit


### PR DESCRIPTION
The binder button is patched, so centralized CI targeting is now uniform