### PR TITLE
[patch] Don't touch storage

### DIFF
--- a/notebooks/deepdive.ipynb
+++ b/notebooks/deepdive.ipynb
@@ -5570,7 +5570,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "reloaded.storage.delete()"
+    "reloaded.delete_storage()"
    ]
   },
   {

--- a/pyiron_workflow/mixin/storage.py
+++ b/pyiron_workflow/mixin/storage.py
@@ -9,7 +9,6 @@ from abc import ABC, abstractmethod
 from importlib import import_module
 import os
 import pickle
-import sys
 from typing import Optional
 
 import cloudpickle

--- a/tests/unit/nodes/test_macro.py
+++ b/tests/unit/nodes/test_macro.py
@@ -532,7 +532,7 @@ class TestMacro(unittest.TestCase):
                             f"Backend {backend} not recognized -- write a test for it"
                         )
                 finally:
-                    macro.storage.delete()
+                    macro.delete_storage()
 
     def test_output_label_stripping(self):
         """Test extensions to the `ScrapesIO` mixin."""

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -521,7 +521,7 @@ class TestNode(unittest.TestCase):
                             "on instantiation"
                     )
                 finally:
-                    saves.storage.delete()  # Clean up
+                    saves.delete_storage()  # Clean up
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -463,7 +463,7 @@ class TestWorkflow(unittest.TestCase):
                     )
                 finally:
                     # Clean up after ourselves
-                    wf.storage.delete()
+                    wf.delete_storage()
 
     def test_storage_scopes(self):
         wf = Workflow("wf")
@@ -480,7 +480,7 @@ class TestWorkflow(unittest.TestCase):
                             wf.save()
                             Workflow(wf.label, storage_backend=backend)
                     finally:
-                        wf.storage.delete()
+                        wf.delete_storage()
 
         with self.subTest("No unimportable nodes for either back-end"):
             for backend in Workflow.allowed_backends():
@@ -496,7 +496,7 @@ class TestWorkflow(unittest.TestCase):
                                 wf.save()
                 finally:
                     wf.remove_child(wf.import_type_mismatch)
-                    wf.storage.delete()
+                    wf.delete_storage()
 
         with self.subTest("Unimportable node"):
             @Workflow.wrap.as_function_node("y")


### PR DESCRIPTION
Don't actually touch the `.storage` object anywhere; use the node-level interface methods