### PR TITLE
Add pyiron_snippets/pint to build requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ requires = [
     "typeguard",
     "setuptools",
     "versioneer[toml]==0.29",
+    "pyiron_snippets",
+    "pint",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Otherwise pip install . will not run in a clean env.

@liamhuber As per our ealier mails, but not sure if this is how you intend things to be.