### PR TITLE
Restarting process

### DIFF
--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -492,14 +492,13 @@ class Node(
         if self.parent is not None:
             self.parent.register_child_starting(self)
 
-        foo = super().run(
+        return super().run(
             check_readiness=check_readiness,
             force_local_execution=force_local_execution,
             _finished_callback=(
                 self._finish_run_and_emit_ran if emit_ran_signal else self._finish_run
             ),
         )
-        return foo
 
     def run_data_tree(self, run_parent_trees_too=False) -> None:
         """

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from concurrent.futures import Future
 from importlib import import_module
-from inspect import getsource
 from typing import Any, Literal, Optional, TYPE_CHECKING
 
 import cloudpickle

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -152,7 +152,7 @@ class Node(
 
     This is an abstract class.
     Children *must* define how :attr:`inputs` and :attr:`outputs` are constructed,
-    what will happen :meth:`_on_run`, the :attr:`run_args` that will get passed to
+    what will happen :meth:`_on_run`, the :attr:`_run_args` that will get passed to
     :meth:`_on_run`, and how to :meth:`process_run_result` once :meth:`_on_run` finishes.
     They may optionally add additional signal channels to the signals IO.
 
@@ -178,8 +178,8 @@ class Node(
         graph_path (str): The file-path-like path of node labels from the parent-most
             node down to this node.
         graph_root (Node): The parent-most node in this graph.
-        run_args (dict): **Abstract** the argmuments to use for actually running the
-            node. Must be specified in child classes.
+        run_args (dict): What to pass to the `on_run` method when :meth:`run` is called.
+            Leans on the abstract :attr:`_run_args` defined in child classes.
         running (bool): Whether the node has called :meth:`run` and has not yet
             received output from this call. (Default is False.)
         checkpoint (Literal["pickle"] | StorageInterface | None): Whether to trigger a
@@ -373,6 +373,15 @@ class Node(
 
     @abstractmethod
     def _on_run(self, *args, **kwargs) -> Any:
+        pass
+
+    @property
+    def run_args(self) -> tuple[tuple, dict]:
+        return self._run_args
+
+    @property
+    @abstractmethod
+    def _run_args(self, *args, **kwargs) -> Any:
         pass
 
     def run(

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -7,7 +7,7 @@ The workhorse class for the entire concept.
 
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from concurrent.futures import Future
 from importlib import import_module
 from inspect import getsource
@@ -152,8 +152,8 @@ class Node(
 
     This is an abstract class.
     Children *must* define how :attr:`inputs` and :attr:`outputs` are constructed,
-    what will happen :meth:`on_run`, the :attr:`run_args` that will get passed to
-    :meth:`on_run`, and how to :meth:`process_run_result` once :meth:`on_run` finishes.
+    what will happen :meth:`_on_run`, the :attr:`run_args` that will get passed to
+    :meth:`_on_run`, and how to :meth:`process_run_result` once :meth:`_on_run` finishes.
     They may optionally add additional signal channels to the signals IO.
 
     Attributes:
@@ -214,8 +214,8 @@ class Node(
             its internal structure.
         execute: An alias for :meth:`run`, but with flags to run right here, right now,
             and with the input it currently has.
-        on_run: **Abstract.** Do the thing. What thing must be specified by child
-            classes.
+        on_run: What the node does on running, leans on abstract `_on_run` method
+            defined by children.
         pull: An alias for :meth:`run` that runs everything upstream, then runs this
             node (but doesn't fire off the `ran` signal, so nothing happens farther
             downstream). "Upstream" may optionally break out of the local scope to run
@@ -367,6 +367,13 @@ class Node(
             f"should be neither running nor failed, and all input values should"
             f" conform to type hints.\n" + self.readiness_report
         )
+
+    def on_run(self, *args, **kwargs) -> Any:
+        return self._on_run(*args, **kwargs)
+
+    @abstractmethod
+    def _on_run(self, *args, **kwargs) -> Any:
+        pass
 
     def run(
         self,

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -200,7 +200,7 @@ class Composite(SemanticParent, HasCreator, Node, ABC):
                 self.signal_queue.append((firing, receiving))
 
     @property
-    def run_args(self) -> tuple[tuple, dict]:
+    def _run_args(self) -> tuple[tuple, dict]:
         return (), {}
 
     def process_run_result(self, run_output):

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -141,9 +141,7 @@ class Composite(SemanticParent, HasCreator, Node, ABC):
         # Reset provenance and run status trackers
         self.provenance_by_execution = []
         self.provenance_by_completion = []
-        self.running_children = [
-            n.label for n in self if n.running
-        ]
+        self.running_children = [n.label for n in self if n.running]
         self.signal_queue = []
 
         for node in self.starting_nodes:

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -141,7 +141,9 @@ class Composite(SemanticParent, HasCreator, Node, ABC):
         # Reset provenance and run status trackers
         self.provenance_by_execution = []
         self.provenance_by_completion = []
-        self.running_children = []
+        self.running_children = [
+            n.label for n in self if n.running
+        ]
         self.signal_queue = []
 
         for node in self.starting_nodes:

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -137,7 +137,7 @@ class Composite(SemanticParent, HasCreator, Node, ABC):
         for node in self:
             node.deactivate_strict_hints()
 
-    def on_run(self):
+    def _on_run(self):
         # Reset provenance and run status trackers
         self.provenance_by_execution = []
         self.provenance_by_completion = []

--- a/pyiron_workflow/nodes/for_loop.py
+++ b/pyiron_workflow/nodes/for_loop.py
@@ -236,9 +236,9 @@ class For(Composite, StaticNode, ABC):
         self.starting_nodes = input_nodes
         self._input_node_labels = tuple(n.label for n in input_nodes)
 
-    def on_run(self):
+    def _on_run(self):
         self._build_body()
-        return super().on_run()
+        return super()._on_run()
 
     def _build_body(self):
         """

--- a/pyiron_workflow/nodes/function.py
+++ b/pyiron_workflow/nodes/function.py
@@ -313,7 +313,7 @@ class Function(StaticNode, ScrapesIO, ABC):
         return preview if len(preview) > 0 else {"None": type(None)}
         # If clause facilitates functions with no return value
 
-    def on_run(self, **kwargs):
+    def _on_run(self, **kwargs):
         return self.node_function(**kwargs)
 
     @property

--- a/pyiron_workflow/nodes/function.py
+++ b/pyiron_workflow/nodes/function.py
@@ -317,7 +317,7 @@ class Function(StaticNode, ScrapesIO, ABC):
         return self.node_function(**kwargs)
 
     @property
-    def run_args(self) -> tuple[tuple, dict]:
+    def _run_args(self) -> tuple[tuple, dict]:
         kwargs = self.inputs.to_value_dict()
         return (), kwargs
 

--- a/pyiron_workflow/nodes/transform.py
+++ b/pyiron_workflow/nodes/transform.py
@@ -36,10 +36,10 @@ class FromManyInputs(Transformer, ABC):
 
     # _build_inputs_preview required from parent class
     # Inputs convert to `run_args` as a value dictionary
-    # This must be commensurate with the internal expectations of on_run
+    # This must be commensurate with the internal expectations of _on_run
 
     @abstractmethod
-    def on_run(self, **inputs_to_value_dict) -> Any:
+    def _on_run(self, **inputs_to_value_dict) -> Any:
         """Must take inputs kwargs"""
 
     @property
@@ -64,7 +64,7 @@ class ToManyOutputs(Transformer, ABC):
     # Must be commensurate with the dictionary returned by transform_to_output
 
     @abstractmethod
-    def on_run(self, input_object) -> callable[..., Any | tuple]:
+    def _on_run(self, input_object) -> callable[..., Any | tuple]:
         """Must take the single object to be transformed"""
 
     @property
@@ -89,7 +89,7 @@ class InputsToList(_HasLength, FromManyInputs, ABC):
     _output_name: ClassVar[str] = "list"
     _output_type_hint: ClassVar[Any] = list
 
-    def on_run(self, **inputs_to_value_dict):
+    def _on_run(self, **inputs_to_value_dict):
         return list(inputs_to_value_dict.values())
 
     @classmethod
@@ -101,7 +101,7 @@ class ListToOutputs(_HasLength, ToManyOutputs, ABC):
     _input_name: ClassVar[str] = "list"
     _input_type_hint: ClassVar[Any] = list
 
-    def on_run(self, input_object: list):
+    def _on_run(self, input_object: list):
         return {f"item_{i}": v for i, v in enumerate(input_object)}
 
     @classmethod
@@ -184,7 +184,7 @@ class InputsToDict(FromManyInputs, ABC):
         list[str] | dict[str, tuple[Any | None, Any | NOT_DATA]]
     ]
 
-    def on_run(self, **inputs_to_value_dict):
+    def _on_run(self, **inputs_to_value_dict):
         return inputs_to_value_dict
 
     @classmethod
@@ -284,7 +284,7 @@ class InputsToDataframe(_HasLength, FromManyInputs, ABC):
     _output_name: ClassVar[str] = "df"
     _output_type_hint: ClassVar[Any] = DataFrame
 
-    def on_run(self, *rows: dict[str, Any]) -> Any:
+    def _on_run(self, *rows: dict[str, Any]) -> Any:
         df_dict = {}
         for i, row in enumerate(rows):
             for key, value in row.items():
@@ -363,7 +363,7 @@ class DataclassNode(FromManyInputs, ABC):
             ):
                 self.inputs[name] = self._dataclass_fields[name].default_factory()
 
