### PR TITLE
Update error message of IO when an inexistent arg is used

### DIFF
--- a/pyiron_workflow/io.py
+++ b/pyiron_workflow/io.py
@@ -420,7 +420,8 @@ class HasIO(HasStateDisplay, HasLabel, HasRun, ABC):
         for k, v in kwargs.items():
             self.inputs[k] = v
 
-    def _ensure_all_input_keys_present(self, used_keys, available_keys):
+    @staticmethod
+    def _ensure_all_input_keys_present(used_keys, available_keys):
         diff = set(used_keys).difference(available_keys)
         if len(diff) > 0:
             raise ValueError(

--- a/pyiron_workflow/io.py
+++ b/pyiron_workflow/io.py
@@ -415,14 +415,17 @@ class HasIO(HasStateDisplay, HasLabel, HasRun, ABC):
 
         kwargs.update(keyed_args)
 
-        if len(set(kwargs.keys()).difference(self.inputs.labels)) > 0:
-            raise ValueError(
-                f"Tried to set input {list(kwargs.keys())}, but one or more label was "
-                f"not found among available inputs: {self.inputs.labels}"
-            )
+        self._ensure_all_input_keys_present(kwargs.keys(), self.inputs.labels)
 
         for k, v in kwargs.items():
             self.inputs[k] = v
+
+    def _ensure_all_input_keys_present(self, used_keys, available_keys):
+        diff = set(used_keys).difference(available_keys)
+        if len(diff) > 0:
+            raise ValueError(
+                f"{diff} not found among available inputs: {available_keys}"
+            )
 
     def copy_io(
         self,


### PR DESCRIPTION
Code:
```python
def f(a, b, c):
    return a

function_node(f, a=1, b=2, d=3)
```

Previous error message:
`ValueError: Tried to set input ['a', 'b', 'd'], but one or more label was not found among available inputs: ['a', 'b', 'c']`

New error message:
`ValueError: {'d'} not found among available inputs: ['a', 'b', 'c']`