### PR TITLE
[patch] Fix typos in dict-like type hints

### DIFF
--- a/pyiron_workflow/mixin/preview.py
+++ b/pyiron_workflow/mixin/preview.py
@@ -75,7 +75,7 @@ class HasIOPreview(ABC):
         return cls._build_outputs_preview()
 
     @classmethod
-    def preview_io(cls) -> DotDict[str:dict]:
+    def preview_io(cls) -> DotDict[str, dict]:
         return DotDict(
             {"inputs": cls.preview_inputs(), "outputs": cls.preview_outputs()}
         )

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -188,7 +188,7 @@ class SemanticParent(Semantic, ABC):
         super().__init__(*args, label=label, parent=parent, **kwargs)
 
     @property
-    def children(self) -> bidict[str:Semantic]:
+    def children(self) -> bidict[str, Semantic]:
         return self._children
 
     @property


### PR DESCRIPTION
I.e. dict[str, object] not dict[str:object], as observed by @XzzX in #514 