-    def on_run(self, **inputs_to_value_dict):
+    def _on_run(self, **inputs_to_value_dict):
         return self.dataclass(**inputs_to_value_dict)
 
     @property

--- a/pyiron_workflow/nodes/transform.py
+++ b/pyiron_workflow/nodes/transform.py
@@ -35,7 +35,7 @@ class FromManyInputs(Transformer, ABC):
     _output_type_hint: ClassVar[Any] = None
 
     # _build_inputs_preview required from parent class
-    # Inputs convert to `run_args` as a value dictionary
+    # Inputs convert to `_run_args` as a value dictionary
     # This must be commensurate with the internal expectations of _on_run
 
     @abstractmethod
@@ -43,7 +43,7 @@ class FromManyInputs(Transformer, ABC):
         """Must take inputs kwargs"""
 
     @property
-    def run_args(self) -> tuple[tuple, dict]:
+    def _run_args(self) -> tuple[tuple, dict]:
         return (), self.inputs.to_value_dict()
 
     @classmethod
@@ -68,7 +68,7 @@ class ToManyOutputs(Transformer, ABC):
         """Must take the single object to be transformed"""
 
     @property
-    def run_args(self) -> tuple[tuple, dict]:
+    def _run_args(self) -> tuple[tuple, dict]:
         return (self.inputs[self._input_name].value,), {}
 
     @classmethod
