### PR TITLE
[minor] interface flexibility

### DIFF
--- a/pyiron_workflow/__init__.py
+++ b/pyiron_workflow/__init__.py
@@ -51,3 +51,8 @@ from pyiron_workflow.nodes.transform import (
     inputs_to_list,
     list_to_outputs,
 )
+from pyiron_workflow.storage import (
+    StorageInterface,
+    PickleStorage,
+    available_backends,
+)

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -816,6 +816,14 @@ class Node(
     ):
         """
         Writes the node to file using the requested interface as a back end.
+
+        Args:
+            backend (str | StorageInterface): The interface to use for serializing the
+                node. (Default is "pickle", which loads the standard pickling back end.)
+            filename (str | Path | None): The name of the file (without extensions) at
+                which to save the node. (Default is None, which uses the node's
+                semantic path.)
+            **kwargs: Back end-specific keyword arguments.
         """
         for backend in available_backends(backend=backend, only_requested=True):
             backend.save(node=self, filename=filename, **kwargs)
@@ -825,6 +833,10 @@ class Node(
     def save_checkpoint(self, backend: str | StorageInterface = "pickle"):
         """
         Triggers a save on the parent-most node.
+
+        Args:
+            backend (str | StorageInterface): The interface to use for serializing the
+                node. (Default is "pickle", which loads the standard pickling back end.)
         """
         self.graph_root.save(backend=backend)
 
@@ -835,9 +847,21 @@ class Node(
         **kwargs
     ):
         """
+
         Loads the node file and set the loaded state as the node's own.
 
+        Args:
+            backend (str | StorageInterface): The interface to use for serializing the
+                node. (Default is "pickle", which loads the standard pickling back end.)
+            only_requested (bool): Whether to _only_ try loading from the specified
+                backend, or to loop through all available backends. (Default is False,
+                try to load whatever you can find.)
+            **kwargs: back end-specific arguments (only likely to work in combination
+                with :param:`only_requested`, otherwise there's nothing to be specific
+                _to_.)
+
         Raises:
+            FileNotFoundError: when nothing got loaded.
             TypeError: when the saved node has a different class name.
         """
         for backend in available_backends(
@@ -866,7 +890,19 @@ class Node(
         only_requested: bool = False,
         **kwargs
     ):
-        """Remove save file(s)."""
+        """
+        Remove save file(s).
+
+        Args:
+            backend (str | StorageInterface): The interface to use for serializing the
+                node. (Default is "pickle", which loads the standard pickling back end.)
+            only_requested (bool): Whether to _only_ try loading from the specified
+                backend, or to loop through all available backends. (Default is False,
+                try to load whatever you can find.)
+            **kwargs: back end-specific arguments (only likely to work in combination
+                with :param:`only_requested`, otherwise there's nothing to be specific
+                _to_.)
+        """
         for backend in available_backends(
             backend=backend, only_requested=only_requested
         ):
@@ -878,6 +914,22 @@ class Node(
         only_requested: bool = False,
         **kwargs
     ):
+        """
+        Whether any save files can be found at the canonical location for this node.
+
+        Args:
+            backend (str | StorageInterface): The interface to use for serializing the
+                node. (Default is "pickle", which loads the standard pickling back end.)
+            only_requested (bool): Whether to _only_ try loading from the specified
+                backend, or to loop through all available backends. (Default is False,
+                try to load whatever you can find.)
+            **kwargs: back end-specific arguments (only likely to work in combination
+                with :param:`only_requested`, otherwise there's nothing to be specific
+                _to_.)
+
+        Returns:
+            bool: Whether any save files were found
+        """
         return any(
             be.has_contents(self, **kwargs)
             for be in available_backends(backend=backend, only_requested=only_requested)

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -808,12 +808,16 @@ class Node(
 
     """
 
-    def save(self, backend: str | StorageInterface = "pickle"):
+    def save(
+        self,
+        backend: str | StorageInterface = "pickle",
+        filename: str | Path | None = None,
+    ):
         """
         Writes the node to file using the requested interface as a back end.
         """
         for backend in available_backends(backend=backend, only_requested=True):
-            backend.save(self)
+            backend.save(node=self, filename=filename)
 
     save.__doc__ += _save_load_warnings
 
@@ -826,7 +830,7 @@ class Node(
     def load(
         self,
         backend: str | StorageInterface = "pickle",
-        only_requested=False
+        only_requested=False,
     ):
         """
         Loads the node file and set the loaded state as the node's own.
@@ -838,9 +842,10 @@ class Node(
             backend=backend,
             only_requested=only_requested
         ):
-            if backend.has_contents(self):
-                inst = backend.load(self)
+            inst = backend.load(node=self)
+            if inst is not None:
                 break
+        if inst is None:
             raise FileNotFoundError(f"{self.label} could not find saved content.")
 
         if inst.__class__ != self.__class__:
@@ -862,7 +867,7 @@ class Node(
         for backend in available_backends(
             backend=backend, only_requested=only_requested
         ):
-            backend.delete(self)
+            backend.delete(node=self)
 
     def has_savefile(self, backend: Literal["pickle"] | StorageInterface | None = None):
         return any(be.has_contents(self) for be in available_backends(backend=backend))

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -812,12 +812,13 @@ class Node(
         self,
         backend: str | StorageInterface = "pickle",
         filename: str | Path | None = None,
+        **kwargs,
     ):
         """
         Writes the node to file using the requested interface as a back end.
         """
         for backend in available_backends(backend=backend, only_requested=True):
-            backend.save(node=self, filename=filename)
+            backend.save(node=self, filename=filename, **kwargs)
 
     save.__doc__ += _save_load_warnings
 
@@ -831,6 +832,7 @@ class Node(
         self,
         backend: str | StorageInterface = "pickle",
         only_requested=False,
+        **kwargs
     ):
         """
         Loads the node file and set the loaded state as the node's own.
@@ -842,7 +844,7 @@ class Node(
             backend=backend,
             only_requested=only_requested
         ):
-            inst = backend.load(node=self)
+            inst = backend.load(node=self, **kwargs)
             if inst is not None:
                 break
         if inst is None:
@@ -862,15 +864,24 @@ class Node(
         self,
         backend: Literal["pickle"] | StorageInterface | None = None,
         only_requested: bool = False,
+        **kwargs
     ):
         """Remove save file(s)."""
         for backend in available_backends(
             backend=backend, only_requested=only_requested
         ):
-            backend.delete(node=self)
+            backend.delete(node=self, **kwargs)
 
-    def has_savefile(self, backend: Literal["pickle"] | StorageInterface | None = None):
-        return any(be.has_contents(self) for be in available_backends(backend=backend))
+    def has_savefile(
+        self,
+        backend: Literal["pickle"] | StorageInterface | None = None,
+        only_requested: bool = False,
+        **kwargs
+    ):
+        return any(
+            be.has_contents(self, **kwargs)
+            for be in available_backends(backend=backend, only_requested=only_requested)
+        )
 
     @property
     def import_ready(self) -> bool:

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -344,7 +344,7 @@ class Node(
 
         if autoload is not None:
             for backend in available_backends(backend=autoload):
-                if backend.has_contents(self):
+                if backend.has_saved_content(self):
                     logger.info(
                         f"A saved file was found for the node {self.full_label} -- "
                         f"attempting to load it...(To delete the saved file instead, "
@@ -908,7 +908,7 @@ class Node(
         ):
             backend.delete(node=self, **kwargs)
 
-    def has_savefile(
+    def has_saved_content(
         self,
         backend: Literal["pickle"] | StorageInterface | None = None,
         only_requested: bool = False,
@@ -931,7 +931,7 @@ class Node(
             bool: Whether any save files were found
         """
         return any(
-            be.has_contents(self, **kwargs)
+            be.has_saved_content(self, **kwargs)
             for be in available_backends(backend=backend, only_requested=only_requested)
         )
 

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -823,14 +823,21 @@ class Node(
         """
         self.graph_root.save(backend=backend)
 
-    def load(self, backend: str | StorageInterface = "pickle"):
+    def load(
+        self,
+        backend: str | StorageInterface = "pickle",
+        only_requested=False
+    ):
         """
         Loads the node file and set the loaded state as the node's own.
 
         Raises:
             TypeError: when the saved node has a different class name.
         """
-        for backend in available_backends(backend=backend):
+        for backend in available_backends(
+            backend=backend,
+            only_requested=only_requested
+        ):
             if backend.has_contents(self):
                 inst = backend.load(self)
                 break

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -45,7 +45,6 @@ class StorageInterface(ABC):
                 extension.)
             **kwargs: Additional keyword arguments.
         """
-        pass
 
     @abstractmethod
     def _load(self, filename: Path, /, **kwargs) -> Node:
@@ -59,7 +58,6 @@ class StorageInterface(ABC):
         Returns:
             Node: The node stored there.
         """
-        pass
 
     @abstractmethod
     def _has_saved_content(self, filename: Path, /, **kwargs) -> bool:
@@ -73,7 +71,6 @@ class StorageInterface(ABC):
         Returns:
             bool: Whether a commensurate file was found.
         """
-        pass
 
     @abstractmethod
     def _delete(self, filename: Path, /, **kwargs):

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -62,7 +62,7 @@ class StorageInterface(ABC):
         pass
 
     @abstractmethod
-    def _has_contents(self, filename: Path, /, **kwargs) -> bool:
+    def _has_saved_content(self, filename: Path, /, **kwargs) -> bool:
         """
         Check for a save file matching this storage interface.
 
@@ -140,7 +140,7 @@ class StorageInterface(ABC):
             **kwargs
         )
 
-    def has_contents(
+    def has_saved_content(
         self,
         node: Node | None = None,
         filename: str | Path | None = None,
@@ -153,12 +153,13 @@ class StorageInterface(ABC):
             node (Node | None): The node to check. Optional if filename is provided.
             filename (str | Path | None): The path to the file to check (without file
                 extension). Optional if the node is provided.
-            **kwargs: Additional keyword arguments passed to the has_contents method.
+            **kwargs: Additional keyword arguments passed to the has_saved_content
+                method.
 
         Returns:
             bool: True if contents exist, False otherwise.
         """
-        return self._has_contents(
+        return self._has_saved_content(
             self._parse_filename(node=node, filename=filename),
             **kwargs
         )
@@ -180,7 +181,7 @@ class StorageInterface(ABC):
             **kwargs: Additional keyword arguments passed to the delete method.
        """
         filename = self._parse_filename(node=node, filename=filename)
-        if self._has_contents(filename, **kwargs):
+        if self._has_saved_content(filename, **kwargs):
             self._delete(filename, **kwargs)
         if filename.parent.exists() and not any(filename.parent.iterdir()):
             filename.parent.rmdir()
@@ -275,7 +276,7 @@ class PickleStorage(StorageInterface):
         for suffix in suffixes:
             filename.with_suffix(suffix).unlink(missing_ok=True)
 
-    def _has_contents(
+    def _has_saved_content(
         self,
         filename: Path,
         cloudpickle_fallback: bool | None = None

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -23,6 +23,22 @@ class TypeNotFoundError(ImportError):
 
 class StorageInterface(ABC):
 
+    @abstractmethod
+    def _save(self, node: Node):
+        pass
+
+    @abstractmethod
+    def _load(self, node: Node):
+        pass
+
+    @abstractmethod
+    def _delete(self, node: Node):
+        """Remove an existing save-file for this backend"""
+
+    @abstractmethod
+    def has_contents(self, node: Node) -> bool:
+        pass
+
     def save(self, node: Node):
         directory = node.as_path()
         directory.mkdir(parents=True, exist_ok=True)
@@ -36,22 +52,10 @@ class StorageInterface(ABC):
             if not any(directory.iterdir()):
                 directory.rmdir()
 
-    @abstractmethod
-    def _save(self, node: Node):
-        pass
-
     def load(self, node: Node) -> Node:
         # Misdirection is strictly for symmetry with _save, so child classes define the
         # private method in both cases
         return self._load(node)
-
-    @abstractmethod
-    def _load(self, node: Node):
-        pass
-
-    @abstractmethod
-    def has_contents(self, node: Node) -> bool:
-        pass
 
     def delete(self, node: Node):
         if self.has_contents(node):
@@ -59,10 +63,6 @@ class StorageInterface(ABC):
         directory = node.as_path()
         if directory.exists() and not any(directory.iterdir()):
             directory.rmdir()
-
-    @abstractmethod
-    def _delete(self, node: Node):
-        """Remove an existing save-file for this backend"""
 
 
 class PickleStorage(StorageInterface):

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -43,7 +43,7 @@ class StorageInterface(ABC):
             node (Node): The node to save
             filename (Path | None): The path to the save location (WITHOUT file
                 extension.)
-            **kwargs: Additional keyword arguments passed to the save method.
+            **kwargs: Additional keyword arguments.
         """
         pass
 
@@ -54,7 +54,7 @@ class StorageInterface(ABC):
 
         Args:
             filename (Path): The path to the file to load (WITHOUT file extension).
-            **kwargs: Additional keyword arguments passed to the save method.
+            **kwargs: Additional keyword arguments.
 
         Returns:
             Node: The node stored there.
@@ -68,7 +68,7 @@ class StorageInterface(ABC):
 
         Args:
             filename (Path): The path to the file to look for (WITHOUT file extension).
-            **kwargs: Additional keyword arguments passed to the save method.
+            **kwargs: Additional keyword arguments.
 
         Returns:
             bool: Whether a commensurate file was found.
@@ -82,7 +82,7 @@ class StorageInterface(ABC):
 
         Args:
             filename (Path): The path to the file to delete (WITHOUT file extension).
-            **kwargs: Additional keyword arguments passed to the save method.
+            **kwargs: Additional keyword arguments.
         """
 
     def save(
@@ -98,7 +98,7 @@ class StorageInterface(ABC):
             node (Node): The node to save
             filename (Path | None): The path to the save location (WITHOUT file
                 extension.)
-            **kwargs: Additional keyword arguments passed to the save method.
+            **kwargs: Additional keyword arguments.
         """
         filename = self._parse_filename(
             node=node if filename is None else None,
@@ -130,7 +130,7 @@ class StorageInterface(ABC):
             filename (str | Path | None): The path to the file to load (without file
                 extension). Uses the canonical filename based on the node's semantic
                 path instead if this is None.
-            **kwargs: Additional keyword arguments passed to the load method.
+            **kwargs: Additional keyword arguments.
 
         Returns:
             Node: The loaded node.
@@ -153,8 +153,7 @@ class StorageInterface(ABC):
             node (Node | None): The node to check. Optional if filename is provided.
             filename (str | Path | None): The path to the file to check (without file
                 extension). Optional if the node is provided.
-            **kwargs: Additional keyword arguments passed to the has_saved_content
-                method.
+            **kwargs: Additional keyword arguments.
 
         Returns:
             bool: True if contents exist, False otherwise.
@@ -178,7 +177,7 @@ class StorageInterface(ABC):
                 Optional if filename is provided.
             filename (str | Path | None): The path to the file to delete (without file
                 extension). Optional if the node is provided.
-            **kwargs: Additional keyword arguments passed to the delete method.
+            **kwargs: Additional keyword arguments.
        """
         filename = self._parse_filename(node=node, filename=filename)
         if self._has_saved_content(filename, **kwargs):

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -405,7 +405,7 @@ class TestNode(unittest.TestCase):
         )
         y = self.n1()
 
-        self.assertFalse(self.n1.has_savefile())
+        self.assertFalse(self.n1.has_saved_content())
 
         with self.assertRaises(
             FileNotFoundError,
@@ -417,7 +417,7 @@ class TestNode(unittest.TestCase):
             with self.subTest(backend):
                 try:
                     self.n1.save(backend=backend)
-                    self.assertTrue(self.n1.has_savefile())
+                    self.assertTrue(self.n1.has_saved_content())
 
                     x = self.n1.inputs.x.value
                     reloaded = ANode(label=self.n1.label, x=x, autoload=backend)

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -1,0 +1,134 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from pyiron_workflow.nodes.function import as_function_node
+from pyiron_workflow.nodes.standard import UserInput
+from pyiron_workflow.storage import (
+    available_backends,
+    PickleStorage,
+    TypeNotFoundError
+)
+
+
+class TestAvailableBackends(unittest.TestCase):
+
+    def test_default_backend(self):
+        backends = list(available_backends())
+        self.assertIsInstance(
+            backends[0],
+            PickleStorage,
+            msg="If more standard backends are added, this will fail -- that's fine, "
+                "just update the test to make sure you're getting the defaults you now "
+                "expect."
+        )
+
+    def test_specific_backend(self):
+        backends = list(available_backends(backend="pickle", only_requested=True))
+        self.assertEqual(
+            len(backends),
+            1,
+            msg="Once more standard backends are available, we should test that string "
+                "access results in the the correct priority assignment among these "
+                "defaults."
+        )
+        self.assertIsInstance(backends[0], PickleStorage)
+
+    def test_extra_backend(self):
+        my_interface = PickleStorage()
+        backends = list(available_backends(my_interface))
+        self.assertEqual(
+            len(backends),
+            2,
+            msg="We expect both the one we passed, and all defaults"
+        )
+        self.assertIs(backends[0], my_interface)
+        self.assertIsNot(
+            backends[0],
+            backends[1],
+            msg="They should be separate instances"
+        )
+
+    def test_exclusive_backend(self):
+        my_interface = PickleStorage()
+        backends = list(available_backends(my_interface, only_requested=True))
+        self.assertEqual(
+            len(backends),
+            1,
+            msg="We expect to filter out everything except the one we asked for"
+        )
+        self.assertIs(backends[0], my_interface)
+
+
+class TestPickleStorage(unittest.TestCase):
+
+    def setUp(self):
+        self.node = UserInput(label="test_node")
+        self.storage = PickleStorage()
+        self.temp_dir = TemporaryDirectory()
+        self.filename = Path(self.temp_dir.name) / "test_node"
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_save_and_load(self):
+        with self.subTest("By Node"):
+            try:
+                self.storage.save(self.node)
+                self.assertTrue(self.storage.has_contents(node=self.node))
+                loaded_node = self.storage.load(node=self.node)
+                self.assertIsNot(loaded_node, self.node, msg="Should be a new instance")
+                self.assertEqual(loaded_node.label, self.node.label)
+            finally:
+                self.storage.delete(node=self.node)
+                self.assertFalse(self.storage.has_contents(node=self.node))
+
+        with self.subTest("By filename"):
+            try:
+                self.storage.save(self.node, self.filename)
+                self.assertFalse(self.storage.has_contents(node=self.node))
+                self.assertTrue(self.storage.has_contents(filename=self.filename))
+                loaded_node = self.storage.load(filename=self.filename)
+                self.assertEqual(loaded_node.label, self.node.label)
+            finally:
+                self.storage.delete(filename=self.filename)
+                self.assertFalse(self.storage.has_contents(filename=self.filename))
+
+    def test_input_validity(self):
+        for method in [
+            self.storage.load,
+            self.storage.has_contents,
+            self.storage.delete
+        ]:
+            with self.subTest(method.__name__):
+                with self.assertRaises(ValueError):
+                    method(self.node, self.filename)
+                with self.assertRaises(ValueError):
+                    method(None, None)
+
+        with self.assertRaises(ValueError):
+            self.storage.save(None, None)
+
+
+class TestPickleStorage(unittest.TestCase):
+    def test_importability(self):
+        @as_function_node
+        def Unimportable(x):
+            return x + 1
+
+        u = Unimportable()
+
+        try:
+            interface = PickleStorage()
+            with self.assertRaises(
+                TypeNotFoundError,
+                msg="We can't import from <locals>, so this is unpicklable"
+            ):
+                interface.save(u)
+        finally:
+            interface.delete(node=u)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -60,7 +60,7 @@ class TestAvailableBackends(unittest.TestCase):
         self.assertIs(backends[0], my_interface)
 
 
-class TestPickleStorage(unittest.TestCase):
+class TestStorage(unittest.TestCase):
 
     def setUp(self):
         self.node = UserInput(label="test_node")

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -111,7 +111,7 @@ class TestPickleStorage(unittest.TestCase):
 
 
 class TestPickleStorage(unittest.TestCase):
-    def test_importability(self):
+    def test_cloudpickle(self):
         @as_function_node
         def Unimportable(x):
             return x + 1
@@ -119,14 +119,21 @@ class TestPickleStorage(unittest.TestCase):
         u = Unimportable()
 
         try:
-            interface = PickleStorage()
+            interface = PickleStorage(cloudpickle_fallback=False)
             with self.assertRaises(
                 TypeNotFoundError,
                 msg="We can't import from <locals>, so this is unpicklable"
             ):
                 interface.save(u)
+
+            interface.save(u, cloudpickle_fallback=True)
+            self.assertFalse(interface.has_contents(u))
+            self.assertTrue(interface.has_contents(u, cloudpickle_fallback=True))
+
+            new_u = interface.load(node=u, cloudpickle_fallback=True)
+            self.assertIsInstance(new_u, Unimportable)
         finally:
-            interface.delete(node=u)
+            interface.delete(node=u, cloudpickle_fallback=True)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -75,29 +75,29 @@ class TestPickleStorage(unittest.TestCase):
         with self.subTest("By Node"):
             try:
                 self.storage.save(self.node)
-                self.assertTrue(self.storage.has_contents(node=self.node))
+                self.assertTrue(self.storage.has_saved_content(node=self.node))
                 loaded_node = self.storage.load(node=self.node)
                 self.assertIsNot(loaded_node, self.node, msg="Should be a new instance")
                 self.assertEqual(loaded_node.label, self.node.label)
             finally:
                 self.storage.delete(node=self.node)
-                self.assertFalse(self.storage.has_contents(node=self.node))
+                self.assertFalse(self.storage.has_saved_content(node=self.node))
 
         with self.subTest("By filename"):
             try:
                 self.storage.save(self.node, self.filename)
-                self.assertFalse(self.storage.has_contents(node=self.node))
-                self.assertTrue(self.storage.has_contents(filename=self.filename))
+                self.assertFalse(self.storage.has_saved_content(node=self.node))
+                self.assertTrue(self.storage.has_saved_content(filename=self.filename))
                 loaded_node = self.storage.load(filename=self.filename)
                 self.assertEqual(loaded_node.label, self.node.label)
             finally:
                 self.storage.delete(filename=self.filename)
-                self.assertFalse(self.storage.has_contents(filename=self.filename))
+                self.assertFalse(self.storage.has_saved_content(filename=self.filename))
 
     def test_input_validity(self):
         for method in [
             self.storage.load,
-            self.storage.has_contents,
+            self.storage.has_saved_content,
             self.storage.delete
         ]:
             with self.subTest(method.__name__):
@@ -127,8 +127,8 @@ class TestPickleStorage(unittest.TestCase):
                 interface.save(u)
 
             interface.save(u, cloudpickle_fallback=True)
-            self.assertFalse(interface.has_contents(u))
-            self.assertTrue(interface.has_contents(u, cloudpickle_fallback=True))
+            self.assertFalse(interface.has_saved_content(u))
+            self.assertTrue(interface.has_saved_content(u, cloudpickle_fallback=True))
 
             new_u = interface.load(node=u, cloudpickle_fallback=True)
             self.assertIsInstance(new_u, Unimportable)

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -489,7 +489,7 @@ class TestWorkflow(unittest.TestCase):
                                 msg="Imported object is function but node type is node "
                                     "-- should fail early on save"
                             ):
-                                wf.save(backend=backend)
+                                wf.save(backend=backend, cloudpickle_fallback=False)
                 finally:
                     wf.remove_child(wf.import_type_mismatch)
                     wf.delete_storage(backend)


### PR DESCRIPTION
Finished the storage refactoring, allowing non-canonical file paths to be specified, allowing children of `StorageInterface` to take `**kwargs` on their methods, and adding tests and docstrings.

I don't currently expose explicit storage interfaces to the user on the `Workflow.create` menu, but this is probably a good idea in the near future as it's a necessary object for using custom save/load paths. It (and the abstract base `StorageInterface` and convenience generator `available_backends`) is (are) now included in `pyiron_workflow.__init__` though, so it's part of the API and pretty easy to access.