### PR TITLE
Semantics generic parent

### DIFF
--- a/pyiron_workflow/mixin/has_interface_mixins.py
+++ b/pyiron_workflow/mixin/has_interface_mixins.py
@@ -53,17 +53,6 @@ class HasLabel(ABC):
         return self.label
 
 
-class HasParent(ABC):
-    """
-    A mixin to guarantee the parent interface exists.
-    """
-
-    @property
-    @abstractmethod
-    def parent(self) -> Any:
-        """A parent for the object."""
-
-
 class HasChannel(ABC):
     """
     A mix-in class for use with the :class:`Channel` class.

--- a/pyiron_workflow/mixin/has_interface_mixins.py
+++ b/pyiron_workflow/mixin/has_interface_mixins.py
@@ -11,7 +11,7 @@ possible coupling between different components of a composed class.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pyiron_workflow.channels import Channel

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -2,10 +2,11 @@
 Classes for "semantic" reasoning.
 
 The motivation here is to be able to provide the object with a unique identifier
-in the context of other semantic objects. Each object may have exactly one parent
-and an arbitrary number of children, and each child's name must be unique in the
-scope of that parent. In this way, the path from the parent-most object to any
-child is completely unique. The typical filesystem on a computer is an excellent
+in the context of other semantic objects. Each object may have at most one parent,
+while semantic parents may have an arbitrary number of children, and each child's name
+must be unique in the scope of that parent. In this way, when semantic parents are also
+themselves semantic, we can build a path from the parent-most object to any child that
+is completely unique. The typical filesystem on a computer is an excellent
 example and fulfills our requirements, the only reason we depart from it is so that
 we are free to have objects stored in different locations (possibly even on totally
 different drives or machines) belong to the same semantic group.
@@ -180,7 +181,7 @@ ChildType = TypeVar("ChildType", bound=Semantic)
 
 class SemanticParent(Generic[ChildType], ABC):
     """
-    A semantic object with a collection of uniquely-named semantic children.
+    An with a collection of uniquely-named semantic children.
 
     Children should be added or removed via the :meth:`add_child` and
     :meth:`remove_child` methods and _not_ by direct manipulation of the

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -293,7 +293,7 @@ class SemanticParent(Semantic, Generic[ChildType], ABC):
         return child
 
     @staticmethod
-    def _ensure_path_is_not_cyclic(parent: SemanticParent | None, child: Semantic):
+    def _ensure_path_is_not_cyclic(parent: SemanticParent | None, child: ChildType):
         if parent is not None and parent.semantic_path.startswith(
             child.semantic_path + child.semantic_delimiter
         ):

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -20,6 +20,7 @@ from typing import Generic, TypeVar
 
 from bidict import bidict
 
+from pyiron_workflow.compatibility import Self
 from pyiron_workflow.logging import logger
 from pyiron_workflow.mixin.has_interface_mixins import HasLabel, HasParent, UsesState
 
@@ -293,7 +294,7 @@ class SemanticParent(Semantic, Generic[ChildType], ABC):
         return child
 
     @staticmethod
-    def _ensure_path_is_not_cyclic(parent: SemanticParent | None, child: ChildType):
+    def _ensure_path_is_not_cyclic(parent: SemanticParent | None, child: Semantic):
         if parent is not None and parent.semantic_path.startswith(
             child.semantic_path + child.semantic_delimiter
         ):

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -271,7 +271,7 @@ class SemanticParent(Semantic, Generic[ChildType], ABC):
                 f"but got {child}"
             )
 
-        self._ensure_path_is_not_cyclic(self, child)
+        _ensure_path_is_not_cyclic(self, child)
 
         self._ensure_child_has_no_other_parent(child)
 
@@ -291,18 +291,6 @@ class SemanticParent(Semantic, Generic[ChildType], ABC):
             self.children[child.label] = child
             child.parent = self
         return child
-
-    @staticmethod
-    def _ensure_path_is_not_cyclic(parent: SemanticParent | None, child: Semantic):
-        if parent is not None and parent.semantic_path.startswith(
-            child.semantic_path + child.semantic_delimiter
-        ):
-            raise CyclicPathError(
-                f"{parent.label} cannot be the parent of {child.label}, because its "
-                f"semantic path is already in {child.label}'s path and cyclic paths "
-                f"are not allowed. (i.e. {child.semantic_path} is in "
-                f"{parent.semantic_path})"
-            )
 
     def _ensure_child_has_no_other_parent(self, child: Semantic):
         if child.parent is not None and child.parent is not self:
@@ -375,7 +363,7 @@ class SemanticParent(Semantic, Generic[ChildType], ABC):
 
     @parent.setter
     def parent(self, new_parent: SemanticParent | None) -> None:
-        self._ensure_path_is_not_cyclic(new_parent, self)
+        _ensure_path_is_not_cyclic(new_parent, self)
         self._set_parent(new_parent)
 
     def __getstate__(self):
@@ -411,3 +399,15 @@ class SemanticParent(Semantic, Generic[ChildType], ABC):
         # children). So, now return their parent to them:
         for child in self:
             child.parent = self
+
+
+def _ensure_path_is_not_cyclic(parent, child: Semantic):
+    if isinstance(parent, Semantic) and parent.semantic_path.startswith(
+        child.semantic_path + child.semantic_delimiter
+    ):
+        raise CyclicPathError(
+            f"{parent.label} cannot be the parent of {child.label}, because its "
+            f"semantic path is already in {child.label}'s path and cyclic paths "
+            f"are not allowed. (i.e. {child.semantic_path} is in "
+            f"{parent.semantic_path})"
+        )

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -21,10 +21,10 @@ from typing import Generic, TypeVar
 from bidict import bidict
 
 from pyiron_workflow.logging import logger
-from pyiron_workflow.mixin.has_interface_mixins import HasLabel, HasParent, UsesState
+from pyiron_workflow.mixin.has_interface_mixins import HasLabel, UsesState
 
 
-class Semantic(UsesState, HasLabel, HasParent, ABC):
+class Semantic(UsesState, HasLabel, ABC):
     """
     An object with a unique semantic path.
 

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -37,9 +37,7 @@ class Semantic(UsesState, HasLabel, Generic[ParentType], ABC):
 
     semantic_delimiter: str = "/"
 
-    def __init__(
-        self, label: str, *args, parent: ParentType | None = None, **kwargs
-    ):
+    def __init__(self, label: str, *args, parent: ParentType | None = None, **kwargs):
         self._label = ""
         self._parent = None
         self._detached_parent_path = None

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -79,6 +79,8 @@ class Semantic(UsesState, HasLabel, ABC):
                 f"{self.label}, but got {new_parent}"
             )
 
+        _ensure_path_is_not_cyclic(new_parent, self)
+
         if (
             self._parent is not None
             and new_parent is not self._parent
@@ -356,15 +358,6 @@ class SemanticParent(Semantic, Generic[ChildType], ABC):
         child.parent = None
 
         return child
-
-    @property
-    def parent(self) -> SemanticParent | None:
-        return self._parent
-
-    @parent.setter
-    def parent(self, new_parent: SemanticParent | None) -> None:
-        _ensure_path_is_not_cyclic(new_parent, self)
-        self._set_parent(new_parent)
 
     def __getstate__(self):
         state = super().__getstate__()

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -23,7 +23,6 @@ from bidict import bidict
 from pyiron_workflow.logging import logger
 from pyiron_workflow.mixin.has_interface_mixins import HasLabel, UsesState
 
-
 ParentType = TypeVar("ParentType", bound="SemanticParent")
 
 

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -20,7 +20,6 @@ from typing import Generic, TypeVar
 
 from bidict import bidict
 
-from pyiron_workflow.compatibility import Self
 from pyiron_workflow.logging import logger
 from pyiron_workflow.mixin.has_interface_mixins import HasLabel, HasParent, UsesState
 

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -170,7 +170,7 @@ class CyclicPathError(ValueError):
 ChildType = TypeVar("ChildType", bound=Semantic)
 
 
-class SemanticParent(Semantic, Generic[ChildType], ABC):
+class SemanticParent(Generic[ChildType], ABC):
     """
     A semantic object with a collection of uniquely-named semantic children.
 
@@ -189,15 +189,14 @@ class SemanticParent(Semantic, Generic[ChildType], ABC):
 
     def __init__(
         self,
-        label: str,
+        label: str | None,  # Vestigial while the label order is broken
         *args,
-        parent: SemanticParent | None = None,
         strict_naming: bool = True,
         **kwargs,
     ):
         self._children: bidict[str, ChildType] = bidict()
         self.strict_naming = strict_naming