@@ -295,7 +295,7 @@ class InputsToDataframe(_HasLength, FromManyInputs, ABC):
         return DataFrame(df_dict)
 
     @property
-    def run_args(self) -> tuple[tuple, dict]:
+    def _run_args(self) -> tuple[tuple, dict]:
         return tuple(self.inputs.to_value_dict().values()), {}
 
     @classmethod
@@ -367,7 +367,7 @@ class DataclassNode(FromManyInputs, ABC):
         return self.dataclass(**inputs_to_value_dict)
 
     @property
-    def run_args(self) -> tuple[tuple, dict]:
+    def _run_args(self) -> tuple[tuple, dict]:
         return (), self.inputs.to_value_dict()
 
     @classmethod

--- a/tests/unit/mixin/test_run.py
+++ b/tests/unit/mixin/test_run.py
@@ -43,7 +43,7 @@ class ConcreteRunnable(Runnable):
 
 
 class FailingRunnable(ConcreteRunnable):
-    def _on_run(self, **kwargs):
+    def on_run(self, **kwargs):
         raise RuntimeError()
 
 

--- a/tests/unit/mixin/test_run.py
+++ b/tests/unit/mixin/test_run.py
@@ -43,7 +43,7 @@ class ConcreteRunnable(Runnable):
 
 
 class FailingRunnable(ConcreteRunnable):
-    def on_run(self, **kwargs):
+    def _on_run(self, **kwargs):
         raise RuntimeError()
 
 

--- a/tests/unit/nodes/test_composite.py
+++ b/tests/unit/nodes/test_composite.py
@@ -603,6 +603,38 @@ class TestComposite(unittest.TestCase):
                 "retain its executor"
         )
 
