### PR TITLE
[patch] :fire: :bug: remove semantic children from the state on __setstate__

### DIFF
--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -334,8 +334,12 @@ class SemanticParent(Semantic, ABC):
 
     def __setstate__(self, state):
         # Reconstruct children from state
+        # Remove them from the state as you go, so they don't hang around in the
+        # __dict__ after we set state -- they were only there to start with to guarantee
+        # that the state path and the semantic path matched (i.e. without ".children."
+        # in between)
         state["_children"] = bidict(
-            {label: state[label] for label in state.pop("child_labels")}
+            {label: state.pop(label) for label in state.pop("child_labels")}
         )
 
         super().__setstate__(state)


### PR DESCRIPTION
This is the inverse operation to adding them to the state in __getstate__. Without this, in the subsequent super call, all these children wind up in __dict__.