### PR TITLE
Use inspect in order to get type hint metadata

### DIFF
--- a/pyiron_workflow/mixin/preview.py
+++ b/pyiron_workflow/mixin/preview.py
@@ -22,7 +22,6 @@ from typing import (
     ClassVar,
     get_args,
 )
-import inspect
 
 from pyiron_snippets.dotdict import DotDict
 

--- a/pyiron_workflow/mixin/preview.py
+++ b/pyiron_workflow/mixin/preview.py
@@ -200,12 +200,15 @@ class ScrapesIO(HasIOPreview, ABC):
         The result of :func:`inspect.signature` on the io-defining function
         """
         sig = inspect.signature(cls._io_defining_function(), eval_str=True)
-        type_dict = {key: value.annotation for key, value in sig.parameters.items()}
-        type_dict = type_dict | {"return": sig.return_annotation}
-        type_dict = {k: v for k, v in type_dict.items() if v != inspect.Parameter.empty}
-        for key, value in type_dict.items():
-            if value is None:
-                type_dict[key] = type(None)
+        type_dict = {
+            key: value.annotation if value.annotation else type(None)
+            for key, value in sig.parameters.items()
+            if value.annotation != inspect.Parameter.empty
+        }
+        if sig.return_annotation != inspect.Parameter.empty:
+            type_dict["return"] = (
+                sig.return_annotation if sig.return_annotation else type(None)
+            )
         return type_dict
 
     @classmethod

--- a/pyiron_workflow/mixin/preview.py
+++ b/pyiron_workflow/mixin/preview.py
@@ -199,7 +199,7 @@ class ScrapesIO(HasIOPreview, ABC):
         """
         The result of :func:`inspect.signature` on the io-defining function
         """
-        sig = inspect.signature(cls._io_defining_function())
+        sig = inspect.signature(cls._io_defining_function(), eval_str=True)
         type_dict = {
             key: value.annotation for key, value in sig.parameters.items()
         }

--- a/pyiron_workflow/mixin/preview.py
+++ b/pyiron_workflow/mixin/preview.py
@@ -200,10 +200,14 @@ class ScrapesIO(HasIOPreview, ABC):
         The result of :func:`inspect.signature` on the io-defining function
         """
         sig = inspect.signature(cls._io_defining_function())
-        d = {key: value.annotation for key, value in sig.parameters.items()}
-        d = d | {"return": sig.return_annotation}
-        d = {k: v for k, v in d.items() if v != inspect.Parameter.empty}
-        return d
+        type_dict = {
+            key: value.annotation for key, value in sig.parameters.items()
+        }
+        type_dict = type_dict | {"return": sig.return_annotation}
+        type_dict = {
+            k: v for k, v in type_dict.items() if v != inspect.Parameter.empty
+        }
+        return type_dict
 
     @classmethod
     @lru_cache(maxsize=1)

--- a/pyiron_workflow/mixin/preview.py
+++ b/pyiron_workflow/mixin/preview.py
@@ -200,13 +200,9 @@ class ScrapesIO(HasIOPreview, ABC):
         The result of :func:`inspect.signature` on the io-defining function
         """
         sig = inspect.signature(cls._io_defining_function(), eval_str=True)
-        type_dict = {
-            key: value.annotation for key, value in sig.parameters.items()
-        }
+        type_dict = {key: value.annotation for key, value in sig.parameters.items()}
         type_dict = type_dict | {"return": sig.return_annotation}
-        type_dict = {
-            k: v for k, v in type_dict.items() if v != inspect.Parameter.empty
-        }
+        type_dict = {k: v for k, v in type_dict.items() if v != inspect.Parameter.empty}
         for key, value in type_dict.items():
             if value is None:
                 type_dict[key] = type(None)

--- a/pyiron_workflow/mixin/preview.py
+++ b/pyiron_workflow/mixin/preview.py
@@ -207,6 +207,9 @@ class ScrapesIO(HasIOPreview, ABC):
         type_dict = {
             k: v for k, v in type_dict.items() if v != inspect.Parameter.empty
         }
+        for key, value in type_dict.items():
+            if value is None:
+                type_dict[key] = type(None)
         return type_dict
 
     @classmethod

--- a/pyiron_workflow/mixin/preview.py
+++ b/pyiron_workflow/mixin/preview.py
@@ -200,7 +200,10 @@ class ScrapesIO(HasIOPreview, ABC):
         The result of :func:`inspect.signature` on the io-defining function
         """
         sig = inspect.signature(cls._io_defining_function())
-        return dict(sig.parameters) | {"return": sig.return_annotation}
+        d = {key: value.annotation for key, value in sig.parameters.items()}
+        d = d | {"return": sig.return_annotation}
+        d = {k: v for k, v in d.items() if v != inspect.Parameter.empty}
+        return d
 
     @classmethod
     @lru_cache(maxsize=1)

--- a/pyiron_workflow/mixin/preview.py
+++ b/pyiron_workflow/mixin/preview.py
@@ -21,8 +21,8 @@ from typing import (
     Any,
     ClassVar,
     get_args,
-    get_type_hints,
 )
+import inspect
 
 from pyiron_snippets.dotdict import DotDict
 
@@ -198,9 +198,10 @@ class ScrapesIO(HasIOPreview, ABC):
     @lru_cache(maxsize=1)
     def _get_type_hints(cls) -> dict:
         """
-        The result of :func:`typing.get_type_hints` on the io-defining function
+        The result of :func:`inspect.signature` on the io-defining function
         """
-        return get_type_hints(cls._io_defining_function())
+        sig = inspect.signature(cls._io_defining_function())
+        return dict(sig.parameters) | {"return": sig.return_annotation}
 
     @classmethod
     @lru_cache(maxsize=1)

--- a/tests/unit/mixin/test_preview.py
+++ b/tests/unit/mixin/test_preview.py
@@ -205,3 +205,7 @@ class TestIOPreview(unittest.TestCase):
                 log.output,
                 msg="Verify that the expected warning appears in the log",
             )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I was trying to get full type hints by using `inspect` instead of `get_type_hints`.

Well, this being said I'm painfully aware of the fact that the tests fail, but I don't really know why XD The problem comes from the fact that somehow `type_dict["return"]` turns the return type into a string, so for example instead of `tuple[float, float, float]` you get `"tuple[float, float, float]"`, even though if I copy and paste the code snippet I can get the correct type. Is there any transformation that takes place before `preview_io`?