### PR TITLE
change style depending on the state

### DIFF
--- a/pyiron_workflow/draw.py
+++ b/pyiron_workflow/draw.py
@@ -174,7 +174,7 @@ class DataChannel(_Channel):
     @property
     def style(self) -> str:
         if len(self.channel.connections) == 0 and self.channel.value is NotData():
-            return "dashed"
+            return "bold"
         return "filled"
 
 

--- a/pyiron_workflow/draw.py
+++ b/pyiron_workflow/draw.py
@@ -10,6 +10,8 @@ from typing import Literal, Optional, TYPE_CHECKING
 import graphviz
 from pyiron_snippets.colors import SeabornColors
 
+from pyiron_workflow.channels import NotData
+
 if TYPE_CHECKING:
     from pyiron_workflow.channels import Channel as WorkflowChannel
     from pyiron_workflow.io import DataIO, SignalIO
@@ -120,7 +122,7 @@ class _Channel(WorkflowGraphvizMap, ABC):
             label=self.label,
             shape=self.shape,
             color=self.color,
-            style="filled",
+            style=self.style,
             fontname="helvetica",
         )
 
@@ -154,6 +156,10 @@ class _Channel(WorkflowGraphvizMap, ABC):
     def graph(self) -> graphviz.graphs.Digraph:
         return self.parent.graph
 
+    @property
+    def style(self) -> str:
+        return "filled"
+
 
 class DataChannel(_Channel):
     @property
@@ -164,6 +170,12 @@ class DataChannel(_Channel):
     @property
     def shape(self) -> str:
         return "oval"
+
+    @property
+    def style(self) -> str:
+        if len(self.channel.connections) == 0 and self.channel.value is NotData():
+            return "dashed"
+        return "filled"
 
 
 class SignalChannel(_Channel):


### PR DESCRIPTION
In the `draw` method I find it extremely difficult to figure out which (especially input) parameters still have to be defined, and I'm sure I'm not the only one feeling this way, but I'm not really sure what would be the best way to distinguish different states. In this example, only `Add__y` has no color, because it's not connected and no value is assigned:

```python
from pyiron_workflow import Workflow, function_node

def add(x, y):
    output = x + y
    return output

def mul(x, y=2):
    output = x * y
    return output

wf = Workflow("draw")
wf.Add = function_node(add, x=1)
wf.Mul = function_node(mul, x=wf.Add)

wf.draw()
```

<img width="1141" alt="Screenshot 2024-09-19 at 13 21 45" src="https://github.com/user-attachments/assets/ec649685-badf-4515-9610-2c0a31d6d106">



I find it pretty nice because you can immediately see that `Add__y` has to get a value or be connected. But this example is just a suggestion, which I don't consider to be the best possible product. So let me know what you think. @liamhuber @JNmpi @Tara-Lakshmipathy.