### PR TITLE
[patch] Let pint-hinted input values pass through type hinting

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - executorlib =0.0.2
 - graphviz =9.0.0
 - pandas =2.2.2
+- pint =0.24.3
 - pyiron_snippets =0.1.4
 - python-graphviz =0.20.3
 - toposort =1.10

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - executorlib =0.0.2
 - graphviz =9.0.0
 - pandas =2.2.2
+- pint =0.24.3
 - pyiron_snippets =0.1.4
 - python-graphviz =0.20.3
 - toposort =1.10

--- a/.ci_support/lower_bound.yml
+++ b/.ci_support/lower_bound.yml
@@ -8,6 +8,7 @@ dependencies:
 - executorlib =0.0.1
 - graphviz =9.0.0
 - pandas =2.2.0
+- pint =0.23.0
 - pyiron_snippets =0.1.4
 - python-graphviz =0.20.0
 - toposort =1.10

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,6 +14,7 @@ dependencies:
 - executorlib =0.0.2
 - graphviz =9.0.0
 - pandas =2.2.2
+- pint =0.24.3
 - pyiron_snippets =0.1.4
 - python-graphviz =0.20.3
 - toposort =1.10

--- a/pyiron_workflow/type_hinting.py
+++ b/pyiron_workflow/type_hinting.py
@@ -7,10 +7,13 @@ import types
 import typing
 from collections.abc import Callable
 
+from pint import Quantity
 from typeguard import check_type, TypeCheckError
 
 
 def valid_value(value, type_hint) -> bool:
+    value = value.magnitude if isinstance(value, Quantity) else value  # De-unit it
+
     try:
         return isinstance(value, type_hint)
     except TypeError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "executorlib==0.0.2",
     "graphviz==0.20.3",
     "pandas==2.2.2",
+    "pint==0.24.3",
     "pyiron_snippets==0.1.4",
     "toposort==1.10",
     "typeguard==4.3.0",

--- a/tests/unit/test_type_hinting.py
+++ b/tests/unit/test_type_hinting.py
@@ -1,6 +1,7 @@
 import typing
 import unittest
 
+from pint import UnitRegistry
 
 from pyiron_workflow.type_hinting import (
     type_hint_is_as_or_more_specific_than, valid_value
@@ -16,6 +17,8 @@ class TestTypeHinting(unittest.TestCase):
             def __call__(self):
                 return None
 
+        ureg = UnitRegistry()
+
         for hint, good, bad in (
                 (int | float, 1, "foo"),
                 (typing.Union[int, float], 2.0, "bar"),
@@ -29,6 +32,7 @@ class TestTypeHinting(unittest.TestCase):
                 (typing.Callable, Bar(), Foo()),
                 (tuple[int, float], (1, 1.1), ("fo", 0)),
                 (dict[str, int], {'a': 1}, {'a': 'b'}),
+                (int, 1 * ureg.seconds, 1.0 * ureg.seconds)  # Disregard unit, look@type
         ):
             with self.subTest(msg=f"Good {good} vs hint {hint}"):
                 self.assertTrue(valid_value(good, hint))


### PR DESCRIPTION
By checking the actual datatype associated with their "magnitude".

I'm also boldly going to try setting the lower bound to the last version and hope it works.

Motivated by https://github.com/pyiron/elaston/pull/45