### PR TITLE
Permit empty graphs

### DIFF
--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -294,8 +294,9 @@ class Composite(SemanticParent[Node], HasCreator, Node, ABC):
         reconnect these according to the DAG flow of the data. On success, sets the
         starting nodes to just be the upstream-most node in this linear DAG flow.
         """
-        _, upstream_most_nodes = set_run_connections_according_to_dag(self.children)
-        self.starting_nodes = upstream_most_nodes
+        if len(self.children) > 0:
+            _, upstream_most_nodes = set_run_connections_according_to_dag(self.children)
+            self.starting_nodes = upstream_most_nodes
 
     def add_child(
         self,

--- a/tests/unit/nodes/test_composite.py
+++ b/tests/unit/nodes/test_composite.py
@@ -601,6 +601,15 @@ class TestComposite(unittest.TestCase):
             "and including the semantic root's own directory",
         )
 
+    def test_empty(self):
+        for child in self.comp.children:
+            self.comp.remove_child(child)
+        self.assertDictEqual(
+            {},
+            self.comp.run(),
+            msg="Empty composite graphs should be allowed to run, but return nothing",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/nodes/test_transform.py
+++ b/tests/unit/nodes/test_transform.py
@@ -258,14 +258,18 @@ class TestTransformer(unittest.TestCase):
                     pass
 
             try:
+
                 @as_dataclass_node
                 class MyConcreteData(MyAbstractData):
                     name: str
+
                     def shout(self):
                         return f"!{self.name}!"
-            except: # noqa: E722
-                self.fail("Wrapping an implementation of an ABC should not raise exceptions!")
 
+            except:  # noqa: E722
+                self.fail(
+                    "Wrapping an implementation of an ABC should not raise exceptions!"
+                )
 
     def test_dataclass_typing_and_storage(self):
         md = MyData()


### PR DESCRIPTION
I.e.

```python
import pyiron_workflow as pwf

wf = pwf.Workflow("empty")
wf()
>>> {}
```

Closes https://github.com/pyiron/pyironFlow/issues/48