### PR TITLE
Fix comparisons tests

### DIFF
--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -297,11 +297,14 @@ def available_backends(
     """
 
     standard_backends = {"pickle": PickleStorage}
-    backend = standard_backends.get(backend, PickleStorage)() if isinstance(backend, str) else backend
+    backend_instance = standard_backends.get(backend, PickleStorage)() if isinstance(backend, str) else backend
 
-    if backend is not None:
-        yield backend
+    if backend_instance is not None:
+        yield backend_instance
         if only_requested:
             return
 
-    yield from (v() for v in standard_backends.values() if not isinstance(backend, v))
+    yield from (
+        v() for k, v in standard_backends.items()
+        if (v != backend_instance and k != backend)
+    )

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -308,8 +308,4 @@ def available_backends(
         if only_requested:
             return
 
-    yield from (
-        v()
-        for k, v in standard_backends.items()
-        if (v != backend_instance and k != backend)
-    )
+    yield from (v() for k, v in standard_backends.items() if k != backend)

--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -297,7 +297,11 @@ def available_backends(
     """
 
     standard_backends = {"pickle": PickleStorage}
-    backend_instance = standard_backends.get(backend, PickleStorage)() if isinstance(backend, str) else backend
+    backend_instance = (
+        standard_backends.get(backend, PickleStorage)()
+        if isinstance(backend, str)
+        else backend
+    )
 
     if backend_instance is not None:
         yield backend_instance
@@ -305,6 +309,7 @@ def available_backends(
             return
 
     yield from (
-        v() for k, v in standard_backends.items()
+        v()
+        for k, v in standard_backends.items()
         if (v != backend_instance and k != backend)
     )

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -217,7 +217,7 @@ class TestNode(unittest.TestCase):
                 msg="Expect a recovery file to be saved on failure",
             )
 
-            reloaded = ANode(label="failing", autoload=True)
+            reloaded = ANode(label="failing")
             self.assertIs(
                 reloaded.inputs.x.value,
                 NOT_DATA,

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -30,15 +30,24 @@ class TestAvailableBackends(unittest.TestCase):
         self.assertIsInstance(backends[0], PickleStorage)
 
     def test_extra_backend(self):
-        my_interface = PickleStorage()
-        backends = list(available_backends(my_interface))
-        self.assertEqual(
-            len(backends), 2, msg="We expect both the one we passed, and all defaults"
-        )
-        self.assertIs(backends[0], my_interface)
-        self.assertIsNot(
-            backends[0], backends[1], msg="They should be separate instances"
-        )
+        with self.subTest("String backend"):
+            backends = list(available_backends("pickle"))
+            print(backends)
+            self.assertEqual(
+                len(backends), 1, msg="We expect only the defaults"
+            )
+            self.assertIsInstance(backends[0], PickleStorage)
+
+        with self.subTest("Object backend"):
+            my_interface = PickleStorage()
+            backends = list(available_backends(my_interface))
+            self.assertEqual(
+                len(backends), 2, msg="We expect both the one we passed, and all defaults"
+            )
+            self.assertIs(backends[0], my_interface)
+            self.assertIsNot(
+                backends[0], backends[1], msg="They should be separate instances"
+            )
 
     def test_exclusive_backend(self):
         my_interface = PickleStorage()

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -33,16 +33,16 @@ class TestAvailableBackends(unittest.TestCase):
         with self.subTest("String backend"):
             backends = list(available_backends("pickle"))
             print(backends)
-            self.assertEqual(
-                len(backends), 1, msg="We expect only the defaults"
-            )
+            self.assertEqual(len(backends), 1, msg="We expect only the defaults")
             self.assertIsInstance(backends[0], PickleStorage)
 
         with self.subTest("Object backend"):
             my_interface = PickleStorage()
             backends = list(available_backends(my_interface))
             self.assertEqual(
-                len(backends), 2, msg="We expect both the one we passed, and all defaults"
+                len(backends),
+                2,
+                msg="We expect both the one we passed, and all defaults",
             )
             self.assertIs(backends[0], my_interface)
             self.assertIsNot(

--- a/tests/unit/test_type_hinting.py
+++ b/tests/unit/test_type_hinting.py
@@ -118,7 +118,7 @@ class TestTypeHinting(unittest.TestCase):
 
     def test_get_type_hints(self):
         for hint, origin in [
-            (int | float, type(int| float)),
+            (int | float, type(int | float)),
             (typing.Annotated[int | float, "foo"], type(int | float)),
             (int, None),
             (typing.Annotated[int, "foo"], None),
@@ -127,7 +127,6 @@ class TestTypeHinting(unittest.TestCase):
         ]:
             with self.subTest(hint=hint, origin=origin):
                 self.assertEqual(_get_type_hints(hint)[0], origin)
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Patching #579 

In particular, when `storage.available_backends` receives a `StorageInterface` instance it needs to return that instance _and_ the standard backend(s), because interfaces may have states so a simple type check is not sufficiently details. And when `storage.available_backends` receives a string, it should _not_ return two copies of the standard backend(s) because the string can't carry any state so the default standard backend must be identical.

Honestly, the whole thing could use more simplification, but I am again uninterested in perfecting it while a new storage infrastructure is currently being worked on. In the mean time, this on top of #579 anyhow moves things in a nice direction in the meantime.