### PR TITLE
`mypy` channels redux

### DIFF
--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -208,7 +208,7 @@ class Channel(
         return self.connections.__iter__()
 
     @property
-    def channel(self) -> Channel:
+    def channel(self) -> Self:
         return self
 
     def copy_connections(self, other: Channel) -> None:
@@ -247,8 +247,6 @@ class Channel(
 class FlavorChannel(Channel[FlavorType], ABC):
     """Abstract base for all flavor-specific channels."""
 
-    pass
-
 
 class InputChannel(Channel[OutputType], ABC):
     """Mixin for input channels."""
@@ -279,8 +277,6 @@ class NotData(metaclass=Singleton):
 
 
 NOT_DATA = NotData()
-
-# DataConnectionPartner = typing.TypeVar("DataConnectionPartner", bound="DataChannel")
 
 
 class DataChannel(FlavorChannel["DataChannel"], ABC):

--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -211,7 +211,7 @@ class Channel(
     def channel(self) -> Self:
         return self
 
-    def copy_connections(self, other: Channel) -> None:
+    def copy_connections(self, other: Self) -> None:
         """
         Adds all the connections in another channel to this channel's connections.
 

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -8,7 +8,7 @@ from pyiron_workflow.channels import (
     BadCallbackError,
     Channel,
     ChannelConnectionError,
-    ConnectionPartner,
+    ConjugateType,
     InputData,
     InputSignal,
     OutputData,
@@ -33,25 +33,25 @@ class DummyOwner:
         return self.locked
 
 
-class DummyChannel(Channel[ConnectionPartner]):
+class DummyChannel(Channel[ConjugateType]):
     """Just to de-abstract the base class"""
 
     def __str__(self):
         return "non-abstract input"
 
     def _valid_connection(self, other: object) -> bool:
-        return isinstance(other, self.connection_partner_type())
+        return isinstance(other, self.connection_conjugate())
 
 
 class InputChannel(DummyChannel["OutputChannel"]):
     @classmethod
-    def connection_partner_type(cls) -> type[OutputChannel]:
+    def connection_conjugate(cls) -> type[OutputChannel]:
         return OutputChannel
 
 
 class OutputChannel(DummyChannel["InputChannel"]):
     @classmethod
-    def connection_partner_type(cls) -> type[InputChannel]:
+    def connection_conjugate(cls) -> type[InputChannel]:
         return InputChannel
 
 


### PR DESCRIPTION
When I proceeded to the `io` module, I realized a problem: Here again we need to be hinting the return of input/output pairs on `disconnect`-like calls. In the `channel` module, we can rely directly on the `Self` and generic types to accomplish this, but for `io` there is no _generic_ way to hint that what gets returned is an I/O pair! This forced me to revisit my [earlier idea](https://github.com/pyiron/pyiron_workflow/pull/534#issue-2776304908) of explicitly decomposing the connection partners (now "conjugate pairs") into a "flavour" channel which should match, and a "direction" channel which should be opposite.

I had to hack away at it a bit to get a representation I liked, but the concrete class definitions are still nearly as succinct, but we have explicit `InputType` and `OutputType` type-vars to work with over in `io`. Since `channel` was already passing `mypy`, this is net neutral on the number of errors.

It's a pain to assert mypy failures against counter-definitions inside the unittest framework, but for the posterity these two counter-examples now fail in a desirable way:

```python

# Fail by pairing input with input
class DataReflexiput(DataChannel, InputChannel["InputData"]):
    @classmethod
    def connection_conjugate(cls) -> type[InputData]:
        return InputData
# error: Type argument "InputData" of "InputChannel" must be a subtype of "OutputChannel[Any]"  [type-var]


# Fail by mismatching flavours
class VomitInput(DataChannel, InputChannel["OutputSignal"]):
    @classmethod
    def connection_conjugate(cls) -> type[OutputSignal]:
        return OutputSignal
# error: Return type "type[OutputSignal]" of "connection_conjugate" incompatible with return type "type[DataChannel]" in supertype "Channel"  [override]
```