### PR TITLE
`mypy` semantics

### DIFF
--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -63,6 +63,13 @@ class Semantic(UsesState, HasLabel, HasParent, ABC):
 
     @parent.setter
     def parent(self, new_parent: SemanticParent | None) -> None:
+        self._set_parent(new_parent)
+
+    def _set_parent(self, new_parent: SemanticParent | None):
+        """
+        mypy is uncooperative with super calls for setters, so we pull the behaviour
+        out.
+        """
         if new_parent is self._parent:
             # Exit early if nothing is changing
             return
@@ -365,7 +372,7 @@ class SemanticParent(Semantic, Generic[ChildType], ABC):
     @parent.setter
     def parent(self, new_parent: SemanticParent | None) -> None:
         self._ensure_path_is_not_cyclic(new_parent, self)
-        super(SemanticParent, type(self)).parent.__set__(self, new_parent)
+        self._set_parent(new_parent)
 
     def __getstate__(self):
         state = super().__getstate__()

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -200,6 +200,11 @@ class SemanticParent(Semantic, Generic[ChildType], ABC):
     @classmethod
     @abstractmethod
     def child_type(cls) -> type[ChildType]:
+        # Dev note: In principle, this could be a regular attribute
+        # However, in other situations this is precluded (e.g. in channels)
+        # since it would result in circular references.
+        # Here we favour consistency over brevity,
+        # and maintain the X_type() class method pattern
         pass
 
     @property

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -259,12 +259,6 @@ class SemanticParent(Semantic, Generic[ChildType], ABC):
                 f"but got {child}"
             )
 
-        if isinstance(child, ParentMost):
-            raise ParentMostError(
-                f"{child.label} is {ParentMost.__name__} and may only take None as a "
-                f"parent but was added as a child to {self.label}"
-            )
-
         self._ensure_path_is_not_cyclic(self, child)
 
         self._ensure_child_has_no_other_parent(child)
@@ -405,27 +399,3 @@ class SemanticParent(Semantic, Generic[ChildType], ABC):
         # children). So, now return their parent to them:
         for child in self:
             child.parent = self
-
-
-class ParentMostError(TypeError):
-    """
-    To be raised when assigning a parent to a parent-most object
-    """
-
-
-class ParentMost(SemanticParent[ChildType], ABC):
-    """
-    A semantic parent that cannot have any other parent.
-    """
-
-    @property
-    def parent(self) -> None:
-        return None
-
-    @parent.setter
-    def parent(self, new_parent: None):
-        if new_parent is not None:
-            raise ParentMostError(
-                f"{self.label} is {ParentMost.__name__} and may only take None as a "
-                f"parent but got {type(new_parent)}"
-            )

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -342,15 +342,15 @@ class SemanticParent(Semantic, Generic[ChildType], ABC):
             )
         return new_label
 
-    def remove_child(self, child: Semantic | str) -> Semantic:
+    def remove_child(self, child: ChildType | str) -> ChildType:
         if isinstance(child, str):
             child = self.children.pop(child)
-        elif isinstance(child, Semantic):
+        elif isinstance(child, self.child_type()):
             self.children.inv.pop(child)
         else:
             raise TypeError(
                 f"{self.label} expected to remove a child of type str or "
-                f"{Semantic.__name__} but got {child}"
+                f"{self.child_type()} but got {child}"
             )
 
         child.parent = None

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -20,6 +20,7 @@ from typing import Generic, TypeVar
 
 from bidict import bidict
 
+from pyiron_workflow.compatibility import Self
 from pyiron_workflow.logging import logger
 from pyiron_workflow.mixin.has_interface_mixins import HasLabel, HasParent, UsesState
 
@@ -281,7 +282,7 @@ class SemanticParent(Semantic, Generic[ChildType], ABC):
         return child
 
     @staticmethod
-    def _ensure_path_is_not_cyclic(parent: SemanticParent | None, child: ChildType):
+    def _ensure_path_is_not_cyclic(parent: SemanticParent | None, child: Semantic):
         if parent is not None and parent.semantic_path.startswith(
             child.semantic_path + child.semantic_delimiter
         ):

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -36,7 +36,7 @@ class Semantic(UsesState, HasLabel, HasParent, ABC):
     def __init__(
         self, label: str, *args, parent: SemanticParent | None = None, **kwargs
     ):
