### PR TITLE
`mypy` channels

### DIFF
--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -91,7 +91,7 @@ class Channel(
         """
         self._label = label
         self.owner: HasIO = owner
-        self.connections: list[Channel] = []
+        self.connections: list[ConnectionPartner] = []
 
     @property
     def label(self) -> str:

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -687,14 +687,15 @@ class AccumulatingInputSignal(InputSignal):
         super().__init__(label=label, owner=owner, callback=callback)
         self.received_signals: set[str] = set()
 
-    def __call__(self, other: OutputSignal) -> None:
+    def __call__(self, other: OutputSignal | None = None) -> None:
         """
         Fire callback iff you have received at least one signal from each of your
         current connections.
 
         Resets the collection of received signals when firing.
         """
-        self.received_signals.update([other.scoped_label])
+        if isinstance(other, OutputSignal):
+            self.received_signals.update([other.scoped_label])
         if (
             len(
                 set(c.scoped_label for c in self.connections).difference(

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -342,7 +342,7 @@ class DataChannel(Channel[DataConnectionPartner], ABC):
             when this channel is a value receiver. This can potentially be expensive, so
             consider deactivating strict hints everywhere for production runs. (Default
             is True, raise exceptions when type hints get violated.)
-        value_receiver (pyiron_workflow.channel.DataChannel|None): Another channel of
+        value_receiver (pyiron_workflow.compatibility.Self|None): Another channel of
             the same class whose value will always get updated when this channel's
             value gets updated.
     """
@@ -354,7 +354,7 @@ class DataChannel(Channel[DataConnectionPartner], ABC):
         default: typing.Any | None = NOT_DATA,
         type_hint: typing.Any | None = None,
         strict_hints: bool = True,
-        value_receiver: InputData | None = None,
+        value_receiver: Self | None = None,
     ):
         super().__init__(label=label, owner=owner)
         self._value = NOT_DATA
@@ -363,7 +363,7 @@ class DataChannel(Channel[DataConnectionPartner], ABC):
         self.strict_hints = strict_hints
         self.default = default
         self.value = default  # Implicitly type check your default by assignment
-        self.value_receiver = value_receiver
+        self.value_receiver: Self = value_receiver
 
     @property
     def value(self):
@@ -390,7 +390,7 @@ class DataChannel(Channel[DataConnectionPartner], ABC):
             )
 
     @property
-    def value_receiver(self) -> InputData | OutputData | None:
+    def value_receiver(self) -> Self | None:
         """
         Another data channel of the same type to whom new values are always pushed
         (without type checking of any sort, not even when forming the couple!)
@@ -401,7 +401,7 @@ class DataChannel(Channel[DataConnectionPartner], ABC):
         return self._value_receiver
 
     @value_receiver.setter
-    def value_receiver(self, new_partner: InputData | OutputData | None):
+    def value_receiver(self, new_partner: Self | None):
         if new_partner is not None:
             if not isinstance(new_partner, self.__class__):
                 raise TypeError(

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -167,7 +167,9 @@ class Channel(
             f"connection."
         )
 
-    def disconnect(self, *others: Channel) -> list[tuple[Channel, Channel]]:
+    def disconnect(
+            self, *others: ConnectionPartner
+    ) -> list[tuple[Channel[ConnectionPartner], ConnectionPartner]]:
         """
         If currently connected to any others, removes this and the other from eachothers
         respective connections lists.
