### PR TITLE
Generic `HasIO` classes to specify data output panel types

### DIFF
--- a/pyiron_workflow/io.py
+++ b/pyiron_workflow/io.py
@@ -294,7 +294,10 @@ class Signals(HasStateDisplay):
         return f"{str(self.input)}\n{str(self.output)}"
 
 
-class HasIO(HasStateDisplay, HasLabel, HasRun, ABC):
+OutputsType = TypeVar("OutputsType", bound=Outputs)
+
+
+class HasIO(HasStateDisplay, HasLabel, HasRun, Generic[OutputsType], ABC):
     """
     A mixin for classes that provide data and signal IO.
 
@@ -329,7 +332,7 @@ class HasIO(HasStateDisplay, HasLabel, HasRun, ABC):
 
     @property
     @abstractmethod
-    def outputs(self) -> Outputs:
+    def outputs(self) -> OutputsType:
         pass
 
     @property

--- a/pyiron_workflow/io.py
+++ b/pyiron_workflow/io.py
@@ -220,7 +220,17 @@ class Inputs(InputsIO, DataIO):
             c.fetch()
 
 
-class Outputs(OutputsIO, DataIO):
+OutputDataType = TypeVar("OutputDataType", bound=OutputData)
+
+
+class GenericOutputs(OutputsIO, DataIO, Generic[OutputDataType], ABC):
+    @property
+    @abstractmethod
+    def _channel_class(self) -> type[OutputDataType]:
+        pass
+
+
+class Outputs(GenericOutputs[OutputData]):
     @property
     def _channel_class(self) -> type[OutputData]:
         return OutputData
@@ -294,7 +304,7 @@ class Signals(HasStateDisplay):
         return f"{str(self.input)}\n{str(self.output)}"
 
 
-OutputsType = TypeVar("OutputsType", bound=Outputs)
+OutputsType = TypeVar("OutputsType", bound=GenericOutputs)
 
 
 class HasIO(HasStateDisplay, HasLabel, HasRun, Generic[OutputsType], ABC):

--- a/pyiron_workflow/mixin/display_state.py
+++ b/pyiron_workflow/mixin/display_state.py
@@ -4,6 +4,7 @@ Simple display capabilities to make it easier for humans to see what's happening
 
 from abc import ABC
 from json import dumps
+from typing import Any
 
 from pyiron_workflow.mixin.has_interface_mixins import UsesState
 
@@ -24,7 +25,7 @@ class HasStateDisplay(UsesState, ABC):
 
     def display_state(
         self, state: dict | None = None, ignore_private: bool = True
-    ) -> dict:
+    ) -> dict[str, Any]:
         """
         A dictionary of JSON-compatible objects based on the object state (plus
         whatever modifications to the state the class designer has chosen to make).

--- a/pyiron_workflow/mixin/has_interface_mixins.py
+++ b/pyiron_workflow/mixin/has_interface_mixins.py
@@ -11,7 +11,7 @@ possible coupling between different components of a composed class.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 if TYPE_CHECKING:
     from pyiron_workflow.channels import Channel
