### PR TITLE
Out-of-process caching

### DIFF
--- a/pyiron_workflow/nodes/for_loop.py
+++ b/pyiron_workflow/nodes/for_loop.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import math
+import pathlib
 from abc import ABC
 from concurrent.futures import Executor
 from functools import lru_cache
@@ -202,6 +203,7 @@ class For(Composite, StaticNode, ABC):
         delete_existing_savefiles: bool = False,
         autorun: bool = False,
         checkpoint: Literal["pickle"] | StorageInterface | None = None,
+        file_cache: str | pathlib.Path | None = None,
         strict_naming: bool = True,
         body_node_executor: Executor | None = None,
         **kwargs,
@@ -214,6 +216,7 @@ class For(Composite, StaticNode, ABC):
             autorun=autorun,
             autoload=autoload,
             checkpoint=checkpoint,
+            file_cache=file_cache,
             strict_naming=strict_naming,
             **kwargs,
         )

--- a/pyiron_workflow/nodes/static_io.py
+++ b/pyiron_workflow/nodes/static_io.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import pathlib
 from abc import ABC
+from typing import TYPE_CHECKING, Literal
 
 from pandas import DataFrame
 from pyiron_snippets.colors import SeabornColors
@@ -14,6 +16,10 @@ from pyiron_workflow.mixin.injection import (
 from pyiron_workflow.mixin.preview import HasIOPreview
 from pyiron_workflow.node import Node
 
+if TYPE_CHECKING:
+    from pyiron_workflow.nodes.composite import Composite
+    from pyiron_workflow.storage import StorageInterface
+
 
 class StaticNode(Node, HasIOPreview, ABC):
     """
@@ -21,6 +27,32 @@ class StaticNode(Node, HasIOPreview, ABC):
 
     Actual IO is then constructed from the preview at instantiation.
     """
+
+    file_cache: pathlib.Path | None
+
+    def __init__(
+        self,
+        *args,
+        label: str | None = None,
+        parent: Composite | None = None,
+        delete_existing_savefiles: bool = False,
+        autoload: Literal["pickle"] | StorageInterface | None = None,
+        autorun: bool = False,
+        checkpoint: Literal["pickle"] | StorageInterface | None = None,
+        file_cache: str | pathlib.Path | None = None,
+        **kwargs,
+    ):
+        self.file_cache = None if file_cache is None else pathlib.Path(file_cache)
+        super().__init__(
+            *args,
+            label=label,
+            parent=parent,
+            delete_existing_savefiles=delete_existing_savefiles,
+            autoload=autoload,
+            autorun=autorun,
+            checkpoint=checkpoint,
+            **kwargs,
+        )
 
     def _setup_node(self) -> None:
         super()._setup_node()

--- a/pyiron_workflow/workflow.py
+++ b/pyiron_workflow/workflow.py
@@ -355,6 +355,7 @@ class Workflow(Composite):
         run_parent_trees_too: bool,
         fetch_input: bool,
         emit_ran_signal: bool,
+        **kwargs: Any,
     ) -> tuple[bool, Any]:
         if self.automate_execution:
             self.set_run_signals_to_dag_execution()


### PR DESCRIPTION
Here is a draft of out-of-process caching.

At the moment, it doesn't actually leverage a database, but uses the filesystem as a database -- a first-attack suggested by @XzzX. In this case, we can provide a file cache directory to write to/read from for any `StaticNode` (i.e., presently anything but a `Workflow`). When this argument is provided, the node will generate its hash using `pyiron_database.instance_database.node.get_hash`, and see if there's a file of the same name. If so, it uses `bagofholding` to load that data to its output and short-circuits its run routine in the same manner as the old in-process cache. Similarly, at the end of its run, it uses `bagofholding` to save its `self.outputs.to_value_dict()` to a file based on the `pyiron_database` hash.

Here I'm not concerned about minor inefficiencies like calculating the hash multiple times, or even re-saving data that has already been saved. I'm only concerned with getting it running and stable. Stability demands tests, but since neither `bagofholding` nor `pyiron_database` are yet available as dependencies, I didn't make any effort here yet. I'm just trying to get the ball rolling.

Usage:

```python
import time

import pyiron_workflow as pwf

@pwf.as_function_node
def sleepy(duration: int):
    time.sleep(duration)
    return duration

wf = pwf.Workflow("my_file_caching")
wf.s = sleepy(5, file_cache=".")
wf()  # 5s 23ms
```

Next cell

```python
wf2 = pwf.Workflow("child_gets_the_same_hash")
wf2.t = sleepy(5, file_cache=".")
wf2()  # 10ms
```

That is obviously a super primitive hash, since it directly points to an integer. But, when I applied it to [@samwaseda's example workflow](https://github.com/pyiron/storage/discussions/2#discussioncomment-12185002) setting the `file_cache` on the `wf.bulk_energy` and `wf.vac_energy` nodes it also worked splendidly.

Since `get_hash` already snags the node module+qualname and versioning (if available), I think we've got a good safety net for making sure only appropriate saves get loaded. `bagofholding` doesn't actually _do_ anything with versioning data yet, but in principle once it does, when the output is some complex data type, `bagofholding` will take care of making sure that the current env is appropriate for reloading it. At the end of the day, we may wish to expose some version bound kwargs in `pyiron_workflow` as they come to exist in `pyiron_database` and `bagofholding`, but I don't think `pyiron_workflow` itself needs to manage any versioning here 🚀 

Moving forward:
- Do we want to provide an `InstanceDatabase` instead of a directory (or directories, for reading)?
  - Do we need _both_, or will the `InstanceDatabase` know about where to move the files to?
- What is the release plan for `pyiron_database` so we can include it as a dependency?
- Releasing `bagofholding` still waits on the copyright ping from KIT