### PR TITLE
Caching `For`

### DIFF
--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -522,6 +522,7 @@ class Node(
             self.inputs.fetch()
 
         if self.use_cache and self.cache_hit:  # Read and use cache
+            self._on_cache_hit()
             if self.parent is None and emit_ran_signal:
                 self.emit()
             elif self.parent is not None:
@@ -529,12 +530,21 @@ class Node(
                 self.parent.register_child_finished(self)
                 if emit_ran_signal:
                     self.parent.register_child_emitting(self)
-
             return True, self._outputs_to_run_return()
-        elif self.use_cache:  # Write cache and continue
-            self._cached_inputs = self.inputs.to_value_dict()
+        else:
+            self._on_cache_miss()
+            if self.use_cache:  # Write cache and continue
+                self._cached_inputs = self.inputs.to_value_dict()
 
         return super()._before_run(check_readiness=check_readiness)
+
+    def _on_cache_hit(self) -> None:
+        """A hook for subclasses to act on cache hits"""
+        return
+
+    def _on_cache_miss(self) -> None:
+        """A hook for subclasses to act on cache misses"""
+        return
 
     def _run(
         self,

--- a/pyiron_workflow/nodes/for_loop.py
+++ b/pyiron_workflow/nodes/for_loop.py
@@ -233,7 +233,8 @@ class For(Composite, StaticNode, ABC):
         self._input_node_labels = tuple(n.label for n in input_nodes)
 
     def _on_cache_miss(self) -> None:
-        self._build_body()
+        if self.ready:
+            self._build_body()
 
     def _build_body(self):
         """

--- a/pyiron_workflow/nodes/for_loop.py
+++ b/pyiron_workflow/nodes/for_loop.py
@@ -232,9 +232,8 @@ class For(Composite, StaticNode, ABC):
         self.starting_nodes = input_nodes
         self._input_node_labels = tuple(n.label for n in input_nodes)
 
-    def _on_run(self):
+    def _on_cache_miss(self) -> None:
         self._build_body()
-        return super()._on_run()
 
     def _build_body(self):
         """


### PR DESCRIPTION
Closes #610 

Basically instead of _always_ rebuilding the child graph, we only rebuild it on cache misses. This is still a bit too aggressive of a rebuild, since in principle we only need to rebuild when the lengths of things we're iterating on change. Nonetheless, it's a simple step in the right direction.

@pmrv does the architecture look ok? Also, I'd like to add a test for this, but all I can think of is iterating over `standard_nodes.Sleep` and making sure it's faster the second time, but I don't really want to make such a slow test -- do you see a more clever route?