### PR TITLE
[patch] Add space for extra information

### DIFF
--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from abc import ABC
 from concurrent.futures import Future
 from importlib import import_module
+from inspect import getsource
 from typing import Any, Literal, Optional, TYPE_CHECKING
 
 from pyiron_snippets.colors import SeabornColors
@@ -943,3 +944,10 @@ class Node(
         if len(state["_user_data"]) > 0:
             self._make_entry_public(state, "_user_data", "user_data")
         return super().display_state(state=state, ignore_private=ignore_private)
+
+    @classmethod
+    def _extra_info(cls) -> str:
+        """
+        Any additional info that may be particularly useful for users of the node class.
+        """
+        return ""

--- a/pyiron_workflow/nodes/function.py
+++ b/pyiron_workflow/nodes/function.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from inspect import getsource
 from typing import Any
 
 from pyiron_snippets.colors import SeabornColors
@@ -341,6 +342,10 @@ class Function(StaticNode, ScrapesIO, ABC):
     def color(self) -> str:
         """For drawing the graph"""
         return SeabornColors.green
+
+    @classmethod
+    def _extra_info(cls) -> str:
+        return getsource(cls.node_function)
 
 
 @classfactory

--- a/pyiron_workflow/nodes/macro.py
+++ b/pyiron_workflow/nodes/macro.py
@@ -459,7 +459,7 @@ class Macro(Composite, StaticNode, ScrapesIO, ABC):
 
     @classmethod
     def _extra_info(cls) -> str:
-        return getsource(cls.node_function)
+        return getsource(cls.graph_creator)
 
 
 @classfactory

--- a/pyiron_workflow/nodes/macro.py
+++ b/pyiron_workflow/nodes/macro.py
@@ -6,6 +6,7 @@ interface and are not intended to be internally modified after instantiation.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from inspect import getsource
 import re
 from typing import TYPE_CHECKING
 
@@ -455,6 +456,10 @@ class Macro(Composite, StaticNode, ScrapesIO, ABC):
 
         for (child, child_out), out in output_links:
             self.children[child].outputs[child_out].value_receiver = self.outputs[out]
+
+    @classmethod
+    def _extra_info(cls) -> str:
+        return getsource(cls.node_function)
 
 
 @classfactory

--- a/pyiron_workflow/nodes/transform.py
+++ b/pyiron_workflow/nodes/transform.py
@@ -372,6 +372,10 @@ class DataclassNode(FromManyInputs, ABC):
             for name, f in cls._dataclass_fields.items()
         }
 
+    @classmethod
+    def _extra_info(cls) -> str:
+        return cls.dataclass.__doc__
+
 
 @classfactory
 def dataclass_node_factory(


### PR DESCRIPTION
@JNmpi, per our discussion today, I added a private and very generic place for nodes to store extra information that might be useful to users of the node class: the class method `Node._extra_info()`.

Function and macros expose the source code for their `node_function` and `graph_creator`, respectively. Dataclass nodes defined in `__main__` are a little prickly with `inspect.getsource` for reasons I don't understand. Instead of having a lengthy fight with it for this private trial feature, I just directly leveraged the underlying dataclass's `__doc__`, which at least has the standard signature info.

Since this is all private methods for now, we can iterate from here freely in whatever direction is most useful for the GUI without worrying about backwards compatibility.