### PR TITLE
Use instance check instead of equality in as_dataclass_node

### DIFF
--- a/pyiron_workflow/nodes/transform.py
+++ b/pyiron_workflow/nodes/transform.py
@@ -386,7 +386,7 @@ class DataclassNode(FromManyInputs, ABC):
 def dataclass_node_factory(
     dataclass: type, use_cache: bool = True, /
 ) -> type[DataclassNode]:
-    if type(dataclass) is not type:
+    if not isinstance(dataclass, type):
         raise TypeError(
             f"{DataclassNode} expected to get a dataclass but {dataclass} is not "
             f"type `type`."

--- a/tests/unit/nodes/test_transform.py
+++ b/tests/unit/nodes/test_transform.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 import pickle
 import random
 import unittest
@@ -248,6 +249,23 @@ class TestTransformer(unittest.TestCase):
                         msg="Fields with default factory won't see their default until "
                         "instantiation",
                     )
+
+        with self.subTest("From instantiated ABC"):
+
+            class MyAbstractData(ABC):
+                @abstractmethod
+                def shout(self):
+                    pass
+
+            try:
+                @as_dataclass_node
+                class MyConcreteData(MyAbstractData):
+                    name: str
+                    def shout(self):
+                        return f"!{self.name}!"
+            except:
+                self.fail("Wrapping an implementation of an ABC should not raise exceptions!")
+
 
     def test_dataclass_typing_and_storage(self):
         md = MyData()

--- a/tests/unit/nodes/test_transform.py
+++ b/tests/unit/nodes/test_transform.py
@@ -1,7 +1,7 @@
-from abc import ABC, abstractmethod
 import pickle
 import random
 import unittest
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, is_dataclass
 
 from pandas import DataFrame

--- a/tests/unit/nodes/test_transform.py
+++ b/tests/unit/nodes/test_transform.py
@@ -263,7 +263,7 @@ class TestTransformer(unittest.TestCase):
                     name: str
                     def shout(self):
                         return f"!{self.name}!"
-            except:
+            except: # noqa: E722
                 self.fail("Wrapping an implementation of an ABC should not raise exceptions!")
 
 


### PR DESCRIPTION
type(cls) is only equal to type if no other meta class has been used. This includes classes derived from ABC, so it is a bit inconvenient. Using the instance check however seems to work in these cases.