-        super().__init__(*args, label=label, parent=parent, **kwargs)
+        super().__init__(*args, label=label, **kwargs)
 
     @classmethod
     @abstractmethod

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -322,6 +322,7 @@ class Node(
     @classmethod
     def parent_type(cls) -> type[Composite]:
         from pyiron_workflow.nodes.composite import Composite
+
         return Composite
 
     def _setup_node(self) -> None:

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -21,7 +21,7 @@ from pyiron_workflow.draw import Node as GraphvizNode
 from pyiron_workflow.logging import logger
 from pyiron_workflow.mixin.injection import HasIOWithInjection
 from pyiron_workflow.mixin.run import ReadinessError, Runnable
-from pyiron_workflow.mixin.semantics import Semantic, ParentType
+from pyiron_workflow.mixin.semantics import Semantic
 from pyiron_workflow.mixin.single_output import ExploitsSingleOutput
 from pyiron_workflow.storage import StorageInterface, available_backends
 from pyiron_workflow.topology import (

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -21,7 +21,7 @@ from pyiron_workflow.draw import Node as GraphvizNode
 from pyiron_workflow.logging import logger
 from pyiron_workflow.mixin.injection import HasIOWithInjection
 from pyiron_workflow.mixin.run import ReadinessError, Runnable
-from pyiron_workflow.mixin.semantics import Semantic
+from pyiron_workflow.mixin.semantics import Semantic, ParentType
 from pyiron_workflow.mixin.single_output import ExploitsSingleOutput
 from pyiron_workflow.storage import StorageInterface, available_backends
 from pyiron_workflow.topology import (
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
 class Node(
     HasIOWithInjection,
-    Semantic,
+    Semantic["Composite"],
     Runnable,
     ExploitsSingleOutput,
     ABC,
@@ -318,6 +318,11 @@ class Node(
             autorun=autorun,
             **kwargs,
         )
+
+    @classmethod
+    def parent_type(cls) -> type[Composite]:
+        from pyiron_workflow.nodes.composite import Composite
+        return Composite
 
     def _setup_node(self) -> None:
         """

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -304,11 +304,6 @@ class Composite(SemanticParent[Node], HasCreator, Node, ABC):
         label: str | None = None,
         strict_naming: bool | None = None,
     ) -> Node:
-        if not isinstance(child, Node):
-            raise TypeError(
-                f"Only new {Node.__name__} instances may be added, but got "
-                f"{type(child)}."
-            )
         self._cached_inputs = None  # Reset cache after graph change
         return super().add_child(child, label=label, strict_naming=strict_naming)
 

--- a/tests/unit/mixin/test_semantics.py
+++ b/tests/unit/mixin/test_semantics.py
@@ -8,7 +8,7 @@ from pyiron_workflow.mixin.semantics import (
 )
 
 
-class ConcreteParent(SemanticParent[Semantic]):
+class ConcreteParent(SemanticParent[Semantic], Semantic):
     @classmethod
     def child_type(cls) -> type[Semantic]:
         return Semantic

--- a/tests/unit/mixin/test_semantics.py
+++ b/tests/unit/mixin/test_semantics.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from pyiron_workflow.mixin.semantics import (
     CyclicPathError,
     Semantic,
-    SemanticParent, ParentType,
+    SemanticParent,
 )
 
 
@@ -53,7 +53,7 @@ class TestSemantics(unittest.TestCase):
     def test_label_delimiter(self):
         with self.assertRaises(
             ValueError,
-                msg=f"Delimiter '{ConcreteSemantic.semantic_delimiter}' not allowed"
+            msg=f"Delimiter '{ConcreteSemantic.semantic_delimiter}' not allowed",
         ):
             ConcreteSemantic(f"invalid{ConcreteSemantic.semantic_delimiter}label")
 

--- a/tests/unit/mixin/test_semantics.py
+++ b/tests/unit/mixin/test_semantics.py
@@ -1,26 +1,34 @@
+from __future__ import annotations
+
 import unittest
 from pathlib import Path
 
 from pyiron_workflow.mixin.semantics import (
     CyclicPathError,
     Semantic,
-    SemanticParent,
+    SemanticParent, ParentType,
 )
 
 
-class ConcreteParent(SemanticParent[Semantic], Semantic):
+class ConcreteSemantic(Semantic["ConcreteParent"]):
     @classmethod
-    def child_type(cls) -> type[Semantic]:
-        return Semantic
+    def parent_type(cls) -> type[ConcreteParent]:
+        return ConcreteParent
+
+
+class ConcreteParent(SemanticParent[ConcreteSemantic], ConcreteSemantic):
+    @classmethod
+    def child_type(cls) -> type[ConcreteSemantic]:
+        return ConcreteSemantic
 
 
 class TestSemantics(unittest.TestCase):
     def setUp(self):
         self.root = ConcreteParent("root")
-        self.child1 = Semantic("child1", parent=self.root)
+        self.child1 = ConcreteSemantic("child1", parent=self.root)
         self.middle1 = ConcreteParent("middle", parent=self.root)
         self.middle2 = ConcreteParent("middle_sub", parent=self.middle1)
-        self.child2 = Semantic("child2", parent=self.middle2)
+        self.child2 = ConcreteSemantic("child2", parent=self.middle2)
 
     def test_getattr(self):
         with self.assertRaises(AttributeError) as context:
@@ -40,18 +48,19 @@ class TestSemantics(unittest.TestCase):
 
     def test_label_validity(self):
         with self.assertRaises(TypeError, msg="Label must be a string"):
-            Semantic(label=123)
+            ConcreteSemantic(label=123)
 
     def test_label_delimiter(self):
         with self.assertRaises(
-            ValueError, msg=f"Delimiter '{Semantic.semantic_delimiter}' not allowed"
+            ValueError,
+                msg=f"Delimiter '{ConcreteSemantic.semantic_delimiter}' not allowed"
         ):
-            Semantic(f"invalid{Semantic.semantic_delimiter}label")
+            ConcreteSemantic(f"invalid{ConcreteSemantic.semantic_delimiter}label")
 
     def test_semantic_delimiter(self):
         self.assertEqual(
             "/",
-            Semantic.semantic_delimiter,
+            ConcreteSemantic.semantic_delimiter,
             msg="This is just a hard-code to the current value, update it freely so "
             "the test passes; if it fails it's just a reminder that your change is "
             "not backwards compatible, and the next release number should reflect "
@@ -105,7 +114,7 @@ class TestSemantics(unittest.TestCase):
         )
 
     def test_detached_parent_path(self):
-        orphan = Semantic("orphan")
+        orphan = ConcreteSemantic("orphan")
         orphan.__setstate__(self.child2.__getstate__())
         self.assertIsNone(
             orphan.parent, msg="We still should not explicitly have a parent"


### PR DESCRIPTION
Some refactoring, namely getting rid of the `HasParent` interface (which was only used in a single place, `Semantic`, which can simply have that as part of _its_ interface) and breaking `SemanticParent` out of the `Semantic` inheritance tree. These made it easier to then make `Semantic` generic on its parent type, so that type narrowing in `Node(..., Semantic["Composite"], ...)` gives us helpful type narrowing.

I think `mypy --strict` will still complain about the typevar definitions,

```python
ParentType = TypeVar("ParentType", bound="SemanticParent")
ChildType = TypeVar("ChildType", bound="Semantic")
```

This is because the bounds are generic and we leave the resolution implicitly as `typing.Any`. At present I'm not concerned about this because (a) let's get `mypy` happy before worrying about `mypy --strict`, and (b) because of the circular way that `Semantic(Generic[ParentType])` and `SemanticParent(Generic[ChildType])`, I think we are anyhow actually achieving 

```python
ParentType = TypeVar("ParentType", bound="SemanticParent[Semantic[SemanticParent[...]]")
ChildType = TypeVar("ChildType", bound="Semantic[SemanticParent[Semantic[...]]")
```

even though we obviously can't actually write that out.


TODO: Take a swing at delaying the specification of `Semantic`'s generic type in `Node`, such that we don't need explicit handling of the parent-most behaviour of `Workflow`, but can do something like `Workflow[Node[None]]`, while `StaticNode[Node[Composite]]` continues to behave in the current way. (It might be necessary to delay this until #360 is resolved and we can directly say `Workflow[Semantic[None]]` and `Node[Semantic[Composite]]` (or similar).