### PR TITLE
Get close matches

### DIFF
--- a/pyiron_workflow/io.py
+++ b/pyiron_workflow/io.py
@@ -77,7 +77,7 @@ class IO(HasStateDisplay, ABC):
             # Raise an attribute error from getattr to make sure hasattr works well!
             raise AttributeError(
                 f"Could not find attribute {item} on {self.__class__.__name__} object "
-                f"nor in its channels ({self.labels})"
+                f"nor in its channels ({self.labels})."
             )
 
     def __setattr__(self, key, value):

--- a/pyiron_workflow/io.py
+++ b/pyiron_workflow/io.py
@@ -77,7 +77,7 @@ class IO(HasStateDisplay, ABC):
             # Raise an attribute error from getattr to make sure hasattr works well!
             raise AttributeError(
                 f"Could not find attribute {item} on {self.__class__.__name__} object "
-                f"nor in its channels ({self.labels})."
+                f"nor in its channels ({self.labels})"
             )
 
     def __setattr__(self, key, value):

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Optional
 
 from bidict import bidict
+from difflib import get_close_matches
 
 from pyiron_workflow.logging import logger
 from pyiron_workflow.mixin.has_interface_mixins import HasLabel, HasParent, UsesState
@@ -199,11 +200,13 @@ class SemanticParent(Semantic, ABC):
             return self._children[key]
         except KeyError:
             # Raise an attribute error from getattr to make sure hasattr works well!
-            raise AttributeError(
-                f"Could not find attribute {key} on {self.label} "
-                f"({self.__class__.__name__}) or among its children "
-                f"({self._children.keys()})"
-            )
+            msg = f"Could not find attribute {key} on {self.label} "
+            msg += f"({self.__class__.__name__}) or among its children "
+            msg += f"({self._children.keys()})."
+            matches = get_close_matches(key, self._children.keys(), cutoff=0.8)
+            if len(matches) > 0:
+                msg += f" Did you mean {matches[0]} instead of {key}?"
+            raise AttributeError(msg)
 
     def __iter__(self):
         return self.children.values().__iter__()

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -200,12 +200,12 @@ class SemanticParent(Semantic, ABC):
             return self._children[key]
         except KeyError:
             # Raise an attribute error from getattr to make sure hasattr works well!
-            msg = f"Could not find attribute {key} on {self.label} "
+            msg = f"Could not find attribute '{key}' on {self.label} "
             msg += f"({self.__class__.__name__}) or among its children "
             msg += f"({self._children.keys()})."
             matches = get_close_matches(key, self._children.keys(), cutoff=0.8)
             if len(matches) > 0:
-                msg += f" Did you mean {matches[0]} and not {key}?"
+                msg += f" Did you mean '{matches[0]}' and not '{key}'?"
             raise AttributeError(msg)
 
     def __iter__(self):

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -205,7 +205,7 @@ class SemanticParent(Semantic, ABC):
             msg += f"({self._children.keys()})."
             matches = get_close_matches(key, self._children.keys(), cutoff=0.8)
             if len(matches) > 0:
-                msg += f" Did you mean {matches[0]} instead of {key}?"
+                msg += f" Did you mean {matches[0]} and not {key}?"
             raise AttributeError(msg)
 
     def __iter__(self):

--- a/tests/unit/mixin/test_semantics.py
+++ b/tests/unit/mixin/test_semantics.py
@@ -18,7 +18,7 @@ class TestSemantics(unittest.TestCase):
         with self.assertRaises(AttributeError) as context:
             _ = self.middle1.Middle_sub
         self.assertIn(
-            "Did you mean middle_sub",
+            "Did you mean middle_sub and not Middle_sub",
             str(context.exception),
             msg="middle_sub must be suggested as it is close to Middle_sub"
         )

--- a/tests/unit/mixin/test_semantics.py
+++ b/tests/unit/mixin/test_semantics.py
@@ -14,6 +14,22 @@ class TestSemantics(unittest.TestCase):
         self.middle2 = SemanticParent("middle_sub", parent=self.middle1)
         self.child2 = Semantic("child2", parent=self.middle2)
 
+    def test_getattr(self):
+        with self.assertRaises(AttributeError) as context:
+            _ = self.middle1.Middle_sub
+        self.assertIn(
+            "Did you mean middle_sub",
+            str(context.exception),
+            msg="middle_sub must be suggested as it is close to Middle_sub"
+        )
+        with self.assertRaises(AttributeError) as context:
+            _ = self.middle1.my_neighbor_stinks
+        self.assertNotIn(
+            "Did you mean",
+            str(context.exception),
+            msg="Nothings should be suggested for my_neighbor_stinks"
+        )
+
     def test_label_validity(self):
         with self.assertRaises(TypeError, msg="Label must be a string"):
             Semantic(label=123)

--- a/tests/unit/mixin/test_semantics.py
+++ b/tests/unit/mixin/test_semantics.py
@@ -18,7 +18,7 @@ class TestSemantics(unittest.TestCase):
         with self.assertRaises(AttributeError) as context:
             _ = self.middle1.Middle_sub
         self.assertIn(
-            "Did you mean middle_sub and not Middle_sub",
+            "Did you mean 'middle_sub' and not 'Middle_sub'",
             str(context.exception),
             msg="middle_sub must be suggested as it is close to Middle_sub"
         )


### PR DESCRIPTION
```python
wf = Workflow("tesile")
wf.Composition = standard_nodes.UserInput("Aluminum")
wf.BoxSize = standard_nodes.UserInput(3 * [1.0e-5])
wf.Seeds = function_node(...)
wf.Grid = function_node(...)
wf.Elasticity = function_node(...)
wf.Plasticity = function_node(...)
wf.Phase = function_node(...)
wf.Homogenization = function_node(...)
wf.Material = function_node(generate_material, elements=wf.Compositions)
```

The previous error message in this situation was: `Could not find attribute Compositions on tesile (Workflow) or among its children (dict_keys(['Composition', 'BoxSize', 'Seeds', 'Grid', 'Elasticity', 'Plasticity', 'Phase', 'Homogenization'])).`. It was sort of difficult to figure out which one I wanted to say for this large number of possibilities. So I added `get_close_matches` to append the message: `Did you mean 'Composition' and not 'Compositions'?`

Also, in general I find the error messages in `pyiron_workflow` difficult to understand. It must be difficult for @liamhuber to figure it out alone so I'm gonna make suggestions in the upcoming weeks.