### PR TITLE
Improvements to semantic labeling

### DIFF
--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -92,10 +92,6 @@ class Channel(
         self.owner: HasIO = owner
         self.connections: list[ConjugateType] = []
 
-    @property
-    def label(self) -> str:
-        return self._label
-
     @abstractmethod
     def __str__(self):
         pass

--- a/pyiron_workflow/mixin/has_interface_mixins.py
+++ b/pyiron_workflow/mixin/has_interface_mixins.py
@@ -38,6 +38,7 @@ class HasLabel(ABC):
     """
     A mixin to guarantee the label interface exists.
     """
+
     _label: str
 
     @property

--- a/pyiron_workflow/mixin/has_interface_mixins.py
+++ b/pyiron_workflow/mixin/has_interface_mixins.py
@@ -38,11 +38,24 @@ class HasLabel(ABC):
     """
     A mixin to guarantee the label interface exists.
     """
+    _label: str
 
     @property
-    @abstractmethod
     def label(self) -> str:
         """A label for the object."""
+        return self._label
+
+    @label.setter
+    def label(self, new_label: str):
+        self._check_label(new_label)
+        self._label = new_label
+
+    def _check_label(self, new_label: str) -> None:
+        """
+        Extensible checking routine for label validity.
+        """
+        if not isinstance(new_label, str):
+            raise TypeError(f"Expected a string label but got {new_label}")
 
     @property
     def full_label(self) -> str:

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -37,11 +37,17 @@ class Semantic(UsesState, HasLabel, Generic[ParentType], ABC):
 
     semantic_delimiter: str = "/"
 
-    def __init__(self, label: str, *args, parent: ParentType | None = None, **kwargs):
+    def __init__(
+            self,
+            *args,
+            label: str | None = None,
+            parent: ParentType | None = None,
+            **kwargs
+    ):
         self._label = ""
         self._parent = None
         self._detached_parent_path = None
-        self.label = label
+        self.label = self.__class__.__name__ if label is None else label
         self.parent = parent
         super().__init__(*args, **kwargs)
 
@@ -202,14 +208,13 @@ class SemanticParent(HasLabel, Generic[ChildType], ABC):
 
     def __init__(
         self,
-        label: str | None,  # Vestigial while the label order is broken
         *args,
         strict_naming: bool = True,
         **kwargs,
     ):
         self._children: bidict[str, ChildType] = bidict()
         self.strict_naming = strict_naming
-        super().__init__(*args, label=label, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @classmethod
     @abstractmethod

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -179,9 +179,9 @@ class CyclicPathError(ValueError):
 ChildType = TypeVar("ChildType", bound=Semantic)
 
 
-class SemanticParent(Generic[ChildType], ABC):
+class SemanticParent(HasLabel, Generic[ChildType], ABC):
     """
-    An with a collection of uniquely-named semantic children.
+    A labeled object with a collection of uniquely-named semantic children.
 
     Children should be added or removed via the :meth:`add_child` and
     :meth:`remove_child` methods and _not_ by direct manipulation of the

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -104,12 +104,16 @@ class Semantic(UsesState, HasLabel, Generic[ParentType], ABC):
         The path of node labels from the graph root (parent-most node) down to this
         node.
         """
+        prefix: str
         if self.parent is None and self.detached_parent_path is None:
             prefix = ""
         elif self.parent is None and self.detached_parent_path is not None:
             prefix = self.detached_parent_path
         elif self.parent is not None and self.detached_parent_path is None:
-            prefix = self.parent.semantic_path
+            if isinstance(self.parent, Semantic):
+                prefix = self.parent.semantic_path
+            else:
+                prefix = self.semantic_delimiter + self.parent.label
         else:
             raise ValueError(
                 f"The parent and detached path should not be able to take non-None "

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -56,17 +56,10 @@ class Semantic(UsesState, HasLabel, Generic[ParentType], ABC):
     def parent_type(cls) -> type[ParentType]:
         pass
 
-    @property
-    def label(self) -> str:
-        return self._label
-
-    @label.setter
-    def label(self, new_label: str) -> None:
-        if not isinstance(new_label, str):
-            raise TypeError(f"Expected a string label but got {new_label}")
+    def _check_label(self, new_label: str) -> None:
+        super()._check_label(new_label)
         if self.semantic_delimiter in new_label:
             raise ValueError(f"{self.semantic_delimiter} cannot be in the label")
-        self._label = new_label
 
     @property
     def parent(self) -> ParentType | None:

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -59,7 +59,10 @@ class Semantic(UsesState, HasLabel, Generic[ParentType], ABC):
     def _check_label(self, new_label: str) -> None:
         super()._check_label(new_label)
         if self.semantic_delimiter in new_label:
-            raise ValueError(f"{self.semantic_delimiter} cannot be in the label")
+            raise ValueError(
+                f"Semantic delimiter {self.semantic_delimiter} cannot be in new label "
+                f"{new_label}"
+            )
 
     @property
     def parent(self) -> ParentType | None:
@@ -117,8 +120,8 @@ class Semantic(UsesState, HasLabel, Generic[ParentType], ABC):
             raise ValueError(
                 f"The parent and detached path should not be able to take non-None "
                 f"values simultaneously, but got {self.parent} and "
-                f"{self.detached_parent_path}, respectively. Please raise an issue on GitHub "
-                f"outlining how your reached this state."
+                f"{self.detached_parent_path}, respectively. Please raise an issue on "
+                f"GitHub outlining how your reached this state."
             )
         return prefix + self.semantic_delimiter + self.label
 

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from difflib import get_close_matches
 from pathlib import Path
-from typing import Generic, TypeVar
+from typing import ClassVar, Generic, TypeVar
 
 from bidict import bidict
 
@@ -35,14 +35,14 @@ class Semantic(UsesState, HasLabel, Generic[ParentType], ABC):
     accessible.
     """
 
-    semantic_delimiter: str = "/"
+    semantic_delimiter: ClassVar[str] = "/"
 
     def __init__(
-            self,
-            *args,
-            label: str | None = None,
-            parent: ParentType | None = None,
-            **kwargs
+        self,
+        *args,
+        label: str | None = None,
+        parent: ParentType | None = None,
+        **kwargs,
     ):
         self._label = ""
         self._parent = None
@@ -226,6 +226,15 @@ class SemanticParent(HasLabel, Generic[ChildType], ABC):
     @property
     def child_labels(self) -> tuple[str]:
         return tuple(child.label for child in self)
+
+    def _check_label(self, new_label: str) -> None:
+        super()._check_label(new_label)
+        if self.child_type().semantic_delimiter in new_label:
+            raise ValueError(
+                f"Child type ({self.child_type()}) semantic delimiter "
+                f"{self.child_type().semantic_delimiter} cannot be in new label "
+                f"{new_label}"
+            )
 
     def __getattr__(self, key) -> ChildType:
         try:

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -297,10 +297,7 @@ class Node(
             **kwargs: Interpreted as node input data, with keys corresponding to
                 channel labels.
         """
-        super().__init__(
-            label=self.__class__.__name__ if label is None else label,
-            parent=parent,
-        )
+        super().__init__(label=label, parent=parent)
         self.checkpoint = checkpoint
         self.recovery: Literal["pickle"] | StorageInterface | None = "pickle"
         self._serialize_result = False  # Advertised, but private to indicate

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -143,8 +143,8 @@ class Composite(SemanticParent[Node], HasCreator, Node, ABC):
         # empty but the running_children list is not
 
         super().__init__(
-            label,
             *args,
+            label=label,
             parent=parent,
             delete_existing_savefiles=delete_existing_savefiles,
             autoload=autoload,

--- a/tests/unit/mixin/test_run.py
+++ b/tests/unit/mixin/test_run.py
@@ -8,9 +8,7 @@ from pyiron_workflow.mixin.run import ReadinessError, Runnable
 
 
 class ConcreteRunnable(Runnable):
-    @property
-    def label(self) -> str:
-        return "child_class_with_all_methods_implemented"
+    _label = "child_class_with_all_methods_implemented"
 
     def on_run(self, **kwargs):
         return kwargs

--- a/tests/unit/mixin/test_semantics.py
+++ b/tests/unit/mixin/test_semantics.py
@@ -12,11 +12,11 @@ from pyiron_workflow.mixin.semantics import (
 
 class ConcreteSemantic(Semantic["ConcreteParent"]):
     @classmethod
-    def parent_type(cls) -> type[ConcreteParent]:
-        return ConcreteParent
+    def parent_type(cls) -> type[ConcreteSemanticParent]:
+        return ConcreteSemanticParent
 
 
-class ConcreteParent(SemanticParent[ConcreteSemantic], ConcreteSemantic):
+class ConcreteSemanticParent(SemanticParent[ConcreteSemantic], ConcreteSemantic):
     @classmethod
     def child_type(cls) -> type[ConcreteSemantic]:
         return ConcreteSemantic
@@ -24,10 +24,10 @@ class ConcreteParent(SemanticParent[ConcreteSemantic], ConcreteSemantic):
 
 class TestSemantics(unittest.TestCase):
     def setUp(self):
-        self.root = ConcreteParent(label="root")
+        self.root = ConcreteSemanticParent(label="root")
         self.child1 = ConcreteSemantic(label="child1", parent=self.root)
-        self.middle1 = ConcreteParent(label="middle", parent=self.root)
-        self.middle2 = ConcreteParent(label="middle_sub", parent=self.middle1)
+        self.middle1 = ConcreteSemanticParent(label="middle", parent=self.root)
+        self.middle2 = ConcreteSemanticParent(label="middle_sub", parent=self.middle1)
         self.child2 = ConcreteSemantic(label="child2", parent=self.middle2)
 
     def test_getattr(self):

--- a/tests/unit/mixin/test_semantics.py
+++ b/tests/unit/mixin/test_semantics.py
@@ -24,11 +24,11 @@ class ConcreteParent(SemanticParent[ConcreteSemantic], ConcreteSemantic):
 
 class TestSemantics(unittest.TestCase):
     def setUp(self):
-        self.root = ConcreteParent("root")
-        self.child1 = ConcreteSemantic("child1", parent=self.root)
-        self.middle1 = ConcreteParent("middle", parent=self.root)
-        self.middle2 = ConcreteParent("middle_sub", parent=self.middle1)
-        self.child2 = ConcreteSemantic("child2", parent=self.middle2)
+        self.root = ConcreteParent(label="root")
+        self.child1 = ConcreteSemantic(label="child1", parent=self.root)
+        self.middle1 = ConcreteParent(label="middle", parent=self.root)
+        self.middle2 = ConcreteParent(label="middle_sub", parent=self.middle1)
+        self.child2 = ConcreteSemantic(label="child2", parent=self.middle2)
 
     def test_getattr(self):
         with self.assertRaises(AttributeError) as context:
@@ -55,7 +55,7 @@ class TestSemantics(unittest.TestCase):
             ValueError,
             msg=f"Delimiter '{ConcreteSemantic.semantic_delimiter}' not allowed",
         ):
-            ConcreteSemantic(f"invalid{ConcreteSemantic.semantic_delimiter}label")
+            ConcreteSemantic(label=f"invalid{ConcreteSemantic.semantic_delimiter}label")
 
     def test_semantic_delimiter(self):
         self.assertEqual(
@@ -114,7 +114,7 @@ class TestSemantics(unittest.TestCase):
         )
 
     def test_detached_parent_path(self):
-        orphan = ConcreteSemantic("orphan")
+        orphan = ConcreteSemantic(label="orphan")
         orphan.__setstate__(self.child2.__getstate__())
         self.assertIsNone(
             orphan.parent, msg="We still should not explicitly have a parent"

--- a/tests/unit/mixin/test_semantics.py
+++ b/tests/unit/mixin/test_semantics.py
@@ -16,10 +16,16 @@ class ConcreteSemantic(Semantic["ConcreteParent"]):
         return ConcreteSemanticParent
 
 
-class ConcreteSemanticParent(SemanticParent[ConcreteSemantic], ConcreteSemantic):
+class ConcreteParent(SemanticParent[ConcreteSemantic]):
+    _label = "concrete_parent_default_label"
+
     @classmethod
     def child_type(cls) -> type[ConcreteSemantic]:
         return ConcreteSemantic
+
+
+class ConcreteSemanticParent(ConcreteParent, ConcreteSemantic):
+    pass
 
 
 class TestSemantics(unittest.TestCase):
@@ -56,6 +62,13 @@ class TestSemantics(unittest.TestCase):
             msg=f"Delimiter '{ConcreteSemantic.semantic_delimiter}' not allowed",
         ):
             ConcreteSemantic(label=f"invalid{ConcreteSemantic.semantic_delimiter}label")
+
+        non_semantic_parent = ConcreteParent()
+        with self.assertRaises(
+            ValueError,
+            msg=f"Delimiter '{ConcreteSemantic.semantic_delimiter}' not allowed",
+        ):
+            non_semantic_parent.label = f"contains_{non_semantic_parent.child_type().semantic_delimiter}_delimiter"
 
     def test_semantic_delimiter(self):
         self.assertEqual(


### PR DESCRIPTION
- Reparented `SemanticParent` onto `HasLabel` and adjusted `Semantic.semantic_path` so it's always valid
- Refactored the `HasLabel` mixin so that the label validation is done there with an extensible method. Then `Semantic` and `SemanticParent` are able to independently verify that their labels don't contain the relevant semantic delimiter
- Pulled the default values for the `label` right into `Semantic` and adjusted the `__init__` signatures of downstream classes accordingly to resolve another mypy complaint