### PR TITLE
Reparent AmbiguousOutputError onto AttributeError

### DIFF
--- a/pyiron_workflow/mixin/single_output.py
+++ b/pyiron_workflow/mixin/single_output.py
@@ -15,7 +15,7 @@ from pyiron_workflow.mixin.injection import (
 )
 
 
-class AmbiguousOutputError(ValueError):
+class AmbiguousOutputError(AttributeError):
     """Raised when searching for exactly one output, but multiple are found."""
 
 
@@ -59,11 +59,15 @@ class ExploitsSingleOutput(
     def __getattr__(self, item):
         try:
             return super().__getattr__(item)
-        except AttributeError as e1:
-            try:
+        except AttributeError as e:
+            if len(self.outputs) == 1:
                 return getattr(self.channel, item)
-            except Exception as e2:
-                raise e2 from e1
+            else:
+                raise AmbiguousOutputError(
+                    f"Tried to access {item} on {self.label}, but failed. Delegating "
+                    f"access to `.channel` was impossible because there is more than "
+                    f"one output channel"
+                ) from e
 
     def __getitem__(self, item):
         return self.channel.__getitem__(item)

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -156,7 +156,6 @@ class TestWorkflow(unittest.TestCase):
             # executorlib < 0.1 had an Executor with optional backend parameter (defaulting to SingleNodeExecutor)
             executors.append(Workflow.create.executorlib.Executor)
 
-
         wf = Workflow("executed")
         wf.a = Workflow.create.standard.UserInput(42)  # Regular
         wf.b = wf.a + 1  # Injected

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -50,6 +50,22 @@ class ANode(Node):
         pass
 
 
+class TwOutputs(ANode):
+    """To de-abstract the class"""
+
+    def _setup_node(self) -> None:
+        super()._setup_node()
+        self._outputs = OutputsWithInjection(
+            OutputDataWithInjection("y", self, type_hint=int),
+            OutputDataWithInjection("z", self, type_hint=int),
+        )
+
+    def process_run_result(self, run_output):
+        self.outputs.y.value = run_output
+        self.outputs.z.value = run_output + 1
+        return self.outputs.y.value, self.outputs.z.value
+
+
 class TestNode(unittest.TestCase):
     def setUp(self):
         self.n1 = ANode(label="start", x=0)
@@ -393,6 +409,29 @@ class TestNode(unittest.TestCase):
             "should fail cleanly",
         ):
             node.channel  # noqa: B018
+
+    def test_injection_hasattr(self):
+        x = 2
+        node = ANode(label="n")
+        node.set_input_values(x=x)
+        node.run()
+
+        self.assertEqual(node.value, add_one(x), msg="With a single output, we expect to access the channel attribute")
+
+        two_outputs = TwOutputs(label="to")
+        two_outputs.set_input_values(x=x)
+        two_outputs.run()
+
+        with self.assertRaises(
+                AmbiguousOutputError,
+                msg="With two output channels, we should not be able to isolate a well defined value attribute because there is no single `channel` to look on",
+        ):
+            getattr(two_outputs, "value")
+
+        self.assertFalse(
+            hasattr(two_outputs, "value"),
+            msg="As a corollary to the last assertion, hasattr should fail",
+        )
 
     def test_storage(self):
         self.assertIs(

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -416,17 +416,21 @@ class TestNode(unittest.TestCase):
         node.set_input_values(x=x)
         node.run()
 
-        self.assertEqual(node.value, add_one(x), msg="With a single output, we expect to access the channel attribute")
+        self.assertEqual(
+            node.value,
+            add_one(x),
+            msg="With a single output, we expect to access the channel attribute",
+        )
 
         two_outputs = TwOutputs(label="to")
         two_outputs.set_input_values(x=x)
         two_outputs.run()
 
         with self.assertRaises(
-                AmbiguousOutputError,
-                msg="With two output channels, we should not be able to isolate a well defined value attribute because there is no single `channel` to look on",
+            AmbiguousOutputError,
+            msg="With two output channels, we should not be able to isolate a well defined value attribute because there is no single `channel` to look on",
         ):
-            getattr(two_outputs, "value")
+            getattr(two_outputs, "value")  # noqa: B009
 
         self.assertFalse(
             hasattr(two_outputs, "value"),


### PR DESCRIPTION
Just conceptually errors being raised from `__getattr__` ought to be this way anyhow, not `ValueError`. But more importantly, raising a `ValueError` instead of an `AttributeError` meant that the builtin `hasattr` method couldn't properly return `False` when the lookup failed due to not having an unambiguous `.channel` attribute to which to delegate the lookup.

Since we redirect `__getitem__` to `__getattr__`, maybe `AmbiguousOutputError` should have dual inheritance with `AttributeError` _and_ `KeyError`. However, this PR is really to address the key problem that `hasattr` is failing. Since I didn't have to touch the rest of the test suite, it seems to have accomplished it without any other side effects. I'd like to delay further modifications until a clear need appears.