### PR TITLE
Recursive graph

### DIFF
--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -28,9 +28,11 @@ if TYPE_CHECKING:
 
 
 def get_graph_as_dict(composite: Composite) -> dict:
+    if not hasattr(composite, "_children"):
+        return composite
     return {
         "object": composite,
-        "nodes": {n.full_label: n for n in composite},
+        "nodes": {n.full_label: get_graph_as_dict(n) for n in composite},
         "edges": {
             "data": {
                 (out.full_label, inp.full_label): (out, inp)

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -27,6 +27,27 @@ if TYPE_CHECKING:
     from pyiron_workflow.storage import StorageInterface
 
 
+def get_graph_as_dict(composite: Composite) -> dict:
+    return {
+        "object": composite,
+        "nodes": {n.full_label: n for n in composite},
+        "edges": {
+            "data": {
+                (out.full_label, inp.full_label): (out, inp)
+                for n in composite
+                for out in n.outputs
+                for inp in out.connections
+            },
+            "signal": {
+                (out.full_label, inp.full_label): (out, inp)
+                for n in composite
+                for out in n.signals.output
+                for inp in out.connections
+            },
+        },
+    }
+
+
 class FailedChildError(RuntimeError):
     """Raise when one or more child nodes raise exceptions."""
 
@@ -429,23 +450,7 @@ class Composite(SemanticParent, HasCreator, Node, ABC):
         A nested dictionary representation of the computation graph using full labels
         as keys and objects as values.
         """
-        return {
-            "nodes": {n.full_label: n for n in self},
-            "edges": {
-                "data": {
-                    (out.full_label, inp.full_label): (out, inp)
-                    for n in self
-                    for out in n.outputs
-                    for inp in out.connections
-                },
-                "signal": {
-                    (out.full_label, inp.full_label): (out, inp)
-                    for n in self
-                    for out in n.signals.output
-                    for inp in out.connections
-                },
-            },
-        }
+        return get_graph_as_dict(self)
 
     def _get_connections_as_strings(
         self, panel_getter: callable

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -27,12 +27,12 @@ if TYPE_CHECKING:
     from pyiron_workflow.storage import StorageInterface
 
 
-def get_graph_as_dict(composite: Composite) -> dict:
-    if not hasattr(composite, "_children"):
+def _get_graph_as_dict(composite: Composite) -> dict:
+    if not isinstance(composite, Composite):
         return composite
     return {
         "object": composite,
-        "nodes": {n.full_label: get_graph_as_dict(n) for n in composite},
+        "nodes": {n.full_label: _get_graph_as_dict(n) for n in composite},
         "edges": {
             "data": {
                 (out.full_label, inp.full_label): (out, inp)
@@ -452,7 +452,7 @@ class Composite(SemanticParent, HasCreator, Node, ABC):
         A nested dictionary representation of the computation graph using full labels
         as keys and objects as values.
         """
-        return get_graph_as_dict(self)
+        return _get_graph_as_dict(self)
 
     def _get_connections_as_strings(
         self, panel_getter: callable


### PR DESCRIPTION
In order to separate the drawing functionality, I extended `graph_as_dict`, so that it returns all the child nodes recursively.

```python
wf = Workflow("wf")

def add(x, y):
    result = x + y
    return result

def mul(x, y):
    result = x * y
    return result

def process(macro, x, y):
    macro.Add = function_node(add, x=1, y=y)
    macro.Mul = function_node(mul, x=x, y=macro.Add)
    return macro.Mul

wf.Process = macro_node(process)
d = wf.graph_as_dict
print(d.keys())
print(d["nodes"].keys())
print(d["nodes"]["/wf/Process"].keys())
print(d["nodes"]["/wf/Process"]["nodes"].keys())
print(d["nodes"]["/wf/Process"]["nodes"]["/wf/Process/Add"])
```

Output:

```python
dict_keys(['object', 'nodes', 'edges'])
dict_keys(['/wf/Process'])
dict_keys(['object', 'nodes', 'edges'])
dict_keys(['/wf/Process/Add', '/wf/Process/Mul'])
Add (add):
Inputs ['x', 'y']
OutputsWithInjection ['result']
InputSignals ['run', 'accumulate_and_run']
OutputSignals ['ran', 'failed']
```

```python
print(d)
```

Output:

```python
{'object': <pyiron_workflow.workflow.Workflow at 0x7ff37b4db7d0>,
 'nodes': {'/wf/Process': {'object': <__main__.process at 0x7ff37ae7afd0>,
   'nodes': {'/wf/Process/Add': <__main__.add at 0x7ff37ab85050>,
    '/wf/Process/Mul': <__main__.mul at 0x7ff37a999e10>},
   'edges': {'data': {('/wf/Process/Add.result',
      '/wf/Process/Mul.y'): (<pyiron_workflow.mixin.injection.OutputDataWithInjection at 0x7ff37aeda790>, <pyiron_workflow.channels.InputData at 0x7ff37acec290>)},
    'signal': {('/wf/Process/Add.ran',
      '/wf/Process/Mul.accumulate_and_run'): (<pyiron_workflow.channels.OutputSignal at 0x7ff37a42c210>, <pyiron_workflow.channels.AccumulatingInputSignal at 0x7ff37acefdd0>)}}}},
 'edges': {'data': {}, 'signal': {}}}
```