### PR TITLE
[patch] `as_dataclass_node` pickle compatibility

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - pandas =2.2.2
 - pyiron_base =0.9.10
 - pyiron_contrib =0.1.17
-- pyiron_snippets =0.1.3
+- pyiron_snippets =0.1.4
 - python-graphviz =0.20.3
 - toposort =1.10
 - typeguard =4.3.0

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - pandas =2.2.2
 - pyiron_base =0.9.10
 - pyiron_contrib =0.1.17
-- pyiron_snippets =0.1.3
+- pyiron_snippets =0.1.4
 - python-graphviz =0.20.3
 - toposort =1.10
 - typeguard =4.3.0

--- a/.ci_support/lower_bound.yml
+++ b/.ci_support/lower_bound.yml
@@ -12,7 +12,7 @@ dependencies:
 - pandas =2.2.0
 - pyiron_base =0.8.3
 - pyiron_contrib =0.1.16
-- pyiron_snippets =0.1.0
+- pyiron_snippets =0.1.4
 - python-graphviz =0.20.0
 - toposort =1.10
 - typeguard =4.2.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,7 +18,7 @@ dependencies:
 - pandas =2.2.2
 - pyiron_base =0.9.10
 - pyiron_contrib =0.1.17
-- pyiron_snippets =0.1.3
+- pyiron_snippets =0.1.4
 - python-graphviz =0.20.3
 - toposort =1.10
 - typeguard =4.3.0

--- a/notebooks/deepdive.ipynb
+++ b/notebooks/deepdive.ipynb
@@ -5521,15 +5521,18 @@
     "- Also related, there is currently zero filtering of which data, or to which depth the graph gets stored -- it's all or nothing\n",
     "- If the source code for nodes gets modified between saving and loading, weird stuff is likely to happen, and some of it may happen silently.\n",
     "\n",
-    "Lastly, we currently use two backends: `tinybase.storage.H5ioStorage` and `h5io` directly. They have slightly different strengths:\n",
-    "- `\"h5io\"` (the default) \n",
+    "Lastly, we currently use three backends: `pickle`, ``tinybase.storage.H5ioStorage` and `h5io` directly. They have slightly different strengths:\n",
+    "- `\"h5io\"` \n",
     "  - Will let you save and load any nodes that defined by subclassing (this includes all nodes defined using the decorators)\n",
     "  - Will preserve changes to a macro (replace/add/remove/rewire)\n",
     "  - Has trouble with some data\n",
     "- `\"tinybase\"`\n",
     "  - Requires all nodes to have been instantiated with the creator (`wf.create...`; this means moving node definitions to a `.py` file in your pythonpath and registering it as a node package -- not particularly difficult!)\n",
     "  - _Ignores_ changes to a macro (will crash nicely if the macro IO changed)\n",
