### PR TITLE
fix faulty comparisons

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install mypy
         run: pip install mypy
       - name: Test
-        run: mypy --ignore-missing-imports ${{ github.event.repository.name }}
+        run: mypy --ignore-missing-imports --strict-equality ${{ github.event.repository.name }}
 
   ruff-check:
     runs-on: ubuntu-latest

--- a/pyiron_workflow/mixin/semantics.py
+++ b/pyiron_workflow/mixin/semantics.py
@@ -97,7 +97,7 @@ class Semantic(UsesState, HasLabel, Generic[ParentType], ABC):
             self._parent.remove_child(self)
         self._parent = new_parent
         self._detached_parent_path = None
-        if self._parent is not None and self not in self._parent.children:
+        if self._parent is not None:
             self._parent.add_child(self)
 
     @property

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -297,11 +297,15 @@ def available_backends(
     """
 
     standard_backends = {"pickle": PickleStorage}
-    backend = standard_backends.get(backend, PickleStorage)() if isinstance(backend, str) else backend
+    backend_instance = (
+        standard_backends.get(backend, PickleStorage)()
+        if isinstance(backend, str)
+        else backend
+    )
 
-    if backend is not None:
-        yield backend
+    if backend_instance is not None:
+        yield backend_instance
         if only_requested:
             return
 
-    yield from (v() for v in standard_backends.values() if not isinstance(backend, v))
+    yield from (v() for k, v in standard_backends.items() if k != backend)

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -297,22 +297,11 @@ def available_backends(
     """
 
     standard_backends = {"pickle": PickleStorage}
-
-    def yield_requested():
-        if isinstance(backend, str):
-            yield standard_backends[backend]()
-        elif isinstance(backend, StorageInterface):
-            yield backend
+    backend = standard_backends.get(backend, PickleStorage)() if isinstance(backend, str) else backend
 
     if backend is not None:
-        yield from yield_requested()
+        yield backend
         if only_requested:
             return
 
-    for key, value in standard_backends.items():
-        if (
-            backend is None
-            or (isinstance(backend, str) and key != backend)
-            or (isinstance(backend, StorageInterface) and value != backend)
-        ):
-            yield value()
+    yield from (v() for v in standard_backends.values() if not isinstance(backend, v))

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -217,7 +217,7 @@ class TestNode(unittest.TestCase):
                 msg="Expect a recovery file to be saved on failure",
             )
 
-            reloaded = ANode(label="failing", autoload=True)
+            reloaded = ANode(label="failing")
             self.assertIs(
                 reloaded.inputs.x.value,
                 NOT_DATA,

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -30,15 +30,24 @@ class TestAvailableBackends(unittest.TestCase):
         self.assertIsInstance(backends[0], PickleStorage)
 
     def test_extra_backend(self):
-        my_interface = PickleStorage()
-        backends = list(available_backends(my_interface))
-        self.assertEqual(
-            len(backends), 2, msg="We expect both the one we passed, and all defaults"
-        )
-        self.assertIs(backends[0], my_interface)
-        self.assertIsNot(
-            backends[0], backends[1], msg="They should be separate instances"
-        )
+        with self.subTest("String backend"):
+            backends = list(available_backends("pickle"))
+            print(backends)
+            self.assertEqual(len(backends), 1, msg="We expect only the defaults")
+            self.assertIsInstance(backends[0], PickleStorage)
+
+        with self.subTest("Object backend"):
+            my_interface = PickleStorage()
+            backends = list(available_backends(my_interface))
+            self.assertEqual(
+                len(backends),
+                2,
+                msg="We expect both the one we passed, and all defaults",
+            )
+            self.assertIs(backends[0], my_interface)
+            self.assertIsNot(
+                backends[0], backends[1], msg="They should be separate instances"
+            )
 
     def test_exclusive_backend(self):
         my_interface = PickleStorage()

--- a/tests/unit/test_type_hinting.py
+++ b/tests/unit/test_type_hinting.py
@@ -118,7 +118,7 @@ class TestTypeHinting(unittest.TestCase):
 
     def test_get_type_hints(self):
         for hint, origin in [
-            (int | float, type(int| float)),
+            (int | float, type(int | float)),
             (typing.Annotated[int | float, "foo"], type(int | float)),
             (int, None),
             (typing.Annotated[int, "foo"], None),
@@ -127,7 +127,6 @@ class TestTypeHinting(unittest.TestCase):
         ]:
             with self.subTest(hint=hint, origin=origin):
                 self.assertEqual(_get_type_hints(hint)[0], origin)
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fix
```
pyiron_workflow/mixin/semantics.py:100: error: Non-overlapping container check (element type: "Semantic[ParentType]", container item type: "str")  [comparison-overlap]
pyiron_workflow/storage.py:316: error: Non-overlapping equality check (left operand type: "type[PickleStorage]", right operand type: "StorageInterface")  [comparison-overlap]
```
and enable corresponding `mypy` check.