### PR TITLE
[patch] Pickle storage backend

### DIFF
--- a/notebooks/deepdive.ipynb
+++ b/notebooks/deepdive.ipynb
@@ -5521,15 +5521,18 @@
     "- Also related, there is currently zero filtering of which data, or to which depth the graph gets stored -- it's all or nothing\n",
     "- If the source code for nodes gets modified between saving and loading, weird stuff is likely to happen, and some of it may happen silently.\n",
     "\n",
-    "Lastly, we currently use two backends: `tinybase.storage.H5ioStorage` and `h5io` directly. They have slightly different strengths:\n",
-    "- `\"h5io\"` (the default) \n",
+    "Lastly, we currently use three backends: `pickle`, ``tinybase.storage.H5ioStorage` and `h5io` directly. They have slightly different strengths:\n",
+    "- `\"h5io\"` \n",
     "  - Will let you save and load any nodes that defined by subclassing (this includes all nodes defined using the decorators)\n",
     "  - Will preserve changes to a macro (replace/add/remove/rewire)\n",
     "  - Has trouble with some data\n",
     "- `\"tinybase\"`\n",
     "  - Requires all nodes to have been instantiated with the creator (`wf.create...`; this means moving node definitions to a `.py` file in your pythonpath and registering it as a node package -- not particularly difficult!)\n",
     "  - _Ignores_ changes to a macro (will crash nicely if the macro IO changed)\n",
-    "  - Falls back to `pickle` for data failures, so can handle a wider variety of data IO objects"
+    "  - Falls back to `pickle` for data failures, so can handle a wider variety of data IO objects\n",
+    "- `\"pickle\"`\n",
+    "  - Can't handle unpickleable IO items, if that's a problem for your data\n",
+    "  - Stored in byte format; not browsable and needs to be loaded to inspect it at all"
    ]
   },
   {

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -102,7 +102,7 @@ class Composite(SemanticParent, HasCreator, Node, ABC):
         parent: Optional[Composite] = None,
         overwrite_save: bool = False,
         run_after_init: bool = False,
-        storage_backend: Optional[Literal["h5io", "tinybase"]] = None,
+        storage_backend: Optional[Literal["h5io", "tinybase", "pickle"]] = None,
         save_after_run: bool = False,
         strict_naming: bool = True,
         **kwargs,

--- a/pyiron_workflow/nodes/for_loop.py
+++ b/pyiron_workflow/nodes/for_loop.py
@@ -201,7 +201,7 @@ class For(Composite, StaticNode, ABC):
         parent: Optional[Composite] = None,
         overwrite_save: bool = False,
         run_after_init: bool = False,
-        storage_backend: Optional[Literal["h5io", "tinybase"]] = None,
+        storage_backend: Optional[Literal["h5io", "tinybase", "pickle"]] = None,
         save_after_run: bool = False,
         strict_naming: bool = True,
         body_node_executor: Optional[Executor] = None,

--- a/pyiron_workflow/nodes/macro.py
+++ b/pyiron_workflow/nodes/macro.py
@@ -302,7 +302,7 @@ class Macro(Composite, StaticNode, ScrapesIO, ABC):
             return scraped_labels
 
     def _prepopulate_ui_nodes_from_graph_creator_signature(
-        self, storage_backend: Literal["h5io", "tinybase"]
+        self, storage_backend: Literal["h5io", "tinybase", "pickle"]
     ):
         ui_nodes = []
         for label, (type_hint, default) in self.preview_inputs().items():

--- a/pyiron_workflow/nodes/static_io.py
+++ b/pyiron_workflow/nodes/static_io.py
@@ -32,7 +32,7 @@ class StaticNode(Node, HasIOPreview, ABC):
         parent: Optional[Composite] = None,
         overwrite_save: bool = False,
         run_after_init: bool = False,
-        storage_backend: Optional[Literal["h5io", "tinybase"]] = None,
+        storage_backend: Optional[Literal["h5io", "tinybase", "pickle"]] = None,
         save_after_run: bool = False,
         **kwargs,
     ):

--- a/pyiron_workflow/workflow.py
+++ b/pyiron_workflow/workflow.py
@@ -204,7 +204,7 @@ class Workflow(ParentMost, Composite):
         *nodes: Node,
         overwrite_save: bool = False,
         run_after_init: bool = False,
-        storage_backend: Optional[Literal["h5io", "tinybase"]] = None,
+        storage_backend: Optional[Literal["h5io", "tinybase", "pickle"]] = None,
         save_after_run: bool = False,
         strict_naming: bool = True,
         inputs_map: Optional[dict | bidict] = None,

--- a/tests/unit/nodes/test_macro.py
+++ b/tests/unit/nodes/test_macro.py
@@ -488,7 +488,6 @@ class TestMacro(unittest.TestCase):
                         Macro.create.demo.AddPlusOne()
                     )
 
-
                     modified_result = macro()
 
                     if backend == "h5io":

--- a/tests/unit/nodes/test_macro.py
+++ b/tests/unit/nodes/test_macro.py
@@ -496,7 +496,7 @@ class TestMacro(unittest.TestCase):
                             TypeError, msg="h5io can't handle custom reconstructors"
                         ):
                             macro.save()
