### PR TITLE
Change return on Composite.remove_child

### DIFF
--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -307,7 +307,7 @@ class Composite(SemanticParent[Node], HasCreator, Node, ABC):
         self._cached_inputs = None  # Reset cache after graph change
         return super().add_child(child, label=label, strict_naming=strict_naming)
 
-    def remove_child(self, child: Node | str) -> list[tuple[Channel, Channel]]:
+    def remove_child(self, child: Node | str) -> Node:
         """
         Remove a child from the :attr:`children` collection, disconnecting it and
         setting its :attr:`parent` to None.
@@ -316,14 +316,14 @@ class Composite(SemanticParent[Node], HasCreator, Node, ABC):
             child (Node|str): The child (or its label) to remove.
 
         Returns:
-            (list[tuple[Channel, Channel]]): Any connections that node had.
+            (Node): The (now disconnected and de-parented) (former) child node.
         """
         child = super().remove_child(child)
-        disconnected = child.disconnect()
+        child.disconnect()
         if child in self.starting_nodes:
             self.starting_nodes.remove(child)
         self._cached_inputs = None  # Reset cache after graph change
-        return disconnected
+        return child
 
     def replace_child(
         self, owned_node: Node | str, replacement: Node | type[Node]

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -281,7 +281,7 @@ class Composite(SemanticParent[Node], HasCreator, Node, ABC):
         Disconnect all `signals.input.run` connections on all child nodes.
 
         Returns:
-            list[tuple[Channel, Channel]]: Any disconnected pairs.
+            list[tuple[InputSignal, OutputSignal]]: Any disconnected pairs.
         """
         disconnected_pairs = []
         for node in self.children.values():

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -20,7 +20,6 @@ from pyiron_workflow.topology import set_run_connections_according_to_dag
 
 if TYPE_CHECKING:
     from pyiron_workflow.channels import (
-        Channel,
         InputSignal,
         OutputSignal,
     )

--- a/tests/unit/nodes/test_composite.py
+++ b/tests/unit/nodes/test_composite.py
@@ -133,29 +133,18 @@ class TestComposite(unittest.TestCase):
         # Connect it inside the composite
         self.comp.foo.inputs.x = self.comp.owned.outputs.y
 
-        disconnected = self.comp.remove_child(node)
+        self.comp.remove_child(node)
         self.assertIsNone(node.parent, msg="Removal should de-parent")
         self.assertFalse(node.connected, msg="Removal should disconnect")
-        self.assertListEqual(
-            [(node.inputs.x, self.comp.owned.outputs.y)],
-            disconnected,
-            msg="Removal should return destroyed connections",
-        )
         self.assertListEqual(
             self.comp.starting_nodes,
             [],
             msg="Removal should also remove from starting nodes",
         )
-
-        node_owned = self.comp.owned
-        disconnections = self.comp.remove_child(node_owned.label)
-        self.assertEqual(
-            node_owned.parent,
-            None,
-            msg="Should be able to remove nodes by label as well as by object",
-        )
         self.assertListEqual(
-            [], disconnections, msg="node1 should have no connections left"
+            [],
+            self.comp.owned.connections,
+            msg="Remaining node should have no connections left",
         )
 
     def test_label_uniqueness(self):


### PR DESCRIPTION
To match return in parent class. Disconnections were only ever used in the test case, and users are always free to disconnect and _then_ remove if they want to capture the broken connections explicitly.