### PR TITLE
[minor] Shift responsibility

### DIFF
--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -103,9 +103,7 @@ class Semantic(UsesState, HasLabel, HasParent, ABC):
         The semantic path as a :class:`pathlib.Path`, with a filesystem :param:`root`
         (default is the current working directory).
         """
-        return (
-            Path.cwd() if root is None else Path(root)
-        ).joinpath(
+        return (Path.cwd() if root is None else Path(root)).joinpath(
             *self.semantic_path.split(self.semantic_delimiter)
         )
 

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -14,6 +14,7 @@ different drives or machines) belong to the same semantic group.
 from __future__ import annotations
 
 from abc import ABC
+from pathlib import Path
 from typing import Optional
 
 from bidict import bidict
@@ -96,6 +97,17 @@ class Semantic(UsesState, HasLabel, HasParent, ABC):
     def semantic_root(self) -> Semantic:
         """The parent-most object in this semantic path; may be self."""
         return self.parent.semantic_root if isinstance(self.parent, Semantic) else self
+
+    def as_path(self, root: Path | str | None = None) -> Path:
+        """
+        The semantic path as a :class:`pathlib.Path`, with a filesystem :param:`root`
+        (default is the current working directory).
+        """
+        return (
+            Path.cwd() if root is None else Path(root)
+        ).joinpath(
+            *self.semantic_path.split(self.semantic_delimiter)
+        )
 
     def __getstate__(self):
         state = super().__getstate__()

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -794,13 +794,6 @@ class Node(
     def allowed_backends(cls):
         return tuple(cls._storage_interfaces().keys())
 
-    @property
-    def storage_directory(self) -> DirectoryObject:
-        return self.working_directory
-
-    def tidy_storage_directory(self):
-        self.tidy_working_directory()
-
     _save_load_warnings = """
         HERE BE DRAGONS!!!
 

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -22,7 +22,7 @@ from pyiron_workflow.mixin.injection import HasIOWithInjection
 from pyiron_workflow.mixin.run import Runnable, ReadinessError
 from pyiron_workflow.mixin.semantics import Semantic
 from pyiron_workflow.mixin.single_output import ExploitsSingleOutput