-                    else:
+                    elif backend == "tinybase":
                         macro.save()
                         reloaded = Macro.create.demo.AddThree(
                             label="m", storage_backend=backend
@@ -524,15 +524,16 @@ class TestMacro(unittest.TestCase):
                         )
                         rerun = reloaded()
 
-                        if backend == "tinybase":
-                            self.assertDictEqual(
-                                original_result,
-                                rerun,
-                                msg="Rerunning should re-execute the _original_ "
-                                    "functionality"
-                            )
-                        else:
-                            raise ValueError(f"Unexpected backend {backend}?")
+                        self.assertDictEqual(
+                            original_result,
+                            rerun,
+                            msg="Rerunning should re-execute the _original_ "
+                                "functionality"
+                        )
+                    else:
+                        raise ValueError(
+                            f"Backend {backend} not recognized -- write a test for it"
+                        )
                 finally:
                     macro.storage.delete()
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -446,7 +446,7 @@ class TestWorkflow(unittest.TestCase):
             with self.subTest(backend):
                 try:
                     print("Trying", backend)
-                    wf = Workflow("wf", storage_backend=backend)
+                    wf = Workflow("wf_values", storage_backend=backend)
                     wf.register("static.demo_nodes", domain="demo")
                     wf.inp = wf.create.demo.AddThree(x=0)
                     wf.out = wf.inp.outputs.add_three + 1
@@ -461,7 +461,7 @@ class TestWorkflow(unittest.TestCase):
                             wf.save()
                     else:
                         wf.save()
-                        reloaded = Workflow("wf", storage_backend=backend)
+                        reloaded = Workflow("wf_values", storage_backend=backend)
                         self.assertEqual(
                             wf_out.out__add,
                             reloaded.outputs.out__add.value,

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -507,20 +507,20 @@ class TestWorkflow(unittest.TestCase):
                         wf.storage.delete()
 
         with self.subTest("No unimportable nodes for either back-end"):
-            try:
-                wf.import_type_mismatch = wf.create.demo.dynamic()
-                for backend in Workflow.allowed_backends():
+            for backend in Workflow.allowed_backends():
+                try:
+                    wf.import_type_mismatch = wf.create.demo.dynamic()
                     with self.subTest(backend):
-                        with self.assertRaises(
-                            TypeNotFoundError,
-                            msg="Imported object is function but node type is node -- "
-                                "should fail early on save"
-                        ):
-                            wf.storage_backend = backend
-                            wf.save()
-            finally:
-                wf.remove_child(wf.import_type_mismatch)
-                wf.storage.delete()
+                            with self.assertRaises(
+                                TypeNotFoundError,
+                                msg="Imported object is function but node type is node "
+                                    "-- should fail early on save"
+                            ):
+                                wf.storage_backend = backend
+                                wf.save()
+                finally:
+                    wf.remove_child(wf.import_type_mismatch)
+                    wf.storage.delete()
 
         if "h5io" in Workflow.allowed_backends():
             wf.add_child(PlusOne(label="local_but_importable"))

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -446,7 +446,7 @@ class TestWorkflow(unittest.TestCase):
             with self.subTest(backend):
                 try:
                     print("Trying", backend)
-                    wf = Workflow("wf_values", storage_backend=backend)
+                    wf = Workflow("wf", storage_backend=backend)
                     wf.register("static.demo_nodes", domain="demo")
                     wf.inp = wf.create.demo.AddThree(x=0)
                     wf.out = wf.inp.outputs.add_three + 1
@@ -461,7 +461,7 @@ class TestWorkflow(unittest.TestCase):
                             wf.save()
                     else:
                         wf.save()
-                        reloaded = Workflow("wf_values", storage_backend=backend)
+                        reloaded = Workflow("wf", storage_backend=backend)
                         self.assertEqual(
                             wf_out.out__add,
                             reloaded.outputs.out__add.value,
@@ -488,8 +488,8 @@ class TestWorkflow(unittest.TestCase):
 
         for backend in Workflow.allowed_backends():
             with self.subTest(backend):
-                try:
-                    for backend in Workflow.allowed_backends():
+                for backend in Workflow.allowed_backends():
+                    try:
                         if backend == "h5io":
                             with self.subTest(backend):
                                 with self.assertRaises(
@@ -503,8 +503,8 @@ class TestWorkflow(unittest.TestCase):
                                 wf.storage_backend = backend
                                 wf.save()
                                 Workflow(wf.label, storage_backend=backend)
-                finally:
-                    wf.storage.delete()
+                    finally:
+                        wf.storage.delete()
 
         with self.subTest("No unimportable nodes for either back-end"):
             try:


### PR DESCRIPTION
This introduces a new `Node.storage_backend = "pickle"` that saves nodes to/from pickle files.

This is just a patch, but locally I experimented with the more significant change of making pickle the _default_ back-end, and the entire test suite still ran without a problem, so I'm optimistic the transition will be easy.

In the medium to long term, I still want something like h5 or json for the storage backend, because we want something browsable and (ideally) compatible with version controlling. In the short term, I just want something robust and straightforward.