### PR TITLE
Remove the extra python paths args from CI

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,5 +11,3 @@ jobs:
   codeql:
     uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-3.2.1
     secrets: inherit
-    with:
-      extra-python-paths: tests tests/benchmark tests/integration tests/static tests/unit  # For executorlib

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -14,7 +14,6 @@ jobs:
     with:
       docs-env-files: .ci_support/environment.yml
       notebooks-env-files: .ci_support/environment.yml
-      extra-python-paths: tests tests/benchmark tests/integration tests/static tests/unit  # For executorlib
       python-version-alt3: 'exclude'  # No python 3.9
       alternate-tests-env-files: .ci_support/lower_bound.yml
       alternate-tests-python-version: '3.10'


### PR DESCRIPTION
To see if executorlib has overcome this necessity that pympipool had