### PR TITLE
[patch] Fail to cache when equality comparison throws an exception

### DIFF
--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -630,7 +630,10 @@ class Node(
 
     @property
     def cache_hit(self):
-        return self.inputs.to_value_dict() == self.cached_inputs
+        try:
+            return self.inputs.to_value_dict() == self.cached_inputs
+        except:
+            return False
 
     def _outputs_to_run_return(self):
         return DotDict(self.outputs.to_value_dict())


### PR DESCRIPTION
E.g. when comparing a numpy array to None. We continue greedily caching, but if it just doesn't work for some reason, the fallback is to simply not cache. Since the current and cached inputs (along with whether or not they generate a cache hit) is always available to the user, I think we still leave enough data for people to debug cache misses on their own.

Otherwise you need to manually disable caching when input has data types that don't play nicely with comparisons. That means you can work around this, so it's not a critical bug, but it's annoying enough I'll probably release a patch version again this week to get rid of the problem.