### PR TITLE
[patch] Simplify setup and allow loading and running at init

### DIFF
--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -342,33 +342,23 @@ class Node(
     ):
         if delete_existing_savefiles:
             self.delete_storage(backend=autoload)
-            do_load = False
-        else:
-            do_load = autoload is not None and self.any_storage_has_contents(autoload)
 
-        if do_load and autorun:
-            raise ValueError(
-                f"{self.full_label} can't both load _and_ run after init -- either"
-                f" delete the save file (e.g. with with the `delete_existing_savefiles=True` "
-                f"kwarg), change the node label to work in a new space, or give up on "
-                f"running after init."
-            )
-        elif do_load:
+        if autoload is not None and self.any_storage_has_contents(autoload):
             logger.info(
                 f"A saved file was found for the node {self.full_label} -- "
                 f"attempting to load it...(To delete the saved file instead, use "
                 f"`delete_existing_savefiles=True`)"
             )
             self.load(backend=autoload)
-            self.set_input_values(*args, **kwargs)
-        elif autorun:
+
+        self.set_input_values(*args, **kwargs)
+
+        if autorun:
             try:
-                self.set_input_values(*args, **kwargs)
                 self.run()
             except ReadinessError:
                 pass
-        else:
-            self.set_input_values(*args, **kwargs)
+
         self.graph_root.tidy_working_directory()
 
     @property

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -436,17 +436,29 @@ class TestNode(unittest.TestCase):
                     )
 
                     run_right_away.save()
-                    with self.assertRaises(
-                        ValueError,
-                        msg="Should not be able to both immediately run _and_ load a "
-                            "node at once"
-                    ):
-                        ANode(
-                            label=self.n1.label,
-                            x=x,
-                            autorun=True,
-                            autoload=backend
-                        )
+                    load_and_rerun_origal_input = ANode(
+                        label=self.n1.label,
+                        autorun=True,
+                        autoload=backend
+                    )
+                    self.assertEqual(
+                        load_and_rerun_origal_input.outputs.y.value,
+                        run_right_away.outputs.y.value,
+                        msg="Loading and then running immediately is fine, and should "
+                            "recover existing input"
+                    )
+                    load_and_rerun_new_input = ANode(
+                        label=self.n1.label,
+                        x=x + 1,
+                        autorun=True,
+                        autoload=backend
+                    )
+                    self.assertEqual(
+                        load_and_rerun_new_input.outputs.y.value,
+                        run_right_away.outputs.y.value + 1,
+                        msg="Loading and then running immediately is fine, and should "
+                            "notice the new input"
+                    )
 
                     force_run = ANode(
                         label=self.n1.label,


### PR DESCRIPTION
Whatever held us back from loading and then running immediately is a non-issue. Since the order of operations is load --> update input based on (args and) kwargs --> run, this can be useful for loading most of your input and changing one value before starting the autorun.