### PR TITLE
[patch] Detatched path

### DIFF
--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -65,12 +65,11 @@ class Semantic(UsesState, HasLabel, HasParent, ABC):
             # Exit early if nothing is changing
             return
 
-        if new_parent is not None:
-            if not isinstance(new_parent, SemanticParent):
-                raise ValueError(
-                    f"Expected None or a {SemanticParent.__name__} for the parent of "
-                    f"{self.label}, but got {new_parent}"
-                )
+        if new_parent is not None and not isinstance(new_parent, SemanticParent):
+            raise ValueError(
+                f"Expected None or a {SemanticParent.__name__} for the parent of "
+                f"{self.label}, but got {new_parent}"
+            )
 
         if (
             self._parent is not None

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -212,6 +212,7 @@ class Composite(SemanticParent, HasCreator, Node, ABC):
         # Un-parent existing nodes before ditching them
         for node in self:
             node._parent = None
+            node._detached_parent_path = None
         other_self.running = False  # It's done now
         state = self._get_state_from_remote_other(other_self)
         self.__setstate__(state)

--- a/tests/unit/mixin/test_semantics.py
+++ b/tests/unit/mixin/test_semantics.py
@@ -97,6 +97,39 @@ class TestSemantics(unittest.TestCase):
             msg="Path root"
         )
 
+    def test_detached_parent_path(self):
+        orphan = Semantic("orphan")
+        orphan.__setstate__(self.child2.__getstate__())
+        self.assertIsNone(
+            orphan.parent,
+            msg="We still should not explicitly have a parent"
+        )
+        self.assertListEqual(
+            orphan.detached_parent_path.split(orphan.semantic_delimiter),
+            self.child2.semantic_path.split(orphan.semantic_delimiter)[:-1],
+            msg="Despite not having a parent, the detached path should store semantic "
+                "path info through the get/set state routine"
+        )
+        self.assertEqual(
+            orphan.semantic_path,
+            self.child2.semantic_path,
+            msg="The detached path should carry through to semantic path in the "
+                "absence of a parent"
+        )
+        orphan.label = "orphan"  # Re-set label after getting state
+        orphan.parent = self.child2.parent
+        self.assertIsNone(
+            orphan.detached_parent_path,
+            msg="Detached paths aren't necessary and shouldn't co-exist with the "
+                "presence of a parent"
+        )
+        self.assertListEqual(
+            orphan.semantic_path.split(orphan.semantic_delimiter)[:-1],
+            self.child2.semantic_path.split(self.child2.semantic_delimiter)[:-1],
+            msg="Sanity check -- except for the now-different labels, we should be "
+                "recovering the usual semantic path on setting a parent."
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Let's the `my_node.semantic_path` retain parent path information even through the `__get/setstate__` cycle (e.g. when (un)pickling)