### PR TITLE
[patch] Catch keyboard interrupts in `Runnable._run`

### DIFF
--- a/pyiron_workflow/mixin/run.py
+++ b/pyiron_workflow/mixin/run.py
@@ -207,7 +207,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
         if executor is None:
             try:
                 run_output = self.on_run(*on_run_args, **on_run_kwargs)
-            except Exception as e:
+            except (Exception, KeyboardInterrupt) as e:
                 self._run_exception(**run_exception_kwargs)
                 self._run_finally(**run_finally_kwargs)
                 if raise_run_exceptions:


### PR DESCRIPTION
I didn't realize they weren't caught by `Exception`; this way the keyboard interrupt still hits the `Runnable._run_finally`, and in particular `Node` still generates a recovery file