### PR TITLE
Emit signals when running a child directly

### DIFF
--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -523,9 +523,9 @@ class Node(
 
         if self.use_cache and self.cache_hit:  # Read and use cache
             self._on_cache_hit()
-            if self.parent is None and emit_ran_signal:
+            if (self.parent is None or not self.parent.running) and emit_ran_signal:
                 self.emit()
-            elif self.parent is not None:
+            elif self.parent is not None and self.parent.running:
                 self.parent.register_child_starting(self)
                 self.parent.register_child_finished(self)
                 if emit_ran_signal:
@@ -554,7 +554,7 @@ class Node(
         run_finally_kwargs: dict,
         finish_run_kwargs: dict,
     ) -> Any | tuple | Future:
-        if self.parent is not None:
+        if self.parent is not None and self.parent.running:
             self.parent.register_child_starting(self)
         return super()._run(
             executor=executor,
@@ -566,7 +566,7 @@ class Node(
 
     def _run_finally(self, /, emit_ran_signal: bool, raise_run_exceptions: bool):
         super()._run_finally()
-        if self.parent is not None:
+        if self.parent is not None and self.parent.running:
             self.parent.register_child_finished(self)
         if self.checkpoint is not None:
             self.save_checkpoint(self.checkpoint)

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -572,7 +572,7 @@ class Node(
             self.save_checkpoint(self.checkpoint)
 
         if emit_ran_signal:
-            if self.parent is None:
+            if self.parent is None or not self.parent.running:
                 self.emit()
             else:
                 self.parent.register_child_emitting(self)

--- a/pyiron_workflow/nodes/for_loop.py
+++ b/pyiron_workflow/nodes/for_loop.py
@@ -271,6 +271,7 @@ class For(Composite, StaticNode, ABC):
                     run_data_tree=False,
                     run_parent_trees_too=False,
                     fetch_input=False,
+                    emit_ran_signal=False,
                     # Data should simply be coming from the value link
                     # We just want to refresh the output
                 )

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -40,7 +40,7 @@ HISTORY: str = ""
 @Workflow.wrap.as_function_node(use_cache=False)
 def SideEffect(x):
     y = x + 1
-    global HISTORY
+    global HISTORY  # noqa: PLW0603
     HISTORY += f"{y}"
     return y
 
@@ -343,7 +343,7 @@ class TestWorkflow(unittest.TestCase):
                 )
 
     def test_push_pull(self):
-        global HISTORY
+        global HISTORY  # noqa: PLW0603
 
         wf = Workflow("push_pull")
         wf.n1 = SideEffect(0)
@@ -422,7 +422,7 @@ class TestWorkflow(unittest.TestCase):
             )
 
     def test_push_pull_with_unconfigured_workflows(self):
-        global HISTORY
+        global HISTORY  # noqa: PLW0603
 
         wf = Workflow("push_pull")
         wf.n1 = SideEffect(0)
@@ -450,7 +450,7 @@ class TestWorkflow(unittest.TestCase):
                         ],
                     )
                 ),
-                msg=f"With no signals configured, we expect the run to go nowhere"
+                msg="With no signals configured, we expect the run to go nowhere"
             )
 
         with self.subTest("Just run"):
@@ -475,8 +475,8 @@ class TestWorkflow(unittest.TestCase):
                         ],
                     )
                 ),
-                msg=f"Explicitly pushing should guarantee push-like behaviour even for "
-                    f"un-configured workflows.",
+                msg="Explicitly pushing should guarantee push-like behaviour even for "
+                    "un-configured workflows.",
             )
 
 


### PR DESCRIPTION
 [@Tara-Lakshmipathy pointed out](https://github.com/pyiron/pyironFlow/issues/104#issuecomment-2718649284) that running a particular node doesn't actually push downstream when those nodes are inside the scope of a parent. Indeed, he's right and there was no simple flag or whatever to enable this! 

So here `Node.run` is modified to force signals to emit from nodes who don't have a parent (the existing behaviour) OR who do but whose parent is not itself currently running (and thus managing execution flow) (the new behaviour).