### PR TITLE
[minor] Hash injection labels

### DIFF
--- a/pyiron_workflow/mixin/injection.py
+++ b/pyiron_workflow/mixin/injection.py
@@ -62,10 +62,6 @@ class OutputDataWithInjection(OutputData):
             other.channel.scoped_label if isinstance(other, HasChannel) else str(other)
         )
 
-    def get_injected_label(self, injection_class, other=None):
-        suffix = f"_{self._other_label(other)}" if other is not None else ""
-        return f"{self.scoped_label}_{injection_class.__name__}{suffix}"
-
     def _get_injection_label(self, injection_class, *args):
         other_labels = "_".join(self._other_label(other) for other in args)
         suffix = f"_{other_labels}" if len(args) > 0 else ""

--- a/pyiron_workflow/mixin/injection.py
+++ b/pyiron_workflow/mixin/injection.py
@@ -65,7 +65,9 @@ class OutputDataWithInjection(OutputData):
     def _get_injection_label(self, injection_class, *args):
         other_labels = "_".join(self._other_label(other) for other in args)
         suffix = f"_{other_labels}" if len(args) > 0 else ""
-        return f"{self.scoped_label}_{injection_class.__name__}{suffix}"
+        nominal_label = f"{self.scoped_label}_{injection_class.__name__}{suffix}"
+        hashed = str(hash(nominal_label)).replace("-", "m")
+        return f"injected_{injection_class.__name__}_{hashed}"
 
     def _node_injection(self, injection_class, *args, inject_self=True):
         """

--- a/pyiron_workflow/nodes/standard.py
+++ b/pyiron_workflow/nodes/standard.py
@@ -793,6 +793,7 @@ nodes = [
     AppendToList,
     Bool,
     Bytes,
+    ChangeDirectory,
     Contains,
     Dir,
     Divide,


### PR DESCRIPTION
Working on a use case, the injection labels quickly got too long for the filesystem. For very short injection paths it was nice having the provenance of the injection listed right in the name, but it quickly gets silly. Anyhow, the provenance is still there in the graph connections. Now, instead, lean on hashes for the name. The class of the injection is still included, to give at least some quick idea what it's there for when looking at the label.

Also snuck in a hotfix for the last PR.

This is minor because it removes an (unused) public method, and because it may screw up loading old save files that had injected nodes. I don't expect either of these to present a practical problem.