-from pyiron_workflow.storage import StorageInterface, PickleStorage, available_backends
+from pyiron_workflow.storage import StorageInterface, available_backends
 from pyiron_workflow.topology import (
     get_nodes_in_data_tree,
     set_run_connections_according_to_linear_dag,

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     import graphviz
-    from pyiron_snippets.files import DirectoryObject
 
     from pyiron_workflow.channels import OutputSignal
     from pyiron_workflow.nodes.composite import Composite

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -851,7 +851,7 @@ class Node(
         backend: Literal["pickle"] | StorageInterface | None = None,
         only_requested: bool = False
     ):
-        """Remove save files for _all_ available backends."""
+        """Remove save file(s)."""
         for backend in available_backends(
             backend=backend,
             only_requested=only_requested

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -887,15 +887,6 @@ class Node(
             except FileNotFoundError:
                 pass
 
-    @property
-    def storage_root(self):
-        """The parent-most object that has storage."""
-        parent = self.parent
-        if isinstance(parent, Node):
-            return parent.storage_root
-        else:
-            return self
-
     def any_storage_has_contents(
         self, backend: Literal["pickle"] | StorageInterface | None
     ):

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -798,10 +798,6 @@ class Node(
     def storage_directory(self) -> DirectoryObject:
         return self.working_directory
 
-    @property
-    def storage_path(self) -> str:
-        return self.graph_path
-
     def tidy_storage_directory(self):
         self.tidy_working_directory()
 

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -876,10 +876,7 @@ class Node(
             backends_to_check.append(backend)
 
         for backend in backends_to_check:
-            try:
-                backend.delete(self)
-            except FileNotFoundError:
-                pass
+            backend.delete(self)
 
     def any_storage_has_contents(
         self, backend: Literal["pickle"] | StorageInterface | None

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -359,8 +359,6 @@ class Node(
             except ReadinessError:
                 pass
 
-        self.graph_root.tidy_working_directory()
-
     @property
     def graph_path(self) -> str:
         """

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -849,21 +849,16 @@ class Node(
     def delete_storage(
         self,
         backend: Literal["pickle"] | StorageInterface | None = None,
-        only_requested: bool = False
+        only_requested: bool = False,
     ):
         """Remove save file(s)."""
         for backend in available_backends(
-            backend=backend,
-            only_requested=only_requested
+            backend=backend, only_requested=only_requested
         ):
             backend.delete(self)
 
-    def has_savefile(
-        self, backend: Literal["pickle"] | StorageInterface | None = None
-    ):
-        return any(
-            be.has_contents(self) for be in available_backends(backend=backend)
-        )
+    def has_savefile(self, backend: Literal["pickle"] | StorageInterface | None = None):
+        return any(be.has_contents(self) for be in available_backends(backend=backend))
 
     @property
     def import_ready(self) -> bool:

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -5,7 +5,6 @@ A bit of abstraction connecting generic storage routines to nodes.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from pathlib import Path
 import pickle
 from typing import TYPE_CHECKING
 

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import os
+from pathlib import Path
 import pickle
 from typing import TYPE_CHECKING
 
@@ -59,8 +60,8 @@ class StorageInterface(ABC):
 
 class PickleStorage(StorageInterface):
 
-    _PICKLE_STORAGE_FILE_NAME = "pickle.pckl"
-    _CLOUDPICKLE_STORAGE_FILE_NAME = "cloudpickle.cpckl"
+    _PICKLE = "pickle.pckl"
+    _CLOUDPICKLE = "cloudpickle.cpckl"
 
     def save(self, obj: Node):
         if not obj.import_ready:
@@ -102,18 +103,18 @@ class PickleStorage(StorageInterface):
 
     def _delete(self, obj: Node):
         if self._has_pickle_contents(obj):
-            self._delete_file(self._PICKLE_STORAGE_FILE_NAME, obj)
+            self._delete_file(self._PICKLE, obj)
         elif self._has_cloudpickle_contents(obj):
-            self._delete_file(self._CLOUDPICKLE_STORAGE_FILE_NAME, obj)
+            self._delete_file(self._CLOUDPICKLE, obj)
 
     def _storage_path(self, file: str, obj: Node):
         return str((obj.storage_directory.path / file).resolve())
 
     def _pickle_storage_file_path(self, obj: Node) -> str:
-        return self._storage_path(self._PICKLE_STORAGE_FILE_NAME, obj)
+        return self._storage_path(self._PICKLE, obj)
 
     def _cloudpickle_storage_file_path(self, obj: Node) -> str:
-        return self._storage_path(self._CLOUDPICKLE_STORAGE_FILE_NAME, obj)
+        return self._storage_path(self._CLOUDPICKLE, obj)
 
     def _has_contents(self, obj: Node) -> bool:
         return self._has_pickle_contents(obj) or self._has_cloudpickle_contents(obj)

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -11,7 +11,6 @@ import pickle
 from typing import TYPE_CHECKING
 
 import cloudpickle
-from pyiron_snippets.files import DirectoryObject, FileObject
 
 if TYPE_CHECKING:
     from pyiron_workflow.node import Node
@@ -110,7 +109,7 @@ class PickleStorage(StorageInterface):
         return inst
 
     def _delete_file(self, file: str, node: Node):
-        FileObject(file, DirectoryObject(self._canonical_node_directory(node))).delete()
+        (self._canonical_node_directory(node) / file).unlink(missing_ok=True)
 
     def _delete(self, node: Node):
         if self._has_contents(self._PICKLE, node):

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -24,8 +24,8 @@ class TypeNotFoundError(ImportError):
 class StorageInterface(ABC):
 
     def save(self, node: Node):
-        dir = node.as_path()
-        dir.mkdir(parents=True, exist_ok=True)
+        directory = node.as_path()
+        directory.mkdir(parents=True, exist_ok=True)
         try:
             self._save(node)
         except Exception as e:
@@ -33,8 +33,8 @@ class StorageInterface(ABC):
         finally:
             # If nothing got written due to the exception, clean up the directory
             # (as long as there's nothing else in it)
-            if not any(dir.iterdir()):
-                dir.rmdir()
+            if not any(directory.iterdir()):
+                directory.rmdir()
 
     @abstractmethod
     def _save(self, node: Node):
@@ -56,9 +56,9 @@ class StorageInterface(ABC):
     def delete(self, node: Node):
         if self.has_contents(node):
             self._delete(node)
-        dir = node.as_path()
-        if dir.exists() and not any(dir.iterdir()):
-            dir.rmdir()
+        directory = node.as_path()
+        if directory.exists() and not any(directory.iterdir()):
+            directory.rmdir()
 
     @abstractmethod
     def _delete(self, node: Node):
@@ -81,12 +81,12 @@ class PickleStorage(StorageInterface):
                 f"{node.report_import_readiness()}"
             )
 
-        dir = node.as_path()
+        directory = node.as_path()
         for file, save_method in [
             (self._PICKLE, pickle.dump),
             (self._CLOUDPICKLE, cloudpickle.dump),
         ]:
-            p = dir / file
+            p = directory / file
             try:
                 with open(p, "wb") as filehandle:
                     save_method(node, filehandle)
@@ -96,12 +96,12 @@ class PickleStorage(StorageInterface):
         raise e
 
     def _load(self, node: Node) -> Node:
-        dir = node.as_path()
+        directory = node.as_path()
         for file, load_method in [
             (self._PICKLE, pickle.load),
             (self._CLOUDPICKLE, cloudpickle.load),
         ]:
-            p = dir / file
+            p = directory / file
             if p.exists():
                 with open(p, "rb") as filehandle:
                     inst = load_method(filehandle)

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -107,14 +107,14 @@ class PickleStorage(StorageInterface):
         elif self._has_cloudpickle_contents(obj):
             self._delete_file(self._CLOUDPICKLE, obj)
 
-    def _storage_path(self, file: str, obj: Node):
+    def _storage_file(self, file: str, obj: Node):
         return str((obj.storage_directory.path / file).resolve())
 
     def _pickle_storage_file_path(self, obj: Node) -> str:
-        return self._storage_path(self._PICKLE, obj)
+        return self._storage_file(self._PICKLE, obj)
 
     def _cloudpickle_storage_file_path(self, obj: Node) -> str:
-        return self._storage_path(self._CLOUDPICKLE, obj)
+        return self._storage_file(self._CLOUDPICKLE, obj)
 
     def _has_contents(self, obj: Node) -> bool:
         return self._has_pickle_contents(obj) or self._has_cloudpickle_contents(obj)

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -75,19 +75,19 @@ class PickleStorage(StorageInterface):
             )
 
         try:
-            with open(self._pickle_storage_file_path(obj), "wb") as file:
+            with open(self._storage_file(self._PICKLE, obj), "wb") as file:
                 pickle.dump(obj, file)
         except Exception:
             self._delete(obj)
-            with open(self._cloudpickle_storage_file_path(obj), "wb") as file:
+            with open(self._storage_file(self._CLOUDPICKLE, obj), "wb") as file:
                 cloudpickle.dump(obj, file)
 
     def _load(self, obj: Node):
         if self._has_pickle_contents(obj):
-            with open(self._pickle_storage_file_path(obj), "rb") as file:
+            with open(self._storage_file(self._PICKLE, obj), "rb") as file:
                 inst = pickle.load(file)
         elif self._has_cloudpickle_contents(obj):
-            with open(self._cloudpickle_storage_file_path(obj), "rb") as file:
+            with open(self._storage_file(self._CLOUDPICKLE, obj), "rb") as file:
                 inst = cloudpickle.load(file)
 
         if inst.__class__ != obj.__class__:
@@ -110,17 +110,11 @@ class PickleStorage(StorageInterface):
     def _storage_file(self, file: str, obj: Node):
         return str((obj.storage_directory.path / file).resolve())
 
-    def _pickle_storage_file_path(self, obj: Node) -> str:
-        return self._storage_file(self._PICKLE, obj)
-
-    def _cloudpickle_storage_file_path(self, obj: Node) -> str:
-        return self._storage_file(self._CLOUDPICKLE, obj)
-
     def _has_contents(self, obj: Node) -> bool:
         return self._has_pickle_contents(obj) or self._has_cloudpickle_contents(obj)
 
     def _has_pickle_contents(self, obj: Node) -> bool:
-        return os.path.isfile(self._pickle_storage_file_path(obj))
+        return os.path.isfile(self._storage_file(self._PICKLE, obj))
 
     def _has_cloudpickle_contents(self, obj: Node) -> bool:
-        return os.path.isfile(self._cloudpickle_storage_file_path(obj))
+        return os.path.isfile(self._storage_file(self._CLOUDPICKLE, obj))

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -44,7 +44,7 @@ class StorageInterface(ABC):
         pass
 
     def delete(self, node: Node):
-        if self.has_contents:
+        if self.has_contents(node):
             self._delete(node)
         self.tidy_storage_directory(node)
 

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -101,7 +101,7 @@ class PickleStorage(StorageInterface):
             (self._PICKLE, pickle.load),
             (self._CLOUDPICKLE, cloudpickle.load),
         ]:
-            p = (dir / file)
+            p = dir / file
             if p.exists():
                 with open(p, "rb") as filehandle:
                     inst = load_method(filehandle)
@@ -120,7 +120,7 @@ class PickleStorage(StorageInterface):
 
 def available_backends(
     backend: Literal["pickle"] | StorageInterface | None = None,
-    only_requested: bool = False
+    only_requested: bool = False,
 ) -> Generator[StorageInterface, None, None]:
     """
     A generator for accessing available :class:`StorageInterface` instances, starting

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -52,13 +52,21 @@ class StorageInterface(ABC):
     def _delete(self, obj: Node):
         """Remove an existing save-file for this backend"""
 
-    @staticmethod
-    def storage_directory(obj: Node) -> DirectoryObject:
-        return obj.working_directory
+    @classmethod
+    def _canonical_node_directory(cls, node: Node, start: Path | None = None) -> Path:
+        return (
+            Path.cwd() if start is None else start
+        ).joinpath(
+            *node.semantic_path.split(node.semantic_delimiter)
+        )
 
-    @staticmethod
-    def tidy_storage_directory(obj: Node):
-        obj.tidy_working_directory()
+    def storage_directory(self, obj: Node) -> DirectoryObject:
+        return DirectoryObject(self._canonical_node_directory(obj))
+
+    def tidy_storage_directory(self, obj: Node):
+        dir = self.storage_directory(obj)
+        if dir.is_empty():
+            dir.delete()
 
 
 class PickleStorage(StorageInterface):

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -30,7 +30,7 @@ class StorageInterface(ABC):
     def save(self, obj: Node):
         pass
 
-    def load(self, obj: Node):
+    def load(self, obj: Node) -> Node:
         # Misdirection is strictly for symmetry with _save, so child classes define the
         # private method in both cases
         return self._load(obj)
@@ -85,21 +85,14 @@ class PickleStorage(StorageInterface):
             with open(self._storage_file(self._CLOUDPICKLE, obj), "wb") as file:
                 cloudpickle.dump(obj, file)
 
-    def _load(self, obj: Node):
+    def _load(self, obj: Node) -> Node:
         if self._has_contents(self._PICKLE, obj):
             with open(self._storage_file(self._PICKLE, obj), "rb") as file:
                 inst = pickle.load(file)
         elif self._has_contents(self._CLOUDPICKLE, obj):
             with open(self._storage_file(self._CLOUDPICKLE, obj), "rb") as file:
                 inst = cloudpickle.load(file)
-
-        if inst.__class__ != obj.__class__:
-            raise TypeError(
-                f"{obj.label} cannot load, as it has type "
-                f"{obj.__class__.__name__},  but the saved node has type "
-                f"{inst.__class__.__name__}"
-            )
-        obj.__setstate__(inst.__getstate__())
+        return inst
 
     def _delete_file(self, file: str, obj: Node):
         FileObject(file, self.storage_directory(obj)).delete()

--- a/tests/unit/mixin/test_semantics.py
+++ b/tests/unit/mixin/test_semantics.py
@@ -1,4 +1,6 @@
+from pathlib import Path
 import unittest
+
 from pyiron_workflow.mixin.semantics import (
     Semantic, SemanticParent, ParentMost, CyclicPathError
 )
@@ -72,6 +74,28 @@ class TestSemantics(unittest.TestCase):
         self.assertEqual(self.middle1.semantic_root, self.root)
         self.assertEqual(self.middle2.semantic_root, self.root)
         self.assertEqual(self.child2.semantic_root, self.root)
+
+    def test_as_path(self):
+        self.assertEqual(
+            self.root.as_path(),
+            Path.cwd() / self.root.label,
+            msg="Default None root"
+        )
+        self.assertEqual(
+            self.child1.as_path(root=".."),
+            Path("..") / self.root.label / self.child1.label,
+            msg="String root"
+        )
+        self.assertEqual(
+            self.middle2.as_path(root=Path("..", "..")),
+            (
+                Path("..", "..") /
+                self.root.label /
+                self.middle1.label /
+                self.middle2.label
+            ),
+            msg="Path root"
+        )
 
 
 if __name__ == '__main__':

--- a/tests/unit/nodes/test_macro.py
+++ b/tests/unit/nodes/test_macro.py
@@ -7,6 +7,7 @@ from pyiron_workflow._tests import ensure_tests_in_python_path
 from pyiron_workflow.channels import NOT_DATA
 from pyiron_workflow.nodes.function import function_node, as_function_node
 from pyiron_workflow.nodes.macro import Macro, macro_node, as_macro_node
+from pyiron_workflow.storage import available_backends, PickleStorage
 from pyiron_workflow.topology import CircularDataFlowError
 
 ensure_tests_in_python_path()
@@ -479,7 +480,7 @@ class TestMacro(unittest.TestCase):
             print(m.child_labels, m.inputs, m.outputs)
 
     def test_storage_for_modified_macros(self):
-        for backend in Macro.allowed_backends():
+        for backend in available_backends():
             with self.subTest(backend):
                 try:
                     macro = demo_nodes.AddThree(label="m", x=0)
@@ -490,7 +491,7 @@ class TestMacro(unittest.TestCase):
 
                     modified_result = macro()
 
-                    if backend == "pickle":
+                    if isinstance(backend, PickleStorage):
                         macro.save(backend)
                         reloaded = demo_nodes.AddThree(
                             label="m", autoload=backend

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -407,6 +407,12 @@ class TestNode(unittest.TestCase):
 
         self.assertFalse(self.n1.has_savefile())
 
+        with self.assertRaises(
+            FileNotFoundError,
+            msg="We just verified there is no save file, so loading should fail."
+        ):
+            self.n1.load()
+
         for backend in available_backends():
             with self.subTest(backend):
                 try:

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -9,7 +9,7 @@ from pyiron_snippets.dotdict import DotDict
 from pyiron_workflow._tests import ensure_tests_in_python_path
 from pyiron_workflow.channels import NOT_DATA
 from pyiron_workflow.mixin.semantics import ParentMostError
-from pyiron_workflow.storage import TypeNotFoundError
+from pyiron_workflow.storage import available_backends, TypeNotFoundError
 from pyiron_workflow.workflow import Workflow
 
 ensure_tests_in_python_path()
@@ -440,7 +440,7 @@ class TestWorkflow(unittest.TestCase):
         wf.executor_shutdown()
 
     def test_storage_values(self):
-        for backend in Workflow.allowed_backends():
+        for backend in available_backends():
             with self.subTest(backend):
                 try:
                     wf = Workflow("wf")
@@ -471,18 +471,16 @@ class TestWorkflow(unittest.TestCase):
         # Test invocation
         wf.add_child(demo_nodes.AddPlusOne(label="by_add"))
 
-        for backend in Workflow.allowed_backends():
-            with self.subTest(backend):
-                for backend in Workflow.allowed_backends():
-                    try:
-                        with self.subTest(backend):
-                            wf.save(backend=backend)
-                            Workflow(wf.label, autoload=backend)
-                    finally:
-                        wf.delete_storage(backend)
+        for backend in available_backends():
+            try:
+                with self.subTest(backend):
+                    wf.save(backend=backend)
+                    Workflow(wf.label, autoload=backend)
+            finally:
+                wf.delete_storage(backend)
 
         with self.subTest("No unimportable nodes for either back-end"):
-            for backend in Workflow.allowed_backends():
+            for backend in available_backends():
                 try:
                     wf.import_type_mismatch = demo_nodes.Dynamic()
                     with self.subTest(backend):


### PR DESCRIPTION
Moves a bunch of storage routine responsibility off of `Node` and into `storage`. Also moves detailed file responsibilities from `pyiron_snippets.files` to `pathlib` -- `DirectoryObject` has a nasty side effect of creating directories you only want to look at, so until that's fixed we'll do it the old fashioned way.