### PR TITLE
[patch] Parse executor construction instructions

### DIFF
--- a/pyiron_workflow/nodes/for_loop.py
+++ b/pyiron_workflow/nodes/for_loop.py
@@ -433,7 +433,8 @@ class For(Composite, StaticNode, ABC):
 
     def __getstate__(self):
         state = super().__getstate__()
-        state["body_node_executor"] = None
+        if isinstance(self.body_node_executor, Executor):
+            state["body_node_executor"] = None
 
         # Duplicated value linking behaviour from Macro class
         state["_input_value_links"] = self._input_value_links

--- a/pyiron_workflow/nodes/for_loop.py
+++ b/pyiron_workflow/nodes/for_loop.py
@@ -444,8 +444,9 @@ class For(Composite, StaticNode, ABC):
 
     def _get_state_from_remote_other(self, other_self):
         state = super()._get_state_from_remote_other(other_self)
-        state.pop("body_node_executor")  # Got overridden to None for __getstate__,
-        # so keep local
+        if state["body_node_executor"] is None and self.body_node_executor is not None:
+            state.pop("body_node_executor")  # May have been overridden to None for
+            # __getstate__ to avoid serializing an executor instance, so keep local
         return state
 
     def __setstate__(self, state):

--- a/tests/integration/test_parallel_speedup.py
+++ b/tests/integration/test_parallel_speedup.py
@@ -75,6 +75,26 @@ class TestSpeedup(unittest.TestCase):
                 f"a sleep node"
         )
 
+    def test_executor_instructions(self):
+        t = 2
+        wf = Workflow("test")
+        wf.sleep1 = Workflow.create.standard.Sleep(t)
+        wf.sleep2 = Workflow.create.standard.Sleep(t)
+        wf.sleep3 = Workflow.create.standard.Sleep(t)
+        wf.sleep4 = Workflow.create.standard.Sleep(t)
+        for n in wf:
+            n.executor = (Workflow.create.ThreadPoolExecutor, (), {})
+
+        t0 = perf_counter()
+        wf()
+        dt = perf_counter() - t0
+        self.assertLess(
+            dt,
+            1.1 * t,
+            msg="Expected the sleeps to run in parallel with minimal overhead (since "
+                "it's just a thread pool executor)"
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/test_parallel_speedup.py
+++ b/tests/integration/test_parallel_speedup.py
@@ -85,14 +85,18 @@ class TestSpeedup(unittest.TestCase):
         for n in wf:
             n.executor = (Workflow.create.ThreadPoolExecutor, (), {})
 
+        wf.save()
+        reloaded = Workflow("test")
+
         t0 = perf_counter()
-        wf()
+        reloaded()
         dt = perf_counter() - t0
         self.assertLess(
             dt,
             1.1 * t,
             msg="Expected the sleeps to run in parallel with minimal overhead (since "
-                "it's just a thread pool executor)"
+                "it's just a thread pool executor) -- the advantage is that the "
+                "constructors should survive (de)serialization"
         )
 
 

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -321,7 +321,7 @@ class TestWorkflow(unittest.TestCase):
                         f"written a recovery file, so after removing that the whole "
                         f"node directory for the workflow should be cleaned up."
                         f"Instead, {wf.as_path()} exists and has content "
-                        f"{[f for f in wf.as_path().iterdir()]}"
+                        f"{[f for f in wf.as_path().iterdir()] if wf.as_path().is_dir() else None}"
                 )
 
 

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -321,7 +321,7 @@ class TestWorkflow(unittest.TestCase):
                         f"written a recovery file, so after removing that the whole "
                         f"node directory for the workflow should be cleaned up."
                         f"Instead, {wf.as_path()} exists and has content "
-                        f"{list[wf.as_path().iterdir()]}"
+                        f"{[f for f in wf.as_path().iterdir()]}"
                 )
 
 

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -317,9 +317,11 @@ class TestWorkflow(unittest.TestCase):
                 wf.delete_storage(filename=wf.as_path().joinpath("recovery"))
                 self.assertFalse(
                     wf.as_path().exists(),
-                    msg="The parent-most object is the _only_ one who should have "
-                        "written a recovery file, so after removing that the whole "
-                        "node directory for the workflow should be cleaned up."
+                    msg=f"The parent-most object is the _only_ one who should have "
+                        f"written a recovery file, so after removing that the whole "
+                        f"node directory for the workflow should be cleaned up."
+                        f"Instead, {wf.as_path()} exists and has content "
+                        f"{list[wf.as_path().iterdir()]}"
                 )
 
 

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -314,6 +314,7 @@ class TestWorkflow(unittest.TestCase):
                             "object when a child fails"
                     )
             finally:
+                wf.delete_storage()
                 wf.delete_storage(filename=wf.as_path().joinpath("recovery"))
                 self.assertFalse(
                     wf.as_path().exists(),

--- a/tests/unit/mixin/test_run.py
+++ b/tests/unit/mixin/test_run.py
@@ -125,29 +125,42 @@ class TestRunnable(unittest.TestCase):
 
     def test_runnable_run_with_executor(self):
         runnable = ConcreteRunnable()
-        runnable.executor = CloudpickleProcessPoolExecutor()
 
-        result = runnable.run()
-        self.assertIsInstance(
-            result,
-            Future,
-            msg="With an executor, a future should be returned"
-        )
-        self.assertIs(
-            result,
-            runnable.future,
-            msg="With an executor, the future attribute should get populated"
-        )
-        self.assertDictEqual(
-            runnable.expected_run_output,
-            result.result(timeout=30),
-            msg="Expected the result (after waiting for it to compute, of course)"
-        )
-        self.assertDictEqual(
-            runnable.expected_processed_value,
-            runnable.processed,
-            msg="Expected the result, including post-processing 'bar' value"
-        )
+        for label, executor in [
+            ("Instance", CloudpickleProcessPoolExecutor()),
+            ("Instructutions", (CloudpickleProcessPoolExecutor, (), {}))
+        ]:
+            with self.subTest(label):
+                runnable.executor = executor
+
+                result = runnable.run()
+                self.assertIsInstance(
+                    result,
+                    Future,
+                    msg="With an executor, a future should be returned"
+                )
+                self.assertIs(
+                    result,
+                    runnable.future,
+                    msg="With an executor, the future attribute should get populated"
+                )
+                self.assertDictEqual(
+                    runnable.expected_run_output,
+                    result.result(timeout=30),
+                    msg="Expected the result (after waiting for it to compute, of course)"
+                )
+                self.assertDictEqual(
+                    runnable.expected_processed_value,
+                    runnable.processed,
+                    msg="Expected the result, including post-processing 'bar' value"
+                )
+
+        with self.assertRaises(
+            NotImplementedError,
+            msg="That's not an executor at all"
+        ):
+            runnable.executor = 42
+            runnable.run()
 
 
 if __name__ == '__main__':

--- a/tests/unit/nodes/test_for_loop.py
+++ b/tests/unit/nodes/test_for_loop.py
@@ -550,6 +550,33 @@ class TestForNode(unittest.TestCase):
         self.assertFalse(n2._output_as_dataframe)
         self.assertTrue(n3._output_as_dataframe)
 
+    def test_executor_deserialization(self):
+
+        for title, executor, expected in [
+            ("Instance", ThreadPoolExecutor(), None),
+            ("Instructions", (ThreadPoolExecutor, (), {}), (ThreadPoolExecutor, (), {}))
+        ]:
+            with self.subTest(title):
+                n = for_node(
+                    body_node_class=FiveTogether,
+                    iter_on="a",
+                    label=title,
+                )
+                n.body_node_executor = executor
+
+                try:
+                    n.save(backend="pickle")
+                    n.load(backend="pickle")
+                    self.assertEqual(
+                        n.body_node_executor,
+                        expected,
+                        msg="Executor instances should get removed on "
+                            "(de)serialization, but instructions on how to build one "
+                            "should not."
+                    )
+                finally:
+                    n.delete_storage()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Just a simple thing for parsing executors so they can survive (de)serialization. Now you can say:

```python
my_node.executor = (ProcessPoolExecutor, (), {"max_workers": 4})
```

and similar.

Even more, now it can be _any_ callable returning an executor. That means that the determined user can exploit this to return the same executor instance to multiple nodes in a pickle-compliant way (e.g. by having a separate module that instantiates an executor and a function that imports it).