### PR TITLE
avoid commented-out code (ruff-ERA)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,8 @@ select = [
     "I",
     # flake8-comprehensions
     "C4",
+    # eradicate
+    "ERA",
 ]
 ignore = ["E501"] #ignore line-length violations
 

--- a/tests/unit/nodes/test_composite.py
+++ b/tests/unit/nodes/test_composite.py
@@ -22,10 +22,6 @@ class AComposite(Composite):
     def __init__(self, label):
         super().__init__(label=label)
 
-    def _get_linking_channel(self, child_reference_channel, composite_io_key):
-        pass  # Shouldn't even be abstract honestly
-        # return child_reference_channel  # IO by reference
-
     @property
     def inputs(self) -> Inputs:
         # Dynamic IO reflecting current children

--- a/tests/unit/nodes/test_for_loop.py
+++ b/tests/unit/nodes/test_for_loop.py
@@ -354,7 +354,7 @@ class TestForNode(unittest.TestCase):
                         d=[9, 10, 11],
                         e="e",
                         output_column_map={
-                            # "a": "out_a",
+                            # Note the absence of the "a" conflicting entry
                             "b": "out_b",
                             "c": "out_c",
                             "d": "out_d",

--- a/tests/unit/nodes/test_function.py
+++ b/tests/unit/nodes/test_function.py
@@ -136,8 +136,8 @@ class TestFunction(unittest.TestCase):
             self.subTest("Fail on multiple return values"),
             self.assertRaises(ValueError),
         ):
-            # Can't automatically parse output labels from a function with multiple
-            # return expressions
+            # Can't automatically parse output labels from a function with
+            # multiple return expressions
             function_node(multiple_branches)
 
         with self.subTest("Override output label scraping"):

--- a/tests/unit/nodes/test_macro.py
+++ b/tests/unit/nodes/test_macro.py
@@ -245,11 +245,11 @@ class TestMacro(unittest.TestCase):
             returned_nodes.one,
             msg="Executing in a parallel process should be returning new instances",
         )
-        # self.assertIs(
-        #     returned_nodes.one,
-        #     macro.nodes.one,
-        #     msg="Returned nodes should be taken as children"
-        # )  # You can't do this, result.result() is returning new instances each call
+        self.assertIs(
+            returned_nodes.one,
+            macro.one,
+            msg="Returned nodes should be taken as children"
+        )
         self.assertIs(
             macro,
             macro.one.parent,

--- a/tests/unit/nodes/test_macro.py
+++ b/tests/unit/nodes/test_macro.py
@@ -248,7 +248,7 @@ class TestMacro(unittest.TestCase):
         self.assertIs(
             returned_nodes.one,
             macro.one,
-            msg="Returned nodes should be taken as children"
+            msg="Returned nodes should be taken as children",
         )
         self.assertIs(
             macro,

--- a/tests/unit/test_type_hinting.py
+++ b/tests/unit/test_type_hinting.py
@@ -27,9 +27,6 @@ class TestTypeHinting(unittest.TestCase):
             (typing.Literal[1, 2], 1, "baz"),
             (Foo, Foo(), Foo),
             (type[Bar], Bar, Bar()),
-            # (callable, Bar(), Foo()),  # Misses the bad!
-            # Can't hint args and returns without typing.Callable anyhow, so that's
-            # what people should be using regardless
             (typing.Callable, Bar(), Foo()),
             (tuple[int, float], (1, 1.1), ("fo", 0)),
             (dict[str, int], {"a": 1}, {"a": "b"}),


### PR DESCRIPTION
Some of the pieces are commented well, however, since we cannot quarantee good comments I suggest avoiding commented-out code entirely to avoid confusion.