-        self._label = None
+        self._label = ""
         self._parent = None
         self._detached_parent_path = None
         self.label = label

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -31,7 +31,7 @@ class Semantic(UsesState, HasLabel, HasParent, ABC):
     accessible.
     """
 
-    semantic_delimiter = "/"
+    semantic_delimiter: str = "/"
 
     def __init__(
         self, label: str, *args, parent: SemanticParent | None = None, **kwargs

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -20,7 +20,6 @@ from typing import Generic, TypeVar
 
 from bidict import bidict
 
-from pyiron_workflow.compatibility import Self
 from pyiron_workflow.logging import logger
 from pyiron_workflow.mixin.has_interface_mixins import HasLabel, HasParent, UsesState
 

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -54,7 +54,7 @@ class FailedChildError(RuntimeError):
     """Raise when one or more child nodes raise exceptions."""
 
 
-class Composite(SemanticParent, HasCreator, Node, ABC):
+class Composite(SemanticParent[Node], HasCreator, Node, ABC):
     """
     A base class for nodes that have internal graph structure -- i.e. they hold a
     collection of child nodes and their computation is to execute that graph.
@@ -153,6 +153,10 @@ class Composite(SemanticParent, HasCreator, Node, ABC):
             strict_naming=strict_naming,
             **kwargs,
         )
+
+    @classmethod
+    def child_type(cls) -> type[Node]:
+        return Node
 
     def activate_strict_hints(self):
         super().activate_strict_hints()

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -424,8 +424,6 @@ class Composite(SemanticParent[Node], HasCreator, Node, ABC):
     def __setattr__(self, key: str, node: Node):
         if isinstance(node, Composite) and key in ["_parent", "parent"]:
             # This is an edge case for assigning a node to an attribute
-            # We either defer to the setter with super, or directly assign the private
-            # variable (as requested in the setter)
             super().__setattr__(key, node)
         elif isinstance(node, Node):
             self.add_child(node, label=key)

--- a/pyiron_workflow/workflow.py
+++ b/pyiron_workflow/workflow.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any, Literal
 from bidict import bidict
 
 from pyiron_workflow.io import Inputs, Outputs
-from pyiron_workflow.mixin.semantics import ParentMost
 from pyiron_workflow.nodes.composite import Composite
 
 if TYPE_CHECKING:
@@ -20,7 +19,13 @@ if TYPE_CHECKING:
     from pyiron_workflow.storage import StorageInterface
 
 
