### PR TITLE
[minor] Replace `HasToDict` mixin with `HasStateDisplay` mixin

### DIFF
--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -14,8 +14,8 @@ import inspect
 
 from pyiron_snippets.singleton import Singleton
 
-from pyiron_workflow.mixin.has_interface_mixins import HasChannel, HasLabel, UsesState
-from pyiron_workflow.mixin.has_to_dict import HasToDict
+from pyiron_workflow.mixin.has_interface_mixins import HasChannel, HasLabel
+from pyiron_workflow.mixin.has_to_dict import HasStateDisplay
 from pyiron_workflow.type_hinting import (
     valid_value,
     type_hint_is_as_or_more_specific_than,
@@ -29,7 +29,7 @@ class ChannelConnectionError(Exception):
     pass
 
 
-class Channel(UsesState, HasChannel, HasLabel, HasToDict, ABC):
+class Channel(HasChannel, HasLabel, HasStateDisplay, ABC):
     """
     Channels facilitate the flow of information (data or control signals) into and
     out of :class:`HasIO` objects (namely nodes).
@@ -220,13 +220,6 @@ class Channel(UsesState, HasChannel, HasLabel, HasToDict, ABC):
             self.disconnect(*new_connections)
             raise e
 
-    def to_dict(self) -> dict:
-        return {
-            "label": self.label,
-            "connected": self.connected,
-            "connections": [f"{c.owner.label}.{c.label}" for c in self.connections],
-        }
-
     def __getstate__(self):
         state = super().__getstate__()
         state["connections"] = []
@@ -234,6 +227,12 @@ class Channel(UsesState, HasChannel, HasLabel, HasToDict, ABC):
         # connections (if any), since these can extend beyond the owner and would thus
         # bloat the data being sent cross-process if the owner is shipped off
         return state
+
+    def display_state(self, state=None, ignore_private=True):
+        state = dict(self.__getstate__()) if state is None else state
+        state["owner"] = state["owner"].full_label  # JSON can't handle recursion
+        state["connections"] = [c.full_label for c in self.connections]
+        return super().display_state(state=state, ignore_private=ignore_private)
 
 
 class NotData(metaclass=Singleton):
@@ -468,13 +467,6 @@ class DataChannel(Channel, ABC):
     def __str__(self):
         return str(self.value)
 
-    def to_dict(self) -> dict:
-        d = super().to_dict()
-        d["value"] = repr(self.value)
-        d["ready"] = self.ready
-        d["type_hint"] = str(self.type_hint)
-        return d
-
     def activate_strict_hints(self) -> None:
         self.strict_hints = True
 
@@ -487,6 +479,11 @@ class DataChannel(Channel, ABC):
         # Value receivers live in the scope of Macros, so (re)storing them is the
         # owning macro's responsibility
         return state
+
+    def display_state(self, state=None, ignore_private=True):
+        state = dict(self.__getstate__()) if state is None else state
+        self._make_entry_public(state, "_value", "value")
+        return super().display_state(state=state, ignore_private=ignore_private)
 
 
 class InputData(DataChannel):
@@ -622,11 +619,6 @@ class InputSignal(SignalChannel):
 
     def __str__(self):
         return f"{self.label} runs {self.callback.__name__}"
-
-    def to_dict(self) -> dict:
-        d = super().to_dict()
-        d["callback"] = self.callback.__name__
-        return d
 
     def _connect_output_signal(self, signal: OutputSignal):
         self.connect(signal)

--- a/pyiron_workflow/mixin/has_to_dict.py
+++ b/pyiron_workflow/mixin/has_to_dict.py
@@ -1,17 +1,76 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 from json import dumps
 
+from pyiron_workflow.mixin.has_interface_mixins import UsesState
 
-class HasToDict(ABC):
-    @abstractmethod
-    def to_dict(self):
-        pass
+
+class HasStateDisplay(UsesState, ABC):
+    """
+    A mixin that leverages :meth:`__getstate__` to automatically build a half-decent
+    JSON-compatible representation dictionary.
+
+    Child classes can over-ride :meth:`display_state` to add or remove elements from
+    the display dictionary, e.g. to (optionally) expose state elements that would
+    otherwise be private or to show properties that are computed and not stored in
+    state, or (mandatory -- JSON demands it) remove recursion from the state.
+
+    Provides a :meth:`_repr_json_` method leveraging this beautified state dictionary
+    to give a standard JSON representation in Jupyter notebooks.
+    """
+
+    def display_state(
+        self, state: dict | None = None, ignore_private: bool = True
+    ) -> dict:
+        """
+        A dictionary of JSON-compatible objects based on the object state (plus
+        whatever modifications to the state the class designer has chosen to make).
+
+        Anything that fails to dump to JSON gets cast as a string and then dumped.
+
+        Args:
+            state (dict|None): The starting state. Default is None which uses
+                `__getstate__`, but available in case child classes want to first
+                sanitize the state values.
+            ignore_private (bool): Whether to ignore or include any state element
+                whose key starts with `'_'`. Default is True, only show public data.
+
+        Returns:
+            dict:
+        """
+        display = dict(self.__getstate__()) if state is None else state
+        to_del = []
+        for k, v in display.items():
+            if ignore_private and k.startswith("_"):
+                to_del.append(k)
+
+            if isinstance(v, HasStateDisplay):
+                display[k] = v.display_state(ignore_private=ignore_private)
+            else:
+                try:
+                    display[k] = dumps(v)
+                except TypeError:
+                    display[k] = dumps(str(v))
+
+        for k in to_del:
+            del display[k]
+
+        return display
 
     def _repr_json_(self):
-        return self.to_dict()
+        return self.display_state()
 
-    def info(self):
-        print(dumps(self.to_dict(), indent=2))
-
-    def __str__(self):
-        return str(self.to_dict())
+    @staticmethod
+    def _make_entry_public(state: dict, private_key: str, public_key: str):
+        if private_key not in state.keys():
+            raise ValueError(
+                f"Can't make {private_key} public, it was not found among "
+                f"{list(state.keys())}"
+            )
+        if public_key in state.keys():
+            raise ValueError(
+                f"Can't make {private_key} public, {public_key} is already a key in"
+                f" the dict!"
+            )
+        state[public_key] = state[private_key]
+        del state[private_key]
+        return state

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -17,7 +17,6 @@ from pyiron_snippets.dotdict import DotDict
 
 from pyiron_workflow.draw import Node as GraphvizNode
 from pyiron_workflow.logging import logger
-from pyiron_workflow.mixin.has_to_dict import HasStateDisplay
 from pyiron_workflow.mixin.injection import HasIOWithInjection
 from pyiron_workflow.mixin.run import Runnable, ReadinessError
 from pyiron_workflow.mixin.semantics import Semantic

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -17,7 +17,7 @@ from pyiron_snippets.dotdict import DotDict
 
 from pyiron_workflow.draw import Node as GraphvizNode
 from pyiron_workflow.logging import logger
-from pyiron_workflow.mixin.has_to_dict import HasToDict
+from pyiron_workflow.mixin.has_to_dict import HasStateDisplay
 from pyiron_workflow.mixin.injection import HasIOWithInjection
 from pyiron_workflow.mixin.run import Runnable, ReadinessError
 from pyiron_workflow.mixin.semantics import Semantic
@@ -38,10 +38,9 @@ if TYPE_CHECKING:
 
 
 class Node(
-    HasToDict,
+    HasIOWithInjection,
     Semantic,
     Runnable,
-    HasIOWithInjection,
     ExploitsSingleOutput,
     ABC,
 ):
@@ -937,3 +936,11 @@ class Node(
             report_so_far + f"{newline}{tabspace}{self.label}: "
             f"{'ok' if self.import_ready else 'NOT IMPORTABLE'}"
         )
+
+    def display_state(self, state=None, ignore_private=True):
+        state = dict(self.__getstate__()) if state is None else state
+        if self.parent is not None:
+            state["parent"] = self.parent.full_label
+        if len(state["_user_data"]) > 0:
+            self._make_entry_public(state, "_user_data", "user_data")
+        return super().display_state(state=state, ignore_private=ignore_private)

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -137,12 +137,6 @@ class Composite(SemanticParent, HasCreator, Node, ABC):
         for node in self:
             node.deactivate_strict_hints()
 
-    def to_dict(self):
-        return {
-            "label": self.label,
-            "nodes": {n.label: n.to_dict() for n in self.children.values()},
-        }
-
     def on_run(self):
         # Reset provenance and run status trackers
         self.provenance_by_execution = []

--- a/pyiron_workflow/nodes/function.py
+++ b/pyiron_workflow/nodes/function.py
@@ -337,17 +337,6 @@ class Function(StaticNode, ScrapesIO, ABC):
             output = output[0]
         return output
 
-    def to_dict(self):
-        return {
-            "label": self.label,
-            "ready": self.ready,
-            "connected": self.connected,
-            "fully_connected": self.fully_connected,
-            "inputs": self.inputs.to_dict(),
-            "outputs": self.outputs.to_dict(),
-            "signals": self.signals.to_dict(),
-        }
-
     @property
     def color(self) -> str:
         """For drawing the graph"""

--- a/pyiron_workflow/nodes/static_io.py
+++ b/pyiron_workflow/nodes/static_io.py
@@ -119,3 +119,10 @@ class StaticNode(Node, HasIOPreview, ABC):
                 f"{self.full_label} cannot iterate on {non_input_kwargs} because "
                 f"they are not among input channels {self.inputs.labels}"
             )
+
+    def display_state(self, state=None, ignore_private=True):
+        state = dict(self.__getstate__()) if state is None else state
+        self._make_entry_public(state, "_inputs", "inputs")
+        self._make_entry_public(state, "_outputs", "outputs")
+        self._make_entry_public(state, "_signals", "signals")
+        return super().display_state(state=state, ignore_private=ignore_private)

--- a/pyiron_workflow/nodes/transform.py
+++ b/pyiron_workflow/nodes/transform.py
@@ -23,9 +23,6 @@ class Transformer(StaticNode, ABC):
     into a single output or vice-versa.
     """
 
-    def to_dict(self):
-        pass  # Vestigial abstract method
-
 
 class FromManyInputs(Transformer, ABC):
     _output_name: ClassVar[str]  # Mandatory attribute for non-abstract subclasses


### PR DESCRIPTION
Functionality is similar -- the point is to get a nice JSON representation for child classes. But the public interface is different (hence minor flag), and in particular we don't use `to_dict` which might interfere with other pyiron activities. There's also some changes to exactly the display looks like, but since it's just a nice/useful thing for humans to look at, this is non-critical and can be improved with patches as needed.