### PR TITLE
[patch] uniformly expose `filename` in `Node` storage interface.

### DIFF
--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -834,7 +834,11 @@ class Node(
         self.graph_root.save(backend=backend)
 
     def load(
-        self, backend: str | StorageInterface = "pickle", only_requested=False, **kwargs
+        self,
+        backend: str | StorageInterface = "pickle",
+        only_requested=False,
+        filename: str | Path | None = None,
+        **kwargs
     ):
         """
 
@@ -846,6 +850,9 @@ class Node(
             only_requested (bool): Whether to _only_ try loading from the specified
                 backend, or to loop through all available backends. (Default is False,
                 try to load whatever you can find.)
+            filename (str | Path | None): The name of the file (without extensions) at
+                which to save the node. (Default is None, which uses the node's
+                semantic path.)
             **kwargs: back end-specific arguments (only likely to work in combination
                 with :param:`only_requested`, otherwise there's nothing to be specific
                 _to_.)
@@ -857,7 +864,11 @@ class Node(
         for backend in available_backends(
             backend=backend, only_requested=only_requested
         ):
-            inst = backend.load(node=self, **kwargs)
+            inst = backend.load(
+                node=self if filename is None else None,
+                filename=filename,
+                **kwargs
+            )
             if inst is not None:
                 break
         if inst is None:
@@ -877,6 +888,7 @@ class Node(
         self,
         backend: Literal["pickle"] | StorageInterface | None = None,
         only_requested: bool = False,
+        filename: str | Path | None = None,
         **kwargs,
     ):
         """
@@ -888,6 +900,9 @@ class Node(
             only_requested (bool): Whether to _only_ try loading from the specified
                 backend, or to loop through all available backends. (Default is False,
                 try to load whatever you can find.)
+            filename (str | Path | None): The name of the file (without extensions) at
+                which to save the node. (Default is None, which uses the node's
+                semantic path.)
             **kwargs: back end-specific arguments (only likely to work in combination
                 with :param:`only_requested`, otherwise there's nothing to be specific
                 _to_.)
@@ -895,12 +910,17 @@ class Node(
         for backend in available_backends(
             backend=backend, only_requested=only_requested
         ):
-            backend.delete(node=self, **kwargs)
+            backend.delete(
+                node=self if filename is None else None,
+                filename=filename,
+                **kwargs
+            )
 
     def has_saved_content(
         self,
         backend: Literal["pickle"] | StorageInterface | None = None,
         only_requested: bool = False,
+        filename: str | Path | None = None,
         **kwargs,
     ):
         """
@@ -912,6 +932,9 @@ class Node(
             only_requested (bool): Whether to _only_ try loading from the specified
                 backend, or to loop through all available backends. (Default is False,
                 try to load whatever you can find.)
+            filename (str | Path | None): The name of the file (without extensions) at
+                which to save the node. (Default is None, which uses the node's
+                semantic path.)
             **kwargs: back end-specific arguments (only likely to work in combination
                 with :param:`only_requested`, otherwise there's nothing to be specific
                 _to_.)
@@ -920,7 +943,11 @@ class Node(
             bool: Whether any save files were found
         """
         return any(
-            be.has_saved_content(self, **kwargs)
+            be.has_saved_content(
+                node=self if filename is None else None,
+                filename=filename,
+                **kwargs
+            )
             for be in available_backends(backend=backend, only_requested=only_requested)
         )
 

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -838,7 +838,7 @@ class Node(
         backend: str | StorageInterface = "pickle",
         only_requested=False,
         filename: str | Path | None = None,
-        **kwargs
+        **kwargs,
     ):
         """
 
@@ -865,9 +865,7 @@ class Node(
             backend=backend, only_requested=only_requested
         ):
             inst = backend.load(
-                node=self if filename is None else None,
-                filename=filename,
-                **kwargs
+                node=self if filename is None else None, filename=filename, **kwargs
             )
             if inst is not None:
                 break
@@ -911,9 +909,7 @@ class Node(
             backend=backend, only_requested=only_requested
         ):
             backend.delete(
-                node=self if filename is None else None,
-                filename=filename,
-                **kwargs
+                node=self if filename is None else None, filename=filename, **kwargs
             )
 
     def has_saved_content(
@@ -944,9 +940,7 @@ class Node(
         """
         return any(
             be.has_saved_content(
-                node=self if filename is None else None,
-                filename=filename,
-                **kwargs
+                node=self if filename is None else None, filename=filename, **kwargs
             )
             for be in available_backends(backend=backend, only_requested=only_requested)
         )


### PR DESCRIPTION
It's already there in the underlying storage interface, and in `Node.save`, so here we just extend the exposure to `Node.load`, `.has_saved_content`, and `.delete_storage`.

I.e. 

```python

from pyiron_workflow import Workflow

n = Workflow.create.standard.UserInput(42)
n.save(filename="foo")
n.has_saved_content()
>>> False
n.has_saved_content(filename="foo")
>>> True
n.delete_storage(filename="foo")
n.has_saved_content(filename="foo")
>>> False
```

This will be useful for things automatic saving on failure, etc, where we don't want to overwrite the user's save file and don't necessarily want the node loading at re-instantiation. Just more flexibility overall.