### PR TITLE
[patch] Composite serialization bugs

### DIFF
--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -218,10 +218,14 @@ class Composite(SemanticParent, HasCreator, Node, ABC):
         for node in self:
             node._parent = None
         other_self.running = False  # It's done now
+        state = self._get_state_from_remote_other(other_self)
+        self.__setstate__(state)
+
+    def _get_state_from_remote_other(self, other_self):
         state = other_self.__getstate__()
         state.pop("executor")  # Got overridden to None for __getstate__, so keep local
         state.pop("_parent")  # Got overridden to None for __getstate__, so keep local
-        self.__setstate__(state)
+        return state
 
     def disconnect_run(self) -> list[tuple[Channel, Channel]]:
         """

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -220,6 +220,7 @@ class Composite(SemanticParent, HasCreator, Node, ABC):
         other_self.running = False  # It's done now
         state = other_self.__getstate__()
         state.pop("executor")  # Got overridden to None for __getstate__, so keep local
+        state.pop("_parent")  # Got overridden to None for __getstate__, so keep local
         self.__setstate__(state)
 
     def disconnect_run(self) -> list[tuple[Channel, Channel]]:

--- a/pyiron_workflow/nodes/for_loop.py
+++ b/pyiron_workflow/nodes/for_loop.py
@@ -347,6 +347,17 @@ class For(Composite, StaticNode, ABC):
     def _build_outputs_preview(cls) -> dict[str, Any]:
         return {"df": DataFrame}
 
+    def __getstate__(self):
+        state = super().__getstate__()
+        state["body_node_executor"] = None
+        return state
+
+    def _get_state_from_remote_other(self, other_self):
+        state = super()._get_state_from_remote_other(other_self)
+        state.pop("body_node_executor")  # Got overridden to None for __getstate__,
+        # so keep local
+        return state
+
 
 def _for_node_class_name(
     body_node_class: type[StaticNode], iter_on: tuple[str, ...], zip_on: tuple[str, ...]

--- a/pyiron_workflow/nodes/macro.py
+++ b/pyiron_workflow/nodes/macro.py
@@ -495,6 +495,7 @@ def macro_node_factory(
         {
             "graph_creator": staticmethod(graph_creator),
             "__module__": graph_creator.__module__,
+            "__qualname__": graph_creator.__qualname__,
             "_output_labels": None if len(output_labels) == 0 else output_labels,
             "_validate_output_labels": validate_output_labels,
             "__doc__": graph_creator.__doc__,

--- a/tests/unit/nodes/test_for_loop.py
+++ b/tests/unit/nodes/test_for_loop.py
@@ -327,6 +327,14 @@ class TestForNode(unittest.TestCase):
                 f"Expected limit {grace} x {t_sleep} = {grace * t_sleep} -- got {dt}"
         )
 
+        reloaded = pickle.loads(pickle.dumps(for_parallel))
+        self.assertIsNone(
+            reloaded.body_node_executor,
+            msg="Just like regular nodes, until executors can be delayed creators "
+                "instead of actual executor nodes, we need to purge executors from "
+                "nodes on serialization or the thread lock/queue objects hit us"
+        )
+
     def test_with_connections(self):
         length_y = 3
 


### PR DESCRIPTION
I ran into a few issues when I tried to put a macro as the body node in a for-loop, just a couple of bugs in the (de)serialization. The actual fixes are just a couple lines, and the rest is tests that fail when the bugfixes aren't there.