### PR TITLE
Raise save errors

### DIFF
--- a/pyiron_workflow/storage.py
+++ b/pyiron_workflow/storage.py
@@ -231,14 +231,16 @@ class PickleStorage(StorageInterface):
         if self._fallback(cloudpickle_fallback):
             attacks += [(self._CLOUDPICKLE, cloudpickle.dump)]
 
-        e = None
+        e: Exception | None = None
         for suffix, save_method in attacks:
+            e = None
             p = filename.with_suffix(suffix)
             try:
                 with open(p, "wb") as filehandle:
                     save_method(node, filehandle)
                 return
-            except Exception:
+            except Exception as ee:
+                e = ee
                 p.unlink(missing_ok=True)
         if e is not None:
             raise e

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -2,6 +2,9 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import cloudpickle
+from pint import UnitRegistry
+
 from pyiron_workflow.nodes.function import as_function_node
 from pyiron_workflow.nodes.standard import UserInput
 from pyiron_workflow.storage import PickleStorage, TypeNotFoundError, available_backends
@@ -134,6 +137,21 @@ class TestPickleStorage(unittest.TestCase):
         finally:
             interface.delete(node=u, cloudpickle_fallback=True)
 
+    def test_uncloudpickleable(self):
+        ureg = UnitRegistry()
+        with self.assertRaises(
+                TypeError,
+                msg="Sanity check that this can't even be cloudpickled"
+        ):
+            cloudpickle.dumps(ureg)
+
+        interface = PickleStorage(cloudpickle_fallback=True)
+        n = UserInput(ureg, label="uncloudpicklable_node")
+        with self.assertRaises(
+                TypeError,
+                msg="Exception should be caught and saving should fail"
+        ):
+            interface.save(n)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The pickle storage back end wasn't actually raising unavoidable errors in the save process! So it would just silently fail. Here, we catch and raise any error that remains when we've exhausted our attacks (in this case, pickle and cloudpickle).

Identified in #614. If the data there is indeed un-cloudpickle-able, then this also closes that issue.