-class Workflow(ParentMost, Composite):
+class ParentMostError(TypeError):
+    """
+    To be raised when assigning a parent to a parent-most object
+    """
+
+
+class Workflow(Composite):
     """
     Workflows are a dynamic composite node -- i.e. they hold and run a collection of
     nodes (a subgraph) which can be dynamically modified (adding and removing nodes,
@@ -495,3 +500,15 @@ class Workflow(ParentMost, Composite):
             raise e
 
         return owned_node
+
+    @property
+    def parent(self) -> None:
+        return None
+
+    @parent.setter
+    def parent(self, new_parent: None):
+        if new_parent is not None:
+            raise ParentMostError(
+                f"{self.label} is a {self.__class__} and may only take None as a "
+                f"parent but got {type(new_parent)}"
+            )

--- a/tests/unit/mixin/test_semantics.py
+++ b/tests/unit/mixin/test_semantics.py
@@ -9,12 +9,24 @@ from pyiron_workflow.mixin.semantics import (
 )
 
 
+class ConcreteParent(SemanticParent[Semantic]):
+    @classmethod
+    def child_type(cls) -> type[Semantic]:
+        return Semantic
+
+
+class ConcreteParentMost(ParentMost[Semantic]):
+    @classmethod
+    def child_type(cls) -> type[Semantic]:
+        return Semantic
+
+
 class TestSemantics(unittest.TestCase):
     def setUp(self):
-        self.root = ParentMost("root")
+        self.root = ConcreteParentMost("root")
         self.child1 = Semantic("child1", parent=self.root)
-        self.middle1 = SemanticParent("middle", parent=self.root)
-        self.middle2 = SemanticParent("middle_sub", parent=self.middle1)
+        self.middle1 = ConcreteParent("middle", parent=self.root)
+        self.middle2 = ConcreteParent("middle_sub", parent=self.middle1)
         self.child2 = Semantic("child2", parent=self.middle2)
 
     def test_getattr(self):
@@ -62,12 +74,12 @@ class TestSemantics(unittest.TestCase):
             with self.assertRaises(
                 TypeError, msg=f"{ParentMost.__name__} instances can't have parent"
             ):
-                self.root.parent = SemanticParent(label="foo")
+                self.root.parent = ConcreteParent(label="foo")
 
             with self.assertRaises(
                 TypeError, msg=f"{ParentMost.__name__} instances can't be children"
             ):
-                some_parent = SemanticParent(label="bar")
+                some_parent = ConcreteParent(label="bar")
                 some_parent.add_child(self.root)
 
         with self.subTest("Cyclicity exceptions"):

--- a/tests/unit/mixin/test_semantics.py
+++ b/tests/unit/mixin/test_semantics.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from pyiron_workflow.mixin.semantics import (
     CyclicPathError,
-    ParentMost,
     Semantic,
     SemanticParent,
 )
@@ -15,15 +14,9 @@ class ConcreteParent(SemanticParent[Semantic]):
         return Semantic
 
 
-class ConcreteParentMost(ParentMost[Semantic]):
-    @classmethod
-    def child_type(cls) -> type[Semantic]:
-        return Semantic
-
-
 class TestSemantics(unittest.TestCase):
     def setUp(self):
-        self.root = ConcreteParentMost("root")
+        self.root = ConcreteParent("root")
         self.child1 = Semantic("child1", parent=self.root)
         self.middle1 = ConcreteParent("middle", parent=self.root)
         self.middle2 = ConcreteParent("middle_sub", parent=self.middle1)
@@ -69,18 +62,6 @@ class TestSemantics(unittest.TestCase):
         with self.subTest("Normal usage"):
             self.assertEqual(self.child1.parent, self.root)
             self.assertEqual(self.root.parent, None)
-
-        with self.subTest(f"{ParentMost.__name__} exceptions"):
-            with self.assertRaises(
-                TypeError, msg=f"{ParentMost.__name__} instances can't have parent"
-            ):
-                self.root.parent = ConcreteParent(label="foo")
-
-            with self.assertRaises(
-                TypeError, msg=f"{ParentMost.__name__} instances can't be children"
-            ):
-                some_parent = ConcreteParent(label="bar")
-                some_parent.add_child(self.root)
 
         with self.subTest("Cyclicity exceptions"):
             with self.assertRaises(CyclicPathError):

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -9,9 +9,8 @@ from static import demo_nodes
 
 from pyiron_workflow._tests import ensure_tests_in_python_path
 from pyiron_workflow.channels import NOT_DATA
-from pyiron_workflow.mixin.semantics import ParentMostError
 from pyiron_workflow.storage import TypeNotFoundError, available_backends
-from pyiron_workflow.workflow import Workflow
+from pyiron_workflow.workflow import ParentMostError, Workflow
 
 ensure_tests_in_python_path()
 
@@ -155,7 +154,7 @@ class TestWorkflow(unittest.TestCase):
             self.assertEqual(3, len(wf.inputs_map), msg="All entries should be stored")
             self.assertEqual(0, len(wf.inputs), msg="No IO should be left exposed")
 
-    def test_is_parentmost(self):
+    def test_takes_no_parent(self):
         wf = Workflow("wf")
         wf2 = Workflow("wf2")
 


### PR DESCRIPTION
Resolves most of the mypy complaints in the `semantics` module. The two main changes are to make `SemanticParent` a generic, and purging the `ParentMost`. 

For the former, the reliance on `Generic` allows us to specify a type for the children, which is leveraged in `Composite(SemanticParent[Node],...)`. In the long run, I believe this should be narrowed to `SemanticParent[StaticNode]`, but that's related to #360 and so I want to hold off for now.

For the latter, the only place this was really relevant was in `Workflow`. It was anyhow not a great solution, since in principle we _do_ want `Workflow` to be able to have semantic parents...just not workflow graph parents. In the absence of `ParentMost`, it is simply up to subclasses of `Semantic` to update their `parent` setter if they want restrictions on their parentage beyond the standard `SemanticParent | None`. IMO this is both cleaner and a step toward the planned idea of non-workflow semantic parents for organizing groups of workflows.

Not dealt with here are some complaints about the `label` argument in `super` calls. The tension I'm running into is that for many nodes, the label can be perfectly well inferred from the class name and/or the node's location in a graph, and so a keyword is fine; while for `Workflow` it is always necessary to provide a name since this is the opening semantic scope and we don't want to start _every_ new workflow with `"Workflow/..."` -- _but_ it would be much nicer to write `Workflow("my_name")` than `Workflow(label="my_name")`. I just want more time to think about the most convenient solution.