-    "  - Falls back to `pickle` for data failures, so can handle a wider variety of data IO objects"
+    "  - Falls back to `pickle` for data failures, so can handle a wider variety of data IO objects\n",
+    "- `\"pickle\"`\n",
+    "  - Can't handle unpickleable IO items, if that's a problem for your data\n",
+    "  - Stored in byte format; not browsable and needs to be loaded to inspect it at all"
    ]
   },
   {

--- a/pyiron_workflow/__init__.py
+++ b/pyiron_workflow/__init__.py
@@ -46,7 +46,7 @@ from pyiron_workflow.nodes.function import Function, as_function_node, function_
 from pyiron_workflow.logging import logger
 from pyiron_workflow.nodes.macro import Macro, as_macro_node, macro_node
 from pyiron_workflow.nodes.transform import (
-    # as_dataclass_node,  # Not pickling nicely yet
+    as_dataclass_node,
     dataclass_node,
     inputs_to_dataframe,
     inputs_to_dict,

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -102,7 +102,7 @@ class Composite(SemanticParent, HasCreator, Node, ABC):
         parent: Optional[Composite] = None,
         overwrite_save: bool = False,
         run_after_init: bool = False,
-        storage_backend: Optional[Literal["h5io", "tinybase"]] = None,
+        storage_backend: Optional[Literal["h5io", "tinybase", "pickle"]] = None,
         save_after_run: bool = False,
         strict_naming: bool = True,
         **kwargs,

--- a/pyiron_workflow/nodes/for_loop.py
+++ b/pyiron_workflow/nodes/for_loop.py
@@ -201,7 +201,7 @@ class For(Composite, StaticNode, ABC):
         parent: Optional[Composite] = None,
         overwrite_save: bool = False,
         run_after_init: bool = False,
-        storage_backend: Optional[Literal["h5io", "tinybase"]] = None,
+        storage_backend: Optional[Literal["h5io", "tinybase", "pickle"]] = None,
         save_after_run: bool = False,
         strict_naming: bool = True,
         body_node_executor: Optional[Executor] = None,

--- a/pyiron_workflow/nodes/function.py
+++ b/pyiron_workflow/nodes/function.py
@@ -421,7 +421,9 @@ def as_function_node(
         factory_made = function_node_factory(
             node_function, validate_output_labels, use_cache, *output_labels
         )
-        factory_made._class_returns_from_decorated_function = node_function
+        factory_made._reduce_imports_as = (
+            node_function.__module__, node_function.__qualname__
+        )
         factory_made.preview_io()
         return factory_made
 

--- a/pyiron_workflow/nodes/function.py
+++ b/pyiron_workflow/nodes/function.py
@@ -422,7 +422,8 @@ def as_function_node(
             node_function, validate_output_labels, use_cache, *output_labels
         )
         factory_made._reduce_imports_as = (
-            node_function.__module__, node_function.__qualname__
+            node_function.__module__,
+            node_function.__qualname__,
         )
         factory_made.preview_io()
         return factory_made

--- a/pyiron_workflow/nodes/macro.py
+++ b/pyiron_workflow/nodes/macro.py
@@ -302,7 +302,7 @@ class Macro(Composite, StaticNode, ScrapesIO, ABC):
             return scraped_labels
 
     def _prepopulate_ui_nodes_from_graph_creator_signature(
-        self, storage_backend: Literal["h5io", "tinybase"]
+        self, storage_backend: Literal["h5io", "tinybase", "pickle"]
     ):
         ui_nodes = []
         for label, (type_hint, default) in self.preview_inputs().items():

--- a/pyiron_workflow/nodes/macro.py
+++ b/pyiron_workflow/nodes/macro.py
@@ -535,7 +535,8 @@ def as_macro_node(
             graph_creator, validate_output_labels, use_cache, *output_labels
         )
         factory_made._reduce_imports_as = (
-            graph_creator.__module__, graph_creator.__qualname__
+            graph_creator.__module__,
+            graph_creator.__qualname__,
         )
         factory_made.preview_io()
         return factory_made

--- a/pyiron_workflow/nodes/macro.py
+++ b/pyiron_workflow/nodes/macro.py
@@ -534,7 +534,9 @@ def as_macro_node(
         factory_made = macro_node_factory(
             graph_creator, validate_output_labels, use_cache, *output_labels
         )
-        factory_made._class_returns_from_decorated_function = graph_creator
+        factory_made._reduce_imports_as = (
+            graph_creator.__module__, graph_creator.__qualname__
+        )
         factory_made.preview_io()
         return factory_made
 

--- a/pyiron_workflow/nodes/static_io.py
+++ b/pyiron_workflow/nodes/static_io.py
@@ -32,7 +32,7 @@ class StaticNode(Node, HasIOPreview, ABC):
         parent: Optional[Composite] = None,
         overwrite_save: bool = False,
         run_after_init: bool = False,
-        storage_backend: Optional[Literal["h5io", "tinybase"]] = None,
+        storage_backend: Optional[Literal["h5io", "tinybase", "pickle"]] = None,
         save_after_run: bool = False,
         **kwargs,
     ):

--- a/pyiron_workflow/nodes/transform.py
+++ b/pyiron_workflow/nodes/transform.py
@@ -453,6 +453,7 @@ def as_dataclass_node(dataclass: type):
         Foo(necessary='input as a node kwarg', bar='bar', answer=42, complex_=[1, 2, 3])
     """
     cls = dataclass_node_factory(dataclass)
+    cls._class_returns_from_decorated_function = dataclass
     cls.preview_io()
     return cls
 

--- a/pyiron_workflow/nodes/transform.py
+++ b/pyiron_workflow/nodes/transform.py
@@ -400,7 +400,7 @@ def dataclass_node_factory(
     )
 
 
-def as_dataclass_node(dataclass: type, use_cache: bool = True):
+def as_dataclass_node(dataclass: type):
     """
     Decorates a dataclass as a dataclass node -- i.e. a node whose inputs correspond
     to dataclass fields and whose output is an instance of the dataclass.
@@ -452,7 +452,7 @@ def as_dataclass_node(dataclass: type, use_cache: bool = True):
         >>> f(necessary="input as a node kwarg")
         Foo(necessary='input as a node kwarg', bar='bar', answer=42, complex_=[1, 2, 3])
     """
-    cls = dataclass_node_factory(dataclass, use_cache)
+    cls = dataclass_node_factory(dataclass)
     cls.preview_io()
     return cls
 

--- a/pyiron_workflow/nodes/transform.py
+++ b/pyiron_workflow/nodes/transform.py
@@ -443,7 +443,7 @@ def as_dataclass_node(dataclass: type):
         >>>
         >>> f = Foo()
         >>> print(f.readiness_report)
-        DataclassNodeFoo readiness: False
+        Foo readiness: False
         STATE:
         running: False
         failed: False
@@ -454,7 +454,7 @@ def as_dataclass_node(dataclass: type):
         complex_ ready: True
 
         >>> f(necessary="input as a node kwarg")
-        Foo(necessary='input as a node kwarg', bar='bar', answer=42, complex_=[1, 2, 3])
+        Foo.dataclass(necessary='input as a node kwarg', bar='bar', answer=42, complex_=[1, 2, 3])
     """
     dataclass_node_factory.clear(dataclass.__name__)  # Force a fresh class
     module, qualname = dataclass.__module__, dataclass.__qualname__
@@ -516,7 +516,7 @@ def dataclass_node(dataclass: type, use_cache: bool = True, *node_args, **node_k
         complex_ ready: True
 
         >>> f(necessary="input as a node kwarg")
-        Foo(necessary='input as a node kwarg', bar='bar', answer=42, complex_=[1, 2, 3])
+        Foo.dataclass(necessary='input as a node kwarg', bar='bar', answer=42, complex_=[1, 2, 3])
     """
     cls = dataclass_node_factory(dataclass)
     cls.preview_io()

--- a/pyiron_workflow/nodes/transform.py
+++ b/pyiron_workflow/nodes/transform.py
@@ -455,8 +455,9 @@ def as_dataclass_node(dataclass: type):
         Foo(necessary='input as a node kwarg', bar='bar', answer=42, complex_=[1, 2, 3])
     """
     dataclass_node_factory.clear(dataclass.__name__)  # Force a fresh class
+    module, qualname = dataclass.__module__, dataclass.__qualname__
     cls = dataclass_node_factory(dataclass)
-    cls._class_returns_from_decorated_function = dataclass
+    cls._reduce_imports_as = (module, qualname)
     cls.preview_io()
     return cls
 

--- a/pyiron_workflow/nodes/transform.py
+++ b/pyiron_workflow/nodes/transform.py
@@ -388,10 +388,12 @@ def dataclass_node_factory(
     if not is_dataclass(dataclass):
         dataclass = as_dataclass(dataclass)
     return (
-        f"{DataclassNode.__name__}{dataclass.__name__}",
+        dataclass.__name__,
         (DataclassNode,),
         {
             "dataclass": dataclass,
+            "__module__": dataclass.__module__,
+            "__qualname__": dataclass.__qualname__,
             "_output_type_hint": dataclass,
             "__doc__": dataclass.__doc__,
             "use_cache": use_cache,
@@ -452,6 +454,7 @@ def as_dataclass_node(dataclass: type):
         >>> f(necessary="input as a node kwarg")
         Foo(necessary='input as a node kwarg', bar='bar', answer=42, complex_=[1, 2, 3])
     """
+    dataclass_node_factory.clear(dataclass.__name__)  # Force a fresh class
     cls = dataclass_node_factory(dataclass)
     cls._class_returns_from_decorated_function = dataclass
     cls.preview_io()

--- a/pyiron_workflow/nodes/transform.py
+++ b/pyiron_workflow/nodes/transform.py
@@ -387,13 +387,15 @@ def dataclass_node_factory(
         )
     if not is_dataclass(dataclass):
         dataclass = as_dataclass(dataclass)
+    module, qualname = dataclass.__module__, dataclass.__qualname__
+    dataclass.__qualname__ += ".dataclass"  # So output type hints know where to find it
     return (
         dataclass.__name__,
         (DataclassNode,),
         {
             "dataclass": dataclass,
-            "__module__": dataclass.__module__,
-            "__qualname__": dataclass.__qualname__,
+            "__module__": module,
+            "__qualname__": qualname,
             "_output_type_hint": dataclass,
             "__doc__": dataclass.__doc__,
             "use_cache": use_cache,

--- a/pyiron_workflow/workflow.py
+++ b/pyiron_workflow/workflow.py
@@ -204,7 +204,7 @@ class Workflow(ParentMost, Composite):
         *nodes: Node,
         overwrite_save: bool = False,
         run_after_init: bool = False,
-        storage_backend: Optional[Literal["h5io", "tinybase"]] = None,
+        storage_backend: Optional[Literal["h5io", "tinybase", "pickle"]] = None,
         save_after_run: bool = False,
         strict_naming: bool = True,
         inputs_map: Optional[dict | bidict] = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "pandas==2.2.2",
     "pyiron_base==0.9.10",
     "pyiron_contrib==0.1.17",
-    "pyiron_snippets==0.1.3",
+    "pyiron_snippets==0.1.4",
     "toposort==1.10",
     "typeguard==4.3.0",
 ]

--- a/tests/unit/mixin/test_preview.py
+++ b/tests/unit/mixin/test_preview.py
@@ -46,7 +46,7 @@ def as_scraper(
         factory_made = scraper_factory(
             fnc, validate_output_labels, io_defining_function_uses_self, *output_labels
         )
-        factory_made._class_returns_from_decorated_function = fnc
+        factory_made._reduce_imports_as = (fnc.__module__, fnc.__qualname__)
         factory_made.preview_io()
         return factory_made
     return scraper_decorator

--- a/tests/unit/nodes/test_macro.py
+++ b/tests/unit/nodes/test_macro.py
@@ -488,7 +488,6 @@ class TestMacro(unittest.TestCase):
                         Macro.create.demo.AddPlusOne()
                     )
 
-
                     modified_result = macro()
 
                     if backend == "h5io":

--- a/tests/unit/nodes/test_macro.py
+++ b/tests/unit/nodes/test_macro.py
@@ -496,7 +496,7 @@ class TestMacro(unittest.TestCase):
                             TypeError, msg="h5io can't handle custom reconstructors"
                         ):
                             macro.save()
-                    else:
+                    elif backend == "tinybase":
                         macro.save()
                         reloaded = Macro.create.demo.AddThree(
                             label="m", storage_backend=backend
@@ -524,15 +524,16 @@ class TestMacro(unittest.TestCase):
                         )
                         rerun = reloaded()
 
-                        if backend == "tinybase":
-                            self.assertDictEqual(
-                                original_result,
-                                rerun,
-                                msg="Rerunning should re-execute the _original_ "
-                                    "functionality"
-                            )
-                        else:
-                            raise ValueError(f"Unexpected backend {backend}?")
+                        self.assertDictEqual(
+                            original_result,
+                            rerun,
+                            msg="Rerunning should re-execute the _original_ "
+                                "functionality"
+                        )
+                    else:
+                        raise ValueError(
+                            f"Backend {backend} not recognized -- write a test for it"
+                        )
                 finally:
                     macro.storage.delete()
 

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -446,7 +446,7 @@ class TestWorkflow(unittest.TestCase):
             with self.subTest(backend):
                 try:
                     print("Trying", backend)
-                    wf = Workflow("wf", storage_backend=backend)
+                    wf = Workflow("wf_values", storage_backend=backend)
                     wf.register("static.demo_nodes", domain="demo")
                     wf.inp = wf.create.demo.AddThree(x=0)
                     wf.out = wf.inp.outputs.add_three + 1
@@ -461,7 +461,7 @@ class TestWorkflow(unittest.TestCase):
                             wf.save()
                     else:
                         wf.save()
-                        reloaded = Workflow("wf", storage_backend=backend)
+                        reloaded = Workflow("wf_values", storage_backend=backend)
                         self.assertEqual(
                             wf_out.out__add,
                             reloaded.outputs.out__add.value,

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -507,20 +507,20 @@ class TestWorkflow(unittest.TestCase):
                         wf.storage.delete()
 
         with self.subTest("No unimportable nodes for either back-end"):
-            try:
-                wf.import_type_mismatch = wf.create.demo.dynamic()
-                for backend in Workflow.allowed_backends():
+            for backend in Workflow.allowed_backends():
+                try:
+                    wf.import_type_mismatch = wf.create.demo.dynamic()
                     with self.subTest(backend):
-                        with self.assertRaises(
-                            TypeNotFoundError,
-                            msg="Imported object is function but node type is node -- "
-                                "should fail early on save"
-                        ):
-                            wf.storage_backend = backend
-                            wf.save()
-            finally:
-                wf.remove_child(wf.import_type_mismatch)
-                wf.storage.delete()
+                            with self.assertRaises(
+                                TypeNotFoundError,
+                                msg="Imported object is function but node type is node "
+                                    "-- should fail early on save"
+                            ):
+                                wf.storage_backend = backend
+                                wf.save()
+                finally:
+                    wf.remove_child(wf.import_type_mismatch)
+                    wf.storage.delete()
 
         if "h5io" in Workflow.allowed_backends():
             wf.add_child(PlusOne(label="local_but_importable"))

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -446,7 +446,7 @@ class TestWorkflow(unittest.TestCase):
             with self.subTest(backend):
                 try:
                     print("Trying", backend)
-                    wf = Workflow("wf_values", storage_backend=backend)
+                    wf = Workflow("wf", storage_backend=backend)
                     wf.register("static.demo_nodes", domain="demo")
                     wf.inp = wf.create.demo.AddThree(x=0)
                     wf.out = wf.inp.outputs.add_three + 1
@@ -461,7 +461,7 @@ class TestWorkflow(unittest.TestCase):
                             wf.save()
                     else:
                         wf.save()
-                        reloaded = Workflow("wf_values", storage_backend=backend)
+                        reloaded = Workflow("wf", storage_backend=backend)
                         self.assertEqual(
                             wf_out.out__add,
                             reloaded.outputs.out__add.value,
@@ -488,8 +488,8 @@ class TestWorkflow(unittest.TestCase):
 
         for backend in Workflow.allowed_backends():
             with self.subTest(backend):
-                try:
-                    for backend in Workflow.allowed_backends():
+                for backend in Workflow.allowed_backends():
+                    try:
                         if backend == "h5io":
                             with self.subTest(backend):
                                 with self.assertRaises(
@@ -503,8 +503,8 @@ class TestWorkflow(unittest.TestCase):
                                 wf.storage_backend = backend
                                 wf.save()
                                 Workflow(wf.label, storage_backend=backend)
-                finally:
-                    wf.storage.delete()
+                    finally:
+                        wf.storage.delete()
 
         with self.subTest("No unimportable nodes for either back-end"):
             try:


### PR DESCRIPTION
Closes #319.

TODO:
- [x] Wait for the new version of `pyiron_snippets`
- [x] See if `as_node_function` and `as_macro_function` can use the same new syntax for `_reduce_imports_as`
- [x] Add `as_node_function` to the default creator now that it's working for pickle
- ~Wait for then bump `pyiron_base`~ I'll make the bump landing-page PR wait, but I want to collapse this stack.