### PR TITLE
[patch] Clean tests

### DIFF
--- a/notebooks/deepdive.ipynb
+++ b/notebooks/deepdive.ipynb
@@ -754,9 +754,7 @@
   {
    "cell_type": "markdown",
    "id": "174f818f-59b5-4fba-8519-864a807c4aa8",
-   "metadata": {
-    "jp-MarkdownHeadingCollapsed": true
-   },
+   "metadata": {},
    "source": [
     "## Dataclass nodes for grouping inputs\n",
     "\n",
@@ -884,6 +882,7 @@
     "repainted = Repaint()\n",
     "repainted.inputs.new_color = \"light urple\"\n",
     "try:\n",
+    "    repainted.recovery = None  # We know this will fail and don't care about a recovery file\n",
     "    repainted.inputs.car = \"a_string_not_a_Car\"\n",
     "except TypeError as e:\n",
     "    print(\"TypeError:\", e)"
@@ -935,6 +934,7 @@
    ],
    "source": [
     "try:\n",
+    "    repainted.recovery = None  # We know this will fail and don't care about a recovery file\n",
     "    repainted.run()\n",
     "except AttributeError as e:\n",
     "    print(\"AttributeError:\", e)"
@@ -4242,6 +4242,7 @@
     "no_fallback = pwf.PickleStorage(cloudpickle_fallback=False)\n",
     "wf.unpickleable.checkpoint = no_fallback\n",
     "try:\n",
+    "    wf.recovery = None  # We know this will fail and don't care about a recovery file\n",
     "    wf(unpickleable__x=3)\n",
     "except pwf.TypeNotFoundError as e:\n",
     "    print(\"TypeNotFoundError:\", e)"

--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -2769,6 +2769,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76d73a6c-3999-45b6-8a62-6ee49f1a0125",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up\n",
+    "reloaded.delete_storage(filename=reloaded.as_path().joinpath(\"recovery\"))"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "4c7f5d84-d9f6-4eb5-9cf0-56494c53110c",
    "metadata": {},

--- a/tests/unit/nodes/test_macro.py
+++ b/tests/unit/nodes/test_macro.py
@@ -404,6 +404,7 @@ class TestMacro(unittest.TestCase):
                 return y
 
             n1 = function_node(fail_at_zero, x=0)
+            n1.recovery = None  # We expect it to fail and don't want a file
             n2 = function_node(add_one, x=n1, label="n1")
             n_not_used = function_node(add_one)
             n_not_used >> n2  # Just here to make sure it gets restored

--- a/tests/unit/nodes/test_transform.py
+++ b/tests/unit/nodes/test_transform.py
@@ -104,6 +104,7 @@ class TestTransformer(unittest.TestCase):
     def test_inputs_to_dataframe(self):
         l = 3
         n = inputs_to_dataframe(l)
+        n.recovery = None  # Some tests intentionally fail, and we don't want a file
         for i in range(l):
             n.inputs[f"row_{i}"] = {"x": i, "xsq": i*i}
         n()
@@ -128,6 +129,7 @@ class TestTransformer(unittest.TestCase):
             n(row_0=d1, row_1=d1, row_2=d2)
 
         n = inputs_to_dataframe(l)  # Freshly instantiate to remove failed status
+        n.recovery = None  # Next test intentionally fails, and we don't want a file
         d3 = {"a": 1}
         with self.assertRaises(
             ValueError,

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -103,45 +103,48 @@ class TestNode(unittest.TestCase):
         n3_cache = self.n3.use_cache
         self.n3.use_cache = False
 
-        with self.assertRaises(
-            ValueError,
-            msg="When input is not data, we should fail early"
-        ):
-            self.n3.run(run_data_tree=False, fetch_input=False, check_readiness=True)
+        try:
+            with self.assertRaises(
+                ValueError,
+                msg="When input is not data, we should fail early"
+            ):
+                self.n3.run(run_data_tree=False, fetch_input=False, check_readiness=True)
 
-        self.assertFalse(
-            self.n3.failed,
-            msg="The benefit of the readiness check should be that we don't actually "
-                "qualify as failed"
-        )
+            self.assertFalse(
+                self.n3.failed,
+                msg="The benefit of the readiness check should be that we don't actually "
+                    "qualify as failed"
+            )
 
-        with self.assertRaises(
-            TypeError,
-            msg="If we bypass the check, we should get the failing function error"
-        ):
-            self.n3.run(run_data_tree=False, fetch_input=False, check_readiness=False)
+            with self.assertRaises(
+                TypeError,
+                msg="If we bypass the check, we should get the failing function error"
+            ):
+                self.n3.run(run_data_tree=False, fetch_input=False, check_readiness=False)
 
-        self.assertTrue(
-            self.n3.failed,
-            msg="If the node operation itself fails, the status should be failed"
-        )
+            self.assertTrue(
+                self.n3.failed,
+                msg="If the node operation itself fails, the status should be failed"
+            )
 
-        self.n3.inputs.x = 0
-        with self.assertRaises(
-            ValueError,
-            msg="When status is failed, we should fail early, even if input data is ok"
-        ):
-            self.n3.run(run_data_tree=False, fetch_input=False, check_readiness=True)
+            self.n3.inputs.x = 0
+            with self.assertRaises(
+                ValueError,
+                msg="When status is failed, we should fail early, even if input data is ok"
+            ):
+                self.n3.run(run_data_tree=False, fetch_input=False, check_readiness=True)
 
-        self.n3.failed = False
-        self.assertEqual(
-            1,
-            self.n3.run(run_data_tree=False, fetch_input=False, check_readiness=True),
-            msg="After manually resetting the failed state and providing good input, "
-                "running should proceed"
-        )
-        
-        self.n3.use_cache = n3_cache
+            self.n3.failed = False
+            self.assertEqual(
+                1,
+                self.n3.run(run_data_tree=False, fetch_input=False, check_readiness=True),
+                msg="After manually resetting the failed state and providing good input, "
+                    "running should proceed"
+            )
+
+            self.n3.use_cache = n3_cache
+        finally:
+            self.n3.delete_storage(filename=self.n3.as_path().joinpath("recovery"))
 
     def test_emit_ran_signal(self):
         self.n1 >> self.n2 >> self.n3  # Chained connection declaration
@@ -176,7 +179,8 @@ class TestNode(unittest.TestCase):
         try:
             n.run(check_readiness=False)
         except TypeError:
-            pass  # Expected -- we're _trying_ to get failure to fire
+            # Expected -- we're _trying_ to get failure to fire
+            n.delete_storage(filename=n.as_path().joinpath("recovery"))
         self.assertEqual(
             c.count,
             1,
@@ -258,13 +262,16 @@ class TestNode(unittest.TestCase):
                 "made a ran/run connection"
         )
 
-        self.n2.inputs.x._value = "manually override the desired int"
-        with self.assertRaises(
-            TypeError,
-            msg="Execute should be running without a readiness check and hitting the "
-                "string + int error"
-        ):
-            self.n2.execute()
+        try:
+            self.n2.inputs.x._value = "manually override the desired int"
+            with self.assertRaises(
+                TypeError,
+                msg="Execute should be running without a readiness check and hitting the "
+                    "string + int error"
+            ):
+                self.n2.execute()
+        finally:
+            self.n2.delete_storage(filename=self.n2.as_path().joinpath("recovery"))
 
     def test_pull(self):
         self.n2 >> self.n3


### PR DESCRIPTION
Cherry pick the commits from #476 (hence the [unrelated] labels) that stop the local tests from being polluted with recovery files