@@ -69,9 +69,7 @@ class HasLabel(ABC):
 
 class HasChannel(ABC):
     """
-    A mix-in class for use with the :class:`Channel` class.
-    A :class:`Channel` is able to (attempt to) connect to any child instance of :class:`HasConnection`
-    by looking at its :attr:`connection` attribute.
+    A mix-in class for use with the :class:`Channel` class and its children.
 
     This is useful for letting channels attempt to connect to non-channel objects
     directly by pointing them to some channel that object holds.
@@ -80,6 +78,16 @@ class HasChannel(ABC):
     @property
     @abstractmethod
     def channel(self) -> Channel:
+        pass
+
+
+ChannelType = TypeVar("ChannelType", bound="Channel")
+
+
+class HasGenericChannel(HasChannel, Generic[ChannelType], ABC):
+    @property
+    @abstractmethod
+    def channel(self) -> ChannelType:
         pass
 
 

--- a/pyiron_workflow/mixin/injection.py
+++ b/pyiron_workflow/mixin/injection.py
@@ -8,11 +8,10 @@ to inject new nodes into the graph dynamically.
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 from pyiron_workflow.channels import NOT_DATA, OutputData
-from pyiron_workflow.io import GenericOutputs, HasIO
+from pyiron_workflow.io import GenericOutputs
 from pyiron_workflow.mixin.has_interface_mixins import HasChannel
 
 if TYPE_CHECKING:
@@ -279,10 +278,3 @@ class OutputsWithInjection(GenericOutputs[OutputDataWithInjection]):
     @property
     def _channel_class(self) -> type[OutputDataWithInjection]:
         return OutputDataWithInjection
-
-
-class HasIOWithInjection(HasIO[OutputsWithInjection], ABC):
-    @property
-    @abstractmethod
-    def outputs(self) -> OutputsWithInjection:
-        pass

--- a/pyiron_workflow/mixin/injection.py
+++ b/pyiron_workflow/mixin/injection.py
@@ -281,7 +281,7 @@ class OutputsWithInjection(Outputs):
         return OutputDataWithInjection
 
 
-class HasIOWithInjection(HasIO, ABC):
+class HasIOWithInjection(HasIO[OutputsWithInjection], ABC):
     @property
     @abstractmethod
     def outputs(self) -> OutputsWithInjection:

--- a/pyiron_workflow/mixin/injection.py
+++ b/pyiron_workflow/mixin/injection.py
@@ -277,7 +277,7 @@ class OutputDataWithInjection(OutputData):
 
 class OutputsWithInjection(Outputs):
     @property
-    def _channel_class(self) -> type(OutputDataWithInjection):
+    def _channel_class(self) -> type[OutputDataWithInjection]:
         return OutputDataWithInjection
 
 

--- a/pyiron_workflow/mixin/injection.py
+++ b/pyiron_workflow/mixin/injection.py
@@ -12,7 +12,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 from pyiron_workflow.channels import NOT_DATA, OutputData
-from pyiron_workflow.io import HasIO, Outputs
+from pyiron_workflow.io import GenericOutputs, HasIO
 from pyiron_workflow.mixin.has_interface_mixins import HasChannel
 
 if TYPE_CHECKING:
@@ -275,7 +275,7 @@ class OutputDataWithInjection(OutputData):
         return self._node_injection(Round)
 
 
-class OutputsWithInjection(Outputs):
+class OutputsWithInjection(GenericOutputs[OutputDataWithInjection]):
     @property
     def _channel_class(self) -> type[OutputDataWithInjection]:
         return OutputDataWithInjection

--- a/pyiron_workflow/mixin/run.py
+++ b/pyiron_workflow/mixin/run.py
@@ -74,7 +74,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
         Any data needed for :meth:`on_run`, will be passed as (*args, **kwargs).
         """
 
-    def process_run_result(self, run_output):
+    def process_run_result(self, run_output: Any) -> Any:
         """
         What to _do_ with the results of :meth:`on_run` once you have them.
 
@@ -165,7 +165,9 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
             **run_kwargs,
         )
 
-    def _before_run(self, /, check_readiness, **kwargs) -> tuple[bool, Any]:
+    def _before_run(
+        self, /, check_readiness: bool, *args, **kwargs
+    ) -> tuple[bool, Any]:
         """
         Things to do _before_ running.
 
@@ -194,6 +196,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
         run_exception_kwargs: dict,
         run_finally_kwargs: dict,
         finish_run_kwargs: dict,
