### PR TITLE
[patch] Refactor run

### DIFF
--- a/pyiron_workflow/mixin/run.py
+++ b/pyiron_workflow/mixin/run.py
@@ -179,7 +179,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
             return finished_callback(run_output)
         else:
             if isinstance(executor, ThreadPoolExecutor):
-                self.future = executor.submit(self.thread_pool_run, *args, **kwargs)
+                self.future = executor.submit(self._thread_pool_run, *args, **kwargs)
             else:
                 self.future = executor.submit(self.on_run, *args, **kwargs)
             self.future.add_done_callback(finished_callback)
@@ -210,7 +210,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
         finally:
             self._run_finally()
 
-    def thread_pool_run(self, *args, **kwargs):
+    def _thread_pool_run(self, *args, **kwargs):
         #
         result = self.on_run(*args, **kwargs)
         sleep(self._thread_pool_sleep_time)

--- a/pyiron_workflow/mixin/run.py
+++ b/pyiron_workflow/mixin/run.py
@@ -128,9 +128,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
             None if self.executor is None else self._parse_executor(self.executor)
         )
         finished_callback = (
-            self._finish_run
-            if _finished_callback is None
-            else _finished_callback
+            self._finish_run if _finished_callback is None else _finished_callback
         )
 
         self.running = True

--- a/pyiron_workflow/mixin/run.py
+++ b/pyiron_workflow/mixin/run.py
@@ -211,7 +211,6 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
             self._run_finally()
 
     def _thread_pool_run(self, *args, **kwargs):
-        #
         result = self.on_run(*args, **kwargs)
         sleep(self._thread_pool_sleep_time)
         return result

--- a/pyiron_workflow/mixin/run.py
+++ b/pyiron_workflow/mixin/run.py
@@ -241,8 +241,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
 
         self.running = False
         try:
-            processed_output = self.process_run_result(run_output)
-            return processed_output
+            return self.process_run_result(run_output)
         except Exception as e:
             self._run_exception()
             raise e

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -477,6 +477,7 @@ class Node(
         return super()._run(finished_callback=finished_callback, executor=executor)
 
     def _run_finally(self):
+        super()._run_finally()
         if self.parent is not None:
             self.parent.register_child_finished(self)
         if self.checkpoint is not None:

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -29,6 +29,7 @@ from pyiron_workflow.topology import (
 )
 
 if TYPE_CHECKING:
+    from concurrent.futures import Executor
     from pathlib import Path
 
     import graphviz
@@ -467,10 +468,14 @@ class Node(
 
         return super()._before_run(check_readiness=check_readiness)
 
-    def _run(self, finished_callback: callable) -> Any | tuple | Future:
+    def _run(
+        self,
+        finished_callback: callable,
+        executor: Executor,
+    ) -> Any | tuple | Future:
         if self.parent is not None:
             self.parent.register_child_starting(self)
-        return super()._run(finished_callback=finished_callback)
+        return super()._run(finished_callback=finished_callback, executor=executor)
 
     def run_data_tree(self, run_parent_trees_too=False) -> None:
         """

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from abc import ABC
 from concurrent.futures import Future
 from importlib import import_module
-from inspect import getsource
 from typing import Any, Literal, Optional, TYPE_CHECKING
 
 from pyiron_snippets.colors import SeabornColors

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -588,15 +588,11 @@ class Node(
     def _outputs_to_run_return(self):
         return DotDict(self.outputs.to_value_dict())
 
-    def _finish_run(self, run_output: tuple | Future) -> Any | tuple:
-        try:
-            processed_output = super()._finish_run(run_output=run_output)
-            if self.parent is not None:
-                self.parent.register_child_finished(self)
-            return processed_output
-        finally:
-            if self.checkpoint is not None:
-                self.save_checkpoint(self.checkpoint)
+    def _run_finally(self):
+        if self.parent is not None:
+            self.parent.register_child_finished(self)
+        if self.checkpoint is not None:
+            self.save_checkpoint(self.checkpoint)
 
     def _finish_run_and_emit_ran(self, run_output: tuple | Future) -> Any | tuple:
         processed_output = self._finish_run(run_output)


### PR DESCRIPTION
The only part that's not a pure refactor (I believe), is that now if you encounter an error trying to `_parse_executor` it will still raise the exception, but the node isn't running yet and so it won't set the status to `failed`. Since the executor is some separate object we apply to any function, I feel this is a minor improvement in behaviour, as the node itself hasn't failed for this sort of exception!