@@ -187,7 +189,9 @@ class Channel(
                 destroyed_connections.append((self, other))
         return destroyed_connections
 
-    def disconnect_all(self) -> list[tuple[Channel, Channel]]:
+    def disconnect_all(
+            self
+    ) -> list[tuple[Channel[ConnectionPartner], ConnectionPartner]]:
         """
         Disconnect from all other channels currently in the connections list.
         """

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -14,6 +14,7 @@ from abc import ABC, abstractmethod
 
 from pyiron_snippets.singleton import Singleton
 
+from pyiron_workflow.compatibility import Self
 from pyiron_workflow.mixin.display_state import HasStateDisplay
 from pyiron_workflow.mixin.has_interface_mixins import HasChannel, HasLabel
 from pyiron_workflow.type_hinting import (
@@ -169,7 +170,7 @@ class Channel(
 
     def disconnect(
             self, *others: ConnectionPartner
-    ) -> list[tuple[Channel[ConnectionPartner], ConnectionPartner]]:
+    ) -> list[tuple[Self, ConnectionPartner]]:
         """
         If currently connected to any others, removes this and the other from eachothers
         respective connections lists.
@@ -191,7 +192,7 @@ class Channel(
 
     def disconnect_all(
             self
-    ) -> list[tuple[Channel[ConnectionPartner], ConnectionPartner]]:
+    ) -> list[tuple[Self, ConnectionPartner]]:
         """
         Disconnect from all other channels currently in the connections list.
         """

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -150,13 +150,7 @@ class Channel(
             else:
                 if isinstance(other, self.connection_partner_type):
                     raise ChannelConnectionError(
-                        f"The channel {other.full_label} ({other.__class__.__name__}"
-                        f") has the correct type "
-                        f"({self.connection_partner_type.__name__}) to connect with "
-                        f"{self.full_label} ({self.__class__.__name__}), but is not "
-                        f"a valid connection. Please check type hints, etc."
-                        f"{other.full_label}.type_hint = {other.type_hint}; "
-                        f"{self.full_label}.type_hint = {self.type_hint}"
+                        self._connection_partner_failure_message(other)
                     ) from None
                 else:
                     raise TypeError(
@@ -164,6 +158,14 @@ class Channel(
                         f"objects, but {self.full_label} ({self.__class__.__name__}) "
                         f"got {other} ({type(other)})"
                     )
+
+    def _connection_partner_failure_message(self, other: ConnectionPartner) -> str:
+        return (
+            f"The channel {other.full_label} ({other.__class__.__name__}) has the "
+            f"correct type ({self.connection_partner_type.__name__}) to connect with "
+            f"{self.full_label} ({self.__class__.__name__}), but is not a valid "
+            f"connection."
+        )
 
     def disconnect(self, *others: Channel) -> list[tuple[Channel, Channel]]:
         """
@@ -464,6 +466,13 @@ class DataChannel(Channel[DataConnectionPartner], ABC):
                 return True
         else:
             return False
+
+    def _connection_partner_failure_message(self, other: DataConnectionPartner) -> str:
+        msg = super()._connection_partner_failure_message(other)
+        msg += (
+            f"Please check type hints, etc. {other.full_label}.type_hint = "
+            f"{other.type_hint}; {self.full_label}.type_hint = {self.type_hint}"
+        )
 
     def _both_typed(self, other: DataConnectionPartner) -> bool:
         return self._has_hint and other._has_hint

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -26,7 +26,11 @@ if typing.TYPE_CHECKING:
     from pyiron_workflow.io import HasIO
 
 
-class ChannelConnectionError(Exception):
+class ChannelError(Exception):
+    pass
+
+
+class ChannelConnectionError(ChannelError):
     pass
 
 
@@ -483,7 +487,18 @@ class DataChannel(Channel[DataConnectionPartner], ABC):
     def _figure_out_who_is_who(
             self, other: DataConnectionPartner
     ) -> tuple[OutputData, InputData]:
-        return (self, other) if isinstance(self, OutputData) else (other, self)
+        if isinstance(self, InputData) and isinstance(other, OutputData):
+            return other, self
+        elif isinstance(self, OutputData) and isinstance(other, InputData):
+            return self, other
+        else:
+            raise ChannelError(
+                f"This should be unreachable; data channel conjugate pairs should "
+                f"always be input/output, but got {type(self)} for {self.full_label} "
+                f"and {type(other)} for {other.full_label}. If you don't believe you "
+                f"are responsible for this error, please contact the maintainers via "
+                f"GitHub."
+            )
 
     def __str__(self):
         return str(self.value)

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -475,6 +475,7 @@ class DataChannel(Channel[DataConnectionPartner], ABC):
             f"Please check type hints, etc. {other.full_label}.type_hint = "
             f"{other.type_hint}; {self.full_label}.type_hint = {self.type_hint}"
         )
+        return msg
 
     def _both_typed(self, other: DataConnectionPartner | Self) -> bool:
         return self._has_hint and other._has_hint

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 
 from pyiron_workflow.channels import (
@@ -37,18 +39,19 @@ class DummyChannel(Channel[ConnectionPartner]):
         return "non-abstract input"
 
     def _valid_connection(self, other: object) -> bool:
-        return isinstance(other, self.connection_partner_type)
+        return isinstance(other, self.connection_partner_type())
 
 
 class InputChannel(DummyChannel["OutputChannel"]):
-    pass
+    @classmethod
+    def connection_partner_type(cls) -> type[OutputChannel]:
+        return OutputChannel
 
 
 class OutputChannel(DummyChannel["InputChannel"]):
-    pass
-
-InputChannel.connection_partner_type = OutputChannel
-OutputChannel.connection_partner_type = InputChannel
+    @classmethod
+    def connection_partner_type(cls) -> type[InputChannel]:
+        return InputChannel
 
 
 class TestChannel(unittest.TestCase):

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -6,6 +6,7 @@ from pyiron_workflow.channels import (
     BadCallbackError,
     Channel,
     ChannelConnectionError,
+    ConnectionPartner,
     InputData,
     InputSignal,
     OutputData,
@@ -30,26 +31,24 @@ class DummyOwner:
         return self.locked
 
 
-class InputChannel(Channel):
+class DummyChannel(Channel[ConnectionPartner]):
     """Just to de-abstract the base class"""
-
     def __str__(self):
         return "non-abstract input"
 
-    @property
-    def connection_partner_type(self) -> type[Channel]:
-        return OutputChannel
+    def _valid_connection(self, other: object) -> bool:
+        return isinstance(other, self.connection_partner_type)
 
 
-class OutputChannel(Channel):
-    """Just to de-abstract the base class"""
+class InputChannel(DummyChannel["OutputChannel"]):
+    pass
 
-    def __str__(self):
-        return "non-abstract output"
 
-    @property
-    def connection_partner_type(self) -> type[Channel]:
-        return InputChannel
+class OutputChannel(DummyChannel["InputChannel"]):
+    pass
+
+InputChannel.connection_partner_type = OutputChannel
+OutputChannel.connection_partner_type = InputChannel
 
 
 class TestChannel(unittest.TestCase):


### PR DESCRIPTION
Resolve all mypy complaints for the `channels` module.

The main thing here was getting the concept of a conjugate partner for connections all on a good footing -- i.e. a conjugate pair should have the same "flavor" (data or signal, so far), and be of opposite directions (i.e. one each of input and output). Doing this was a learning experience for me in using `typing.Generics`, but was relatively straightforward using a type-var for the partner and then holding it in a class method. For now I stuck as close as possible to the existing implementation, so I use the "flavors" for type-narrowing on the connection partner type.

I briefly played around with actually splitting `Channel` apart to depend on two generics: a "flavor" and a "direction" independently. I like the idea of this because I think it gives a nicer way of representing connection validity where the flavor classes are the same but the direction classes are not. However, I found it made it hard to express the _actual class_ of the connection partner, and it's important to hint these in places like the `disconnect` return values, so I abandoned this attack.