### PR TITLE
By default, be picker about callable

### DIFF
--- a/pyiron_workflow/type_hinting.py
+++ b/pyiron_workflow/type_hinting.py
@@ -11,8 +11,24 @@ from pint import Quantity
 from typeguard import TypeCheckError, check_type
 
 
-def valid_value(value, type_hint) -> bool:
+def valid_value(value, type_hint, strict_callables: bool = True) -> bool:
+    """
+    Check if a value is a valid representation of a type hint.
+
+    Args:
+        value: The value to verify.
+        type_hint: The type hint against which
+        strict_callables (bool): Whether to convert `callable` hints into
+            `collections.abc.Callable`. This can be important as the interaction of
+            `callable` and `check_type` is very relaxed, e.g. a class that fails to
+            define `__call__` will still pass as `callable`. Converting to the formal
+            typing hint resolves this and gives more intuitive results. Default is True.
+
+    Returns:
+        (bool): Whether the value conforms to the hint.
+    """
     value = value.magnitude if isinstance(value, Quantity) else value  # De-unit it
+    type_hint = Callable if strict_callables and type_hint is callable else type_hint
 
     try:
         return isinstance(value, type_hint)

--- a/tests/unit/test_type_hinting.py
+++ b/tests/unit/test_type_hinting.py
@@ -37,6 +37,27 @@ class TestTypeHinting(unittest.TestCase):
             with self.subTest(msg=f"Bad {bad} vs hint {hint}"):
                 self.assertFalse(valid_value(bad, hint))
 
+        with self.subTest(msg="Test strictness"):
+            self.assertTrue(
+                valid_value(Bar(), callable, strict_callables=False),
+                msg="Sanity: Bar implements __call__ and should always appear callable",
+            )
+            self.assertTrue(
+                valid_value(Bar(), callable, strict_callables=True),
+                msg="Sanity: Bar implements __call__ and should always appear callable",
+            )
+
+            self.assertTrue(
+                valid_value(Foo(), callable, strict_callables=False),
+                msg="typeguard is relaxed about callable, and doesn't care that Foo "
+                "fails to implement __call__",
+            )
+            self.assertFalse(
+                valid_value(Foo(), callable, strict_callables=True),
+                msg="typeguard is stringent about Callable, and notices that Foo fails "
+                "to implement __call__",
+            )
+
     def test_hint_comparisons(self):
         # Standard types and typing types should be interoperable
         # tuple, dict, and typing.Callable care about the exact matching of args


### PR DESCRIPTION
`typeguard.check_type` is quite relaxed when seeing if something is `callable` -- so much so that _everything_ will pass through, even `check_type(5, callable)`, or (as in the test suite) a check against an instance of a class that has not defined `__call__`. This switches the default behaviour of `type_hinting.valid_value` to convert raw `callable` hints into `collections.abc.Callable`, which `check_type` treats more rigorously. I believe this is closer to the intuitively expected behaviour of `valid_value`, but the original behaviour can still be recovered via a flag argument.

@XzzX, I only noticed this because of #545, so thanks for pushing that!