+    def test_result_serialization(self):
+        """
+        This is actually only a useful feature if you have an executor which will
+        continue the process _after_ the parent python process has been shut down
+        (e.g. you sent the run code off to a slurm queue using `executorlib`.), but
+        we'll ensure that the plumbing works here by faking things a bit.
+        """
+        self.comp.use_cache = False
+
+        self.comp.child = Composite.create.function_node(plus_one, x=42)
+        self.comp.starting_nodes = [self.comp.child]
+
+        self.comp.child.serialize_result = True
+        self.comp.child.use_cache = False
+        self.comp.child._do_clean = False
+
+        out = self.comp.run()
+        self.assertTrue(self.comp.child._temporary_results_file.is_file())
+        self.assertEqual(self.comp.child.outputs.y.value, 42 + 1)
+
+        self.comp.child.running = True  # Fake it
+        self.comp.child._do_clean = True  # Clean up this time
+        self.comp.run()
+
+        self.assertFalse(self.comp.child._temporary_results_file.is_file())
+        self.assertEqual(self.comp.child.outputs.y.value, 42 + 1)
+        self.assertFalse(
+            self.comp.as_path().is_dir(),
+            msg="Actually, we expect cleanup to have removed empty directories up to "
+                "and including the semantic root's own directory"
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -34,7 +34,7 @@ class ANode(Node):
         return add_one(*args)
 
     @property
-    def run_args(self) -> dict:
+    def _run_args(self) -> dict:
         return (self.inputs.x.value,), {}
 
     def process_run_result(self, run_output):

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -511,6 +511,36 @@ class TestNode(unittest.TestCase):
                 finally:
                     saves.delete_storage(backend)  # Clean up
 
+    def test_result_serialization(self):
+        """
+        This is actually only a useful feature if you have an executor which will
+        continue the process _after_ the parent python process has been shut down
+        (e.g. you sent the run code off to a slurm queue using `executorlib`.), but
+        we'll ensure that the plumbing works here by faking things a bit.
+        """
+        n = ANode(label="test", x=42)
+        n.serialize_result = True
+        n.use_cache = False
+        n._do_clean = False  # Power-user override to prevent the serialization from
+        # being removed
+        out = n()
+        self.assertTrue(
+            n._temporary_results_file.is_file(),
+            msg="Sanity check that we've saved the output"
+        )
+        # Now fake it
+        n.running = True
+        n._do_clean = True  # This time clean up after yourself
+        reloaded = n()
+        self.assertEqual(out, reloaded)
+        self.assertFalse(n.running)
+        self.assertFalse(n._temporary_results_file.is_file())
+        self.assertFalse(
+            n.as_path().is_dir(),
+            msg="Actually, we expect cleanup to have removed empty directories up to "
+                "and including the node's own directory"
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -30,7 +30,7 @@ class ANode(Node):
     def outputs(self) -> OutputsWithInjection:
         return self._outputs
 
-    def on_run(self, *args, **kwargs):
+    def _on_run(self, *args, **kwargs):
         return add_one(*args)
 
     @property


### PR DESCRIPTION
To work with long-duration nodes on executors that survive the shutdown of the parent workflow/node python process (e.g. `executorlib` using slurm), we need to be able to tell the run paradigm to serialize the results, and to try to load such a serialization if we come back and the node is running.

This introduces new attributes `Node.serialize_results` to trigger the result serialization, and a private `Node._do_clean` to let power users (i.e. me writing the unit tests) stop the serialized results from getting cleaned up automatically at read-time. 

Under the hood, `Node` now directly implements `Runnable.on_run` and `Runnable.run_args` leveraging the new detached path from #457 to make sure that each run has access to a semantically relevant path for writing the temporary output file (using cloudpickle). Child classes of `Node` implement new abstract methods `Node._on_run` and `Node._run_args` in place of the previous `Runnable` abstract methods they implemented.

TODO:
- [ ] ~Figure out how to get the node/parent workflow to checkpoint itself _after_ it has set its status to "running" when it is going to rely on serialization~ rebase this onto `main`; since breaking the `Runnable.run` cycle down, getting a right-before-running-checkpoint should be quite easy
- [ ] Try it out on cmmc to make sure it actually works in production
- [ ] Document it, probably in the deepdive