+        *args,
         **kwargs,
     ) -> Any | tuple | Future:
         """
@@ -254,7 +257,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
             )
             return self.future
 
-    def _run_exception(self, /, **kwargs):
+    def _run_exception(self, /, *args, **kwargs):
         """
         What to do if an exception is encountered inside :meth:`_run` or
         :meth:`_finish_run.
@@ -262,7 +265,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
         self.running = False
         self.failed = True
 
-    def _run_finally(self, /, **kwargs):
+    def _run_finally(self, /, *args, **kwargs):
         """
         What to do after :meth:`_finish_run` (whether an exception is encountered or
         not), or in :meth:`_run` after an exception is encountered.

--- a/pyiron_workflow/mixin/single_output.py
+++ b/pyiron_workflow/mixin/single_output.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+from pyiron_workflow.io import HasIO
 from pyiron_workflow.mixin.has_interface_mixins import HasGenericChannel
 from pyiron_workflow.mixin.injection import (
-    HasIOWithInjection,
     OutputDataWithInjection,
     OutputsWithInjection,
 )
@@ -20,7 +20,7 @@ class AmbiguousOutputError(ValueError):
 
 
 class ExploitsSingleOutput(
-    HasIOWithInjection, HasGenericChannel[OutputDataWithInjection], ABC
+    HasIO[OutputsWithInjection], HasGenericChannel[OutputDataWithInjection], ABC
 ):
     @property
     @abstractmethod

--- a/pyiron_workflow/mixin/single_output.py
+++ b/pyiron_workflow/mixin/single_output.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from pyiron_workflow.mixin.has_interface_mixins import HasChannel, HasLabel
+from pyiron_workflow.mixin.has_interface_mixins import HasGenericChannel, HasLabel
 from pyiron_workflow.mixin.injection import (
     OutputDataWithInjection,
     OutputsWithInjection,
@@ -18,7 +18,7 @@ class AmbiguousOutputError(ValueError):
     """Raised when searching for exactly one output, but multiple are found."""
 
 
-class ExploitsSingleOutput(HasLabel, HasChannel, ABC):
+class ExploitsSingleOutput(HasLabel, HasGenericChannel[OutputDataWithInjection], ABC):
     @property
     @abstractmethod
     def outputs(self) -> OutputsWithInjection:

--- a/pyiron_workflow/mixin/single_output.py
+++ b/pyiron_workflow/mixin/single_output.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from pyiron_workflow.mixin.has_interface_mixins import HasGenericChannel, HasLabel
+from pyiron_workflow.mixin.has_interface_mixins import HasGenericChannel
 from pyiron_workflow.mixin.injection import (
+    HasIOWithInjection,
     OutputDataWithInjection,
     OutputsWithInjection,
 )
@@ -18,7 +19,9 @@ class AmbiguousOutputError(ValueError):
     """Raised when searching for exactly one output, but multiple are found."""
 
 
-class ExploitsSingleOutput(HasLabel, HasGenericChannel[OutputDataWithInjection], ABC):
+class ExploitsSingleOutput(
+    HasIOWithInjection, HasGenericChannel[OutputDataWithInjection], ABC
+):
     @property
     @abstractmethod
     def outputs(self) -> OutputsWithInjection:

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -177,8 +177,9 @@ class Node(
         inputs (pyiron_workflow.io.Inputs): **Abstract.** Children must define
             a property returning an :class:`Inputs` object.
         label (str): A name for the node.
-        outputs (pyiron_workflow.io.Outputs): **Abstract.** Children must define
-            a property returning an :class:`Outputs` object.
+        outputs (pyiron_workflow.mixin.injection.OutputsWithInjection): **Abstract.**
+            Children must define a property returning an :class:`OutputsWithInjection`
+            object.
         parent (pyiron_workflow.composite.Composite | None): The parent object
             owning this, if any.
         ready (bool): Whether the inputs are all ready and the node is neither

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -19,7 +19,6 @@ from pyiron_snippets.dotdict import DotDict
 
 from pyiron_workflow.draw import Node as GraphvizNode
 from pyiron_workflow.logging import logger
-from pyiron_workflow.mixin.injection import HasIOWithInjection
 from pyiron_workflow.mixin.run import ReadinessError, Runnable
 from pyiron_workflow.mixin.semantics import Semantic
 from pyiron_workflow.mixin.single_output import ExploitsSingleOutput
@@ -40,7 +39,6 @@ if TYPE_CHECKING:
 
 
 class Node(
-    HasIOWithInjection,
     Semantic["Composite"],
     Runnable,
     ExploitsSingleOutput,

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -304,7 +304,9 @@ class Node(
         self._do_clean: bool = False  # Power-user override for cleaning up temporary
         # serialized results and empty directories (or not).
         self._cached_inputs = None
-        self._user_data = {}  # A place for power-users to bypass node-injection
+
+        self._user_data: dict[str, Any] = {}
+        # A place for power-users to bypass node-injection
 
         self._setup_node()
         self._after_node_setup(
@@ -629,7 +631,7 @@ class Node(
 
         try:
             parent_starting_nodes = (
-                self.parent.starting_nodes if self.parent is not None else None
+                self.parent.starting_nodes if self.parent is not None else []
             )  # We need these for state recovery later, even if we crash
 
             if len(data_tree_starters) == 1 and data_tree_starters[0] is self:

--- a/pyiron_workflow/nodes/macro.py
+++ b/pyiron_workflow/nodes/macro.py
@@ -13,8 +13,9 @@ from typing import TYPE_CHECKING
 
 from pyiron_snippets.factory import classfactory
 
-from pyiron_workflow.io import Inputs, Outputs
+from pyiron_workflow.io import Inputs
 from pyiron_workflow.mixin.has_interface_mixins import HasChannel
+from pyiron_workflow.mixin.injection import OutputsWithInjection
 from pyiron_workflow.mixin.preview import ScrapesIO
 from pyiron_workflow.nodes.composite import Composite
 from pyiron_workflow.nodes.multiple_distpatch import dispatch_output_labels
@@ -342,7 +343,7 @@ class Macro(Composite, StaticNode, ScrapesIO, ABC):
         return self._inputs
 
     @property
-    def outputs(self) -> Outputs:
+    def outputs(self) -> OutputsWithInjection:
         return self._outputs
 
     def _parse_remotely_executed_self(self, other_self):

--- a/pyiron_workflow/nodes/transform.py
+++ b/pyiron_workflow/nodes/transform.py
@@ -40,10 +40,6 @@ class FromManyInputs(Transformer, ABC):
     # Inputs convert to `run_args` as a value dictionary
     # This must be commensurate with the internal expectations of _on_run
 
-    @abstractmethod
-    def _on_run(self, **inputs_to_value_dict) -> Any:
-        """Must take inputs kwargs"""
-
     @property
     def _run_args(self) -> tuple[tuple, dict]:
         return (), self.inputs.to_value_dict()

--- a/pyiron_workflow/workflow.py
+++ b/pyiron_workflow/workflow.py
@@ -26,6 +26,12 @@ class ParentMostError(TypeError):
     """
 
 
+class NoArgsError(TypeError):
+    """
+    To be raised when *args can't be processed but are received
+    """
+
+
 class Workflow(Composite):
     """
     Workflows are a dynamic composite node -- i.e. they hold and run a collection of
@@ -225,7 +231,7 @@ class Workflow(Composite):
         self.outputs_map = outputs_map
         self._inputs = None
         self._outputs = None
-        self.automate_execution = automate_execution
+        self.automate_execution: bool = automate_execution
 
         super().__init__(
             *nodes,
@@ -361,12 +367,18 @@ class Workflow(Composite):
 
     def run(
         self,
+        *args,
         check_readiness: bool = True,
         **kwargs,
     ):
         # Note: Workflows may have neither parents nor siblings, so we don't need to
         # worry about running their data trees first, fetching their input, nor firing
         # their `ran` signal, hence the change in signature from Node.run
+        if len(args) > 0:
+            raise NoArgsError(
+                f"{self.__class__} does not know how to process *args on run, but "
+                f"received {args}"
+            )
 
         return super().run(
             run_data_tree=False,

--- a/pyiron_workflow/workflow.py
+++ b/pyiron_workflow/workflow.py
@@ -10,7 +10,8 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from bidict import bidict
 
-from pyiron_workflow.io import Inputs, Outputs
+from pyiron_workflow.io import Inputs
+from pyiron_workflow.mixin.injection import OutputsWithInjection
 from pyiron_workflow.nodes.composite import Composite
 
 if TYPE_CHECKING:
@@ -294,7 +295,7 @@ class Workflow(Composite):
         return self._build_io("inputs", self.inputs_map)
 
     @property
-    def outputs(self) -> Outputs:
+    def outputs(self) -> OutputsWithInjection:
         return self._build_outputs()
 
     def _build_outputs(self):
@@ -304,7 +305,7 @@ class Workflow(Composite):
         self,
         i_or_o: Literal["inputs", "outputs"],
         key_map: dict[str, str | None] | None,
-    ) -> Inputs | Outputs:
+    ) -> Inputs | OutputsWithInjection:
         """
         Build an IO panel for exposing child node IO to the outside world at the level
         of the composite node's IO.
@@ -320,10 +321,10 @@ class Workflow(Composite):
                 (which normally would be exposed) by providing a string-None map.
 
         Returns:
-            (Inputs|Outputs): The populated panel.
+            (Inputs|OutputsWithInjection): The populated panel.
         """
         key_map = {} if key_map is None else key_map
-        io = Inputs() if i_or_o == "inputs" else Outputs()
+        io = Inputs() if i_or_o == "inputs" else OutputsWithInjection()
         for node in self.children.values():
             panel = getattr(node, i_or_o)
             for channel in panel:

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -17,7 +17,7 @@ from pyiron_workflow.io import (
 )
 
 
-class Dummy(HasIO):
+class Dummy(HasIO[Outputs]):
     def __init__(self, label: str | None = "has_io"):
         super().__init__()
         self._label = label

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -10,7 +10,7 @@ from static import demo_nodes
 from pyiron_workflow._tests import ensure_tests_in_python_path
 from pyiron_workflow.channels import NOT_DATA
 from pyiron_workflow.storage import TypeNotFoundError, available_backends
-from pyiron_workflow.workflow import ParentMostError, Workflow
+from pyiron_workflow.workflow import NoArgsError, ParentMostError, Workflow
 
 ensure_tests_in_python_path()
 
@@ -258,6 +258,12 @@ class TestWorkflow(unittest.TestCase):
             return a + b
 
         wf.sum = sum_(wf.a, wf.b)
+        with self.assertRaises(
+            NoArgsError,
+            msg="Workflows don't know what to do with raw args, since their input "
+            "has no intrinsic order",
+        ):
+            wf.run(1, 2)
         wf.run()
         self.assertEqual(
             wf.a.outputs.y.value + wf.b.outputs.y.value,


### PR DESCRIPTION
Makes `HasIO` generic on the type of data output panel it returns. A new generic class is introduced for the data outputs panel, but intermediate classes are trimmed elsewhere. Also tacked on some type hint fixes where the panels are used.