### PR TITLE
[patch] `Runnable` flexibility and a new output signal

### DIFF
--- a/pyiron_workflow/io.py
+++ b/pyiron_workflow/io.py
@@ -299,6 +299,7 @@ class HasIO(HasStateDisplay, HasLabel, HasRun, ABC):
             "accumulate_and_run", self, self.run
         )
         self._signals.output.ran = OutputSignal("ran", self)
+        self._signals.output.failed = OutputSignal("failed", self)
 
     @property
     @abstractmethod

--- a/pyiron_workflow/mixin/run.py
+++ b/pyiron_workflow/mixin/run.py
@@ -98,7 +98,8 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
         self,
         check_readiness: bool = True,
         _finished_callback: Optional[callable] = None,
-        **kwargs,
+        before_run_kwargs: dict | None = None,
+        finish_run_kwargs: dict | None = None,
     ) -> Any | tuple | Future:
         """
         Checks that the runnable is :attr:`ready` (if requested), then executes the
@@ -120,7 +121,11 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
                 (:attr:`running`/:attr:`failed`) and should only be set by expert users.
                 (Default is :meth:`_finish_run`.)
         """
-        stop_early, result = self._before_run(check_readiness=check_readiness, **kwargs)
+        before_run_kwargs = {} if before_run_kwargs is None else before_run_kwargs
+        stop_early, result = self._before_run(
+            check_readiness=check_readiness,
+            **before_run_kwargs
+        )
         if stop_early:
             return result
 

--- a/pyiron_workflow/mixin/run.py
+++ b/pyiron_workflow/mixin/run.py
@@ -135,8 +135,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
         finish_run_kwargs = _none_to_dict(finish_run_kwargs)
 
         stop_early, result = self._before_run(
-            check_readiness=check_readiness,
-            **before_run_kwargs
+            check_readiness=check_readiness, **before_run_kwargs
         )
         if stop_early:
             return result
@@ -151,7 +150,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
             run_exception_kwargs=run_exception_kwargs,
             run_finally_kwargs=run_finally_kwargs,
             finish_run_kwargs=finish_run_kwargs,
-            **run_kwargs
+            **run_kwargs,
         )
 
     def _before_run(self, /, check_readiness, **kwargs) -> tuple[bool, Any]:
@@ -182,7 +181,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
         run_exception_kwargs: dict,
         run_finally_kwargs: dict,
         finish_run_kwargs: dict,
-        **kwargs
+        **kwargs,
     ) -> Any | tuple | Future:
         """
         What happens while the status is :attr:`running`, namely invoking
@@ -215,7 +214,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
                 run_output,
                 run_exception_kwargs=run_exception_kwargs,
                 run_finally_kwargs=run_finally_kwargs,
-                **finish_run_kwargs
+                **finish_run_kwargs,
             )
         else:
             if isinstance(executor, ThreadPoolExecutor):
@@ -231,7 +230,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
                     self._finish_run,
                     run_exception_kwargs=run_exception_kwargs,
                     run_finally_kwargs=run_finally_kwargs,
-                    **finish_run_kwargs
+                    **finish_run_kwargs,
                 )
             )
             return self.future
@@ -256,7 +255,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
         /,
         run_exception_kwargs: dict,
         run_finally_kwargs: dict,
-        **kwargs
+        **kwargs,
     ) -> Any | tuple:
         """
         Switch the status, then process and return the run result.

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -427,10 +427,12 @@ class Node(
 
         return super().run(
             check_readiness=check_readiness,
-            run_data_tree=run_data_tree,
-            run_parent_trees_too=run_parent_trees_too,
-            fetch_input=fetch_input,
-            emit_ran_signal=emit_ran_signal,
+            before_run_kwargs={
+                "run_data_tree": run_data_tree,
+                "run_parent_trees_too": run_parent_trees_too,
+                "fetch_input": fetch_input,
+                "emit_ran_signal": emit_ran_signal,
+            },
             _finished_callback=(
                 self._finish_run_and_emit_ran if emit_ran_signal else self._finish_run
             ),

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -614,7 +614,10 @@ class Node(
 
     @property
     def emitting_channels(self) -> tuple[OutputSignal]:
-        return (self.signals.output.ran,)
+        if self.failed:
+            return (self.signals.output.failed,)
+        else:
+            return (self.signals.output.ran,)
 
     def emit(self):
         for channel in self.emitting_channels:

--- a/pyiron_workflow/nodes/standard.py
+++ b/pyiron_workflow/nodes/standard.py
@@ -63,7 +63,9 @@ class If(Function):
 
     @property
     def emitting_channels(self) -> tuple[OutputSignal]:
-        if self.outputs.truth.value:
+        if self.outputs.truth.value is NOT_DATA:
+            return super().emitting_channels
+        elif self.outputs.truth.value:
             return (*super().emitting_channels, self.signals.output.true)
         else:
             return (*super().emitting_channels, self.signals.output.false)

--- a/tests/unit/mixin/test_run.py
+++ b/tests/unit/mixin/test_run.py
@@ -141,21 +141,6 @@ class TestRunnable(unittest.TestCase):
             msg="Expected the result, including post-processing 'bar' value"
         )
 
-    def test_runnable_run_with_executor_and_callback(self):
-        runnable = ConcreteRunnable()
-        runnable.executor = CloudpickleProcessPoolExecutor()
-
-        result = runnable.run(_finished_callback=runnable.custom_callback)
-        self.assertDictEqual(
-            runnable.expected_run_output,
-            result.result(timeout=30),
-            msg="Callback does not impact the actual run function"
-        )
-        self.assertDictEqual(
-            runnable.expected_custom_callback_processed_value,
-            runnable.processed
-        )
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -159,6 +159,24 @@ class TestNode(unittest.TestCase):
                 "execution"
         )
 
+    def test_failure_signal(self):
+        n = ANode(label="failing")
+        n.inputs.x._value = "cannot add 1 to this"  # Bypass type hint with private
+
+        class Counter:
+            def __init__(self):
+                self.count = 0
+
+            def add(self):
+                self.count += 1
+        c = Counter()
+        n.signals.output.failed.connections = [c.add]
+        self.assertEqual(
+            c.count,
+            1,
+            msg="Failed signal should fire after type error"
+        )
+
     def test_execute(self):
         self.n1.outputs.y = 0  # Prime the upstream data source for fetching
         self.n2 >> self.n3

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -172,7 +172,10 @@ class TestNode(unittest.TestCase):
 
         c = Counter()
         n.signals.output.failed.connections = [c.add]
-        n.run(check_readiness=False)
+        try:
+            n.run(check_readiness=False)
+        except TypeError:
+            pass  # Expected -- we're _trying_ to get failure to fire
         self.assertEqual(
             c.count,
             1,

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -167,10 +167,12 @@ class TestNode(unittest.TestCase):
             def __init__(self):
                 self.count = 0
 
-            def add(self):
+            def add(self, signal):
                 self.count += 1
+
         c = Counter()
         n.signals.output.failed.connections = [c.add]
+        n.run(check_readiness=False)
         self.assertEqual(
             c.count,
             1,


### PR DESCRIPTION
Now we always use the same callback function, but each step of the `Runnable.run` cycle flexibly lets child classes define kwargs for each step. This lets us stop passing the callback function as an argument and just always use `Runnable._finish_run`.

In `Node`, the new kwargs mean we can move firing the signals over to the `_run_finally` method, and take advantage of this to add a new `failed` output signal.

There's a decent amount going on under the hood here, but for users there is no incompatible changes, just the new signal.