### PR TITLE
[patch] Better error messages

### DIFF
--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -103,6 +103,11 @@ class Channel(UsesState, HasChannel, HasLabel, HasToDict, ABC):
         """A label combining the channel's usual label and its owner's label"""
         return f"{self.owner.label}__{self.label}"
 
+    @property
+    def full_label(self) -> str:
+        """A label combining the channel's usual label and its owner's semantic path"""
+        return f"{self.owner.full_label}.{self.label}"
+
     def _valid_connection(self, other: Channel) -> bool:
         """
         Logic for determining if a connection is valid.

--- a/pyiron_workflow/io.py
+++ b/pyiron_workflow/io.py
@@ -220,9 +220,9 @@ class Outputs(DataIO):
 class SignalIO(IO, ABC):
     def _assign_a_non_channel_value(self, channel: SignalChannel, value) -> None:
         raise TypeError(
-            f"Tried to assign {value} ({type(value)} to the {channel.label}, which is "
-            f"already a {type(channel)}. Only other signal channels may be connected "
-            f"in this way."
+            f"Tried to assign {value} ({type(value)} to the {channel.full_label}, "
+            f"which is already a {type(channel)}. Only other signal channels may be "
+            f"connected in this way."
         )
 
 

--- a/pyiron_workflow/mixin/has_interface_mixins.py
+++ b/pyiron_workflow/mixin/has_interface_mixins.py
@@ -44,6 +44,14 @@ class HasLabel(ABC):
     def label(self) -> str:
         """A label for the object."""
 
+    @property
+    def full_label(self) -> str:
+        """
+        A more verbose label based off the underlying label attribute (and possibly
+        other data) -- in the root class, it's just the same as the label.
+        """
+        return self.label
+
 
 class HasParent(ABC):
     """

--- a/pyiron_workflow/mixin/injection.py
+++ b/pyiron_workflow/mixin/injection.py
@@ -113,10 +113,10 @@ class OutputDataWithInjection(OutputData):
             )
         if name.startswith("_"):
             raise AttributeError(
-                f"{OutputDataWithInjection.__name__} {self.label} tried to inject on "
-                f"the attribute {name}, but injecting on private attributes is "
-                f"forbidden -- if you really need it create a {GetAttr.__name__} node "
-                f"manually."
+                f"{self.full_label} ({OutputDataWithInjection.__name__}) tried to "
+                f"inject on the attribute {name}, but injecting on private attributes "
+                f"is forbidden -- if you really need it create a {GetAttr.__name__} "
+                f"node manually."
             )
         return self._node_injection(GetAttr, name)
 

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -86,6 +86,13 @@ class Semantic(UsesState, HasLabel, HasParent, ABC):
         return prefix + self.semantic_delimiter + self.label
 
     @property
+    def full_label(self) -> str:
+        """
+        A shortcut that combines the semantic path and label into a single string.
+        """
+        return self.semantic_path
+
+    @property
     def semantic_root(self) -> Semantic:
         """The parent-most object in this semantic path; may be self."""
         return self.parent.semantic_root if isinstance(self.parent, Semantic) else self

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -369,14 +369,15 @@ class Node(
 
         if do_load and run_after_init:
             raise ValueError(
-                "Can't both load _and_ run after init -- either delete the save file "
-                "(e.g. with with the `overwrite_save=True` kwarg), change the node "
-                "label to work in a new space, or give up on running after init."
+                f"{self.full_label} can't both load _and_ run after init -- either"
+                f" delete the save file (e.g. with with the `overwrite_save=True` "
+                f"kwarg), change the node label to work in a new space, or give up on "
+                f"running after init."
             )
         elif do_load:
             logger.info(
-                f"A saved file was found for the node {self.label} -- attempting to "
-                f"load it...(To delete the saved file instead, use "
+                f"A saved file was found for the node {self.full_label} -- "
+                f"attempting to load it...(To delete the saved file instead, use "
                 f"`overwrite_save=True`)"
             )
             self.load()
@@ -522,8 +523,9 @@ class Node(
             if node.executor is not None:
                 raise ValueError(
                     f"Running the data tree is pull-paradigm action, and is "
-                    f"incompatible with using executors. An executor request was found "
-                    f"on {node.label}"
+                    f"incompatible with using executors. While running "
+                    f"{self.full_label}, an executor request was found on "
+                    f"{node.full_label}"
                 )
 
         for node in data_tree_nodes:

--- a/pyiron_workflow/nodes/function.py
+++ b/pyiron_workflow/nodes/function.py
@@ -151,7 +151,7 @@ class Function(StaticNode, ScrapesIO, ABC):
         ...     plus_minus_1.inputs.x =  "not an int or float"
         ... except TypeError as e:
         ...     print("TypeError:", e.args[0])
-        TypeError: The channel x cannot take the value `not an int or float` because it is not compliant with the type hint typing.Union[int, float]
+        TypeError: The channel /hinted_example.x cannot take the value `not an int or float` (<class 'str'>) because it is not compliant with the type hint typing.Union[int, float]
 
         We can turn off type hinting with the `strict_hints` boolean property, or just
         circumvent the type hinting by applying the new data directly to the private

--- a/pyiron_workflow/nodes/macro.py
+++ b/pyiron_workflow/nodes/macro.py
@@ -398,7 +398,7 @@ class Macro(Composite, StaticNode, ScrapesIO, ABC):
             self.set_run_signals_to_dag_execution()
         else:
             raise ValueError(
-                f"The macro '{self.label}' has {len(run_signals)} run signals "
+                f"The macro {self.full_label} has {len(run_signals)} run signals "
                 f"internally and {len(self.starting_nodes)} starting nodes. Either "
                 f"the entire execution graph must be specified manually, or both run "
                 f"signals and starting nodes must be left entirely unspecified for "

--- a/pyiron_workflow/nodes/static_io.py
+++ b/pyiron_workflow/nodes/static_io.py
@@ -141,6 +141,6 @@ class StaticNode(Node, HasIOPreview, ABC):
         non_input_kwargs = set(presumed_input_keys).difference(self.inputs.labels)
         if len(non_input_kwargs) > 0:
             raise ValueError(
-                f"{self.label} cannot iterate on {non_input_kwargs} because they are "
-                f"not among input channels {self.inputs.labels}"
+                f"{self.full_label} cannot iterate on {non_input_kwargs} because "
+                f"they are not among input channels {self.inputs.labels}"
             )

--- a/pyiron_workflow/topology.py
+++ b/pyiron_workflow/topology.py
@@ -45,9 +45,10 @@ def nodes_to_data_digraph(nodes: dict[str, Node]) -> dict[str, set[str]]:
 
     parent = next(iter(nodes.values())).parent  # Just grab any one
     if not all(n.parent is parent for n in nodes.values()):
+        node_identifiers = "\n".join([n.full_label for n in nodes.values()])
         raise ValueError(
-            "Nodes in a data digraph must all be siblings -- i.e. have the same "
-            "`parent` attribute."
+            f"Nodes in a data digraph must all be siblings -- i.e. have the same "
+            f"`parent` attribute. Some of these do not: {node_identifiers}"
         )
 
     for node in nodes.values():
@@ -59,18 +60,17 @@ def nodes_to_data_digraph(nodes: dict[str, Node]) -> dict[str, set[str]]:
                     upstream_node = nodes[upstream.owner.label]
                 except KeyError as e:
                     raise KeyError(
-                        f"The {channel.label} channel of {node.label} has a connection "
-                        f"to {upstream.label} channel of {upstream.owner.label}, but "
-                        f"{upstream.owner.label} was not found among nodes. All nodes "
-                        f"in the data flow dependency tree must be included."
+                        f"The channel {channel.full_label} has a connection to the "
+                        f"upstream channel {upstream.full_label}, but the upstream "
+                        f"owner {upstream.owner.label} was not found among nodes. "
+                        f"All nodes in the data flow dependency tree must be included."
                     )
                 if upstream_node is not upstream.owner:
                     raise ValueError(
-                        f"The {channel.label} channel of {node.label} has a connection "
-                        f"to {upstream.label} channel of {upstream.owner.label}, but "
-                        f"that channel's node is not the same as the nodes passed "
-                        f"here. All nodes in the data flow dependency tree must be "
-                        f"included."
+                        f"The channel {channel.full_label} has a connection to the "
+                        f"upstream channel {upstream.full_label}, but that channel's "
+                        f"node is not the same as the nodes passed  here. All nodes in "
+                        f"the data flow dependency tree must be included."
                     )
                 locally_scoped_dependencies.append(upstream.owner.label)
             node_dependencies.extend(locally_scoped_dependencies)
@@ -81,7 +81,8 @@ def nodes_to_data_digraph(nodes: dict[str, Node]) -> dict[str, set[str]]:
             # That self-dependency isn't caught, so we catch it manually here.
             raise CircularDataFlowError(
                 f"Detected a cycle in the data flow topology, unable to automate "
-                f"the execution of non-DAGs: {node.label} appears in its own input."
+                f"the execution of non-DAGs: {node.full_label} appears in its own "
+                f"input."
             )
         digraph[node.label] = node_dependencies
 

--- a/pyiron_workflow/workflow.py
+++ b/pyiron_workflow/workflow.py
@@ -441,7 +441,7 @@ class Workflow(ParentMost, Composite):
             self._inputs = old_inputs
             self._outputs = old_outputs
             e.message = (
-                f"Unable to rebuild IO for {self.label}; reverting to old IO."
+                f"Unable to rebuild IO for {self.full_label}; reverting to old IO."
                 f"{e.message}"
             )
             raise e
@@ -545,13 +545,14 @@ class Workflow(ParentMost, Composite):
             node.package_identifier is None for node in self
         ):
             raise NotImplementedError(
-                f"{self.__class__.__name__} can currently only save itself to file if "
-                f"_all_ of its child nodes were created via the creator and have an "
-                f"associated `package_identifier` -- otherwise we won't know how to "
-                f"re-instantiate them at load time! Right now this is as easy as "
-                f"moving your custom nodes to their own .py file and registering it "
-                f"like any other node package. Remember that this new module needs to "
-                f"be in your python path and importable at load time too."
+                f"{self.full_label} ({self.__class__.__name__}) can currently only "
+                f"save itself to file if _all_ of its child nodes were created via the "
+                f"creator and have an associated `package_identifier` -- otherwise we "
+                f"won't know how to re-instantiate them at load time! Right now this "
+                f"is as easy as moving your custom nodes to their own .py file and "
+                f"registering it like any other node package. Remember that this new "
+                f"module needs to be in your python path and importable at load time "
+                f"too."
             )
         super().save()
 

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -12,6 +12,10 @@ class DummyOwner:
         self.locked = False
         self.label = "owner_label"
 
+    @property
+    def full_label(self):
+        return self.label
+
     def update(self):
         self.foo.append(self.foo[-1] + 1)
 


### PR DESCRIPTION
Adds a new property `HasLabel.full_label`; for `HasLabel` it's identical to `label`, but for `Node` it uses the semantic path, and for `Channel` it uses the owner's `full_label` plus the channel `label`.