### PR TITLE
Don't rely on parent to run data tree

### DIFF
--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -657,30 +657,9 @@ class Node(
                 self.signals.disconnect_run()
                 # Don't let anything upstream trigger _this_ node
 
-                if self.parent is None:
-                    for starter in data_tree_starters:
-                        starter.run()  # Now push from the top
-                else:
-                    # Run the special exec connections from above with the parent
+                for starter in data_tree_starters:
+                    starter.run()  # Now push from the top
 
-                    # Workflow parents will attempt to automate execution on run,
-                    # undoing all our careful execution
-                    # This heinous hack breaks in and stops that behaviour
-                    # I recognize this is dirty, but let's be pragmatic about getting
-                    # the features playing together. Workflows and pull are anyhow
-                    # already both very annoying on their own...
-                    from pyiron_workflow.workflow import Workflow
-
-                    if isinstance(self.parent, Workflow):
-                        automated = self.parent.automate_execution
-                        self.parent.automate_execution = False
-
-                    self.parent.starting_nodes = data_tree_starters
-                    self.parent.run()
-
-                    # And revert our workflow hack
-                    if isinstance(self.parent, Workflow):
-                        self.parent.automate_execution = automated
         finally:
             # No matter what, restore the original connections and labels afterwards
             for modified_label, node in nodes.items():
@@ -688,8 +667,6 @@ class Node(
                 node.signals.disconnect_run()
             for c1, c2 in disconnected_pairs:
                 c1.connect(c2)
-            if self.parent is not None:
-                self.parent.starting_nodes = parent_starting_nodes
 
     @property
     def cache_hit(self):


### PR DESCRIPTION
Another alternative to #618 and #619 for more sensible interactions of caching and pulling.

In principle I like this best, but I need to look at what tests are failing and why, and think harder about why I implemented it the way it currently is to start with.