### PR TITLE
Inline Function class creator

### DIFF
--- a/pyiron_workflow/__init__.py
+++ b/pyiron_workflow/__init__.py
@@ -45,7 +45,12 @@ from pyiron_workflow.logging import logger
 from pyiron_workflow.nodes import standard as standard_nodes
 from pyiron_workflow.nodes.composite import FailedChildError
 from pyiron_workflow.nodes.for_loop import For, for_node, for_node_factory
-from pyiron_workflow.nodes.function import Function, as_function_node, function_node
+from pyiron_workflow.nodes.function import (
+    Function,
+    as_function_node,
+    function_node,
+    to_function_node,
+)
 from pyiron_workflow.nodes.macro import Macro, as_macro_node, macro_node
 from pyiron_workflow.nodes.transform import (
     as_dataclass_node,

--- a/pyiron_workflow/mixin/preview.py
+++ b/pyiron_workflow/mixin/preview.py
@@ -111,6 +111,8 @@ class ScrapesIO(HasIOPreview, ABC):
         thus be left static from the time of class definition onwards.
     """
 
+    _extra_type_hint_scope: ClassVar[dict[str, type] | None] = None
+
     @classmethod
     @abstractmethod
     def _io_defining_function(cls) -> Callable:
@@ -202,7 +204,11 @@ class ScrapesIO(HasIOPreview, ABC):
         """
         The result of :func:`inspect.signature` on the io-defining function
         """
-        return inspect.signature(cls._io_defining_function(), eval_str=True)
+        return inspect.signature(
+            cls._io_defining_function(),
+            eval_str=True,
+            locals=cls._extra_type_hint_scope,
+        )
 
     @classmethod
     @lru_cache(maxsize=1)

--- a/pyiron_workflow/nodes/for_loop.py
+++ b/pyiron_workflow/nodes/for_loop.py
@@ -91,7 +91,7 @@ def dictionary_to_index_maps(
         return range(n_zip)
 
     def zipped_index_map(zipped_index):
-        return {key: zipped_index for key in zipped_keys}
+        return dict.fromkeys(zipped_keys, zipped_index)
 
     def merge(d1, d2):
         d1.update(d2)

--- a/pyiron_workflow/nodes/function.py
+++ b/pyiron_workflow/nodes/function.py
@@ -454,11 +454,7 @@ def to_function_node(
     >>>
     >>> Trapz = to_function_node("Trapz", np.trapz, "trapz")
     >>> Trapz.preview_io()
-    {'inputs': {'y': (None, NOT_DATA),
-      'x': (None, None),
-      'dx': (None, 1.0),
-      'axis': (None, -1)},
-     'outputs': {'trapz': None}}
+    {'inputs': {'y': (None, NOT_DATA), 'x': (None, None), 'dx': (None, 1.0), 'axis': (None, -1)}, 'outputs': {'trapz': None}}
 
 
     - The function must be inspectable

--- a/pyiron_workflow/nodes/function.py
+++ b/pyiron_workflow/nodes/function.py
@@ -417,7 +417,7 @@ def as_function_node(
             subclass.
     """
 
-    def decorator(node_function):
+    def decorator(node_function) -> type[Function]:
         function_node_factory.clear(node_function.__name__)  # Force a fresh class
         factory_made = function_node_factory(
             node_function.__qualname__,
@@ -443,7 +443,7 @@ def to_function_node(
     *output_labels,
     validate_output_labels: bool = True,
     use_cache: bool = True,
-):
+) -> type[Function]:
     """
     Create a new :class:`Function` node class from an existing function.
     Useful when the function does not exist in a context where you are free to
@@ -509,7 +509,7 @@ def function_node(
     validate_output_labels: bool = True,
     use_cache: bool = True,
     **node_kwargs,
-):
+) -> Function:
     """
     Create and initialize a new instance of a :class:`Function` node.
 

--- a/pyiron_workflow/nodes/function.py
+++ b/pyiron_workflow/nodes/function.py
@@ -443,6 +443,7 @@ def to_function_node(
     *output_labels,
     validate_output_labels: bool = True,
     use_cache: bool = True,
+    scope: dict[str, type] | None = None,
 ) -> type[Function]:
     """
     Create a new :class:`Function` node class from an existing function.
@@ -456,14 +457,38 @@ def to_function_node(
     >>> Trapz.preview_io()
     {'inputs': {'y': (None, NOT_DATA), 'x': (None, None), 'dx': (None, 1.0), 'axis': (None, -1)}, 'outputs': {'trapz': None}}
 
-
+    We still have two requirements on functions converted in this way:
     - The function must be inspectable
         - e.g. :func:`numpy.arange` fails this requirement
-    - The function must not use protected or argument names
+    - The function must not use protected or argument names (as with decorated
+        functions)
         - e.g. variadics `*args` and `**kwargs`
-    - The function's annotations must be universally accessible
-        - In most cases this means they are restricted to no annotation at all, or a
-            type hint from the :mod:`builtins` like :class:`int` etc.
+    - The function must have a single return value (as with decorated functions)
+
+    Otherwise you will need to explicitly write a decorated function that wraps your
+    desired function.
+
+    Because nodes convert type hints to actual python objects for strict type checking,
+    we also need to provide non-builting type hints in the scope of the new node class
+    (for the benefit of an underlying `inspect.signature(..., eval_str=True)` call).
+    E.g., this function hints that it returns `set[Node]`, so while the new class is
+    being created it will need to know how to parse the `"Node"` string type hint
+    into an object. We do this by providing the `Node` class in its `scope` dictionary
+    (it already knows what a `set` is because this is just a python built-in type):
+
+    >>> from pyiron_workflow.topology import get_nodes_in_data_tree
+    >>> from pyiron_workflow.node import Node
+    >>>
+    >>> GetNodesInDataTree = to_function_node(
+    ...     "GetNodesInDataTree",
+    ...     get_nodes_in_data_tree,
+    ...     "nodes_set",  # Just a nice label for the output
+    ...     scope={"Node": Node},
+    ... )
+    >>>
+    >>> print(GetNodesInDataTree.preview_io())
+    {'inputs': {'node': (<class 'pyiron_workflow.node.Node'>, NOT_DATA)}, 'outputs': {'nodes_set': set[pyiron_workflow.node.Node]}}
+
 
     Args:
         node_class_name (str): The name of the new class -- MUST be manually matched to
@@ -494,6 +519,7 @@ def to_function_node(
         use_cache,
         *output_labels,
     )
+    factory_made._extra_type_hint_scope = scope
     factory_made.preview_io()
     return factory_made
 

--- a/pyiron_workflow/nodes/function.py
+++ b/pyiron_workflow/nodes/function.py
@@ -425,7 +425,7 @@ def as_function_node(
             node_function,
             validate_output_labels,
             use_cache,
-            *output_labels
+            *output_labels,
         )
         factory_made._reduce_imports_as = (
             node_function.__module__,
@@ -496,7 +496,7 @@ def to_function_node(
         node_function,
         validate_output_labels,
         use_cache,
-        *output_labels
+        *output_labels,
     )
     factory_made.preview_io()
     return factory_made
@@ -543,7 +543,7 @@ def function_node(
         node_function,
         validate_output_labels,
         use_cache,
-        *output_labels
+        *output_labels,
     )
     factory_made.preview_io()
     return factory_made(*node_args, **node_kwargs)

--- a/pyiron_workflow/nodes/transform.py
+++ b/pyiron_workflow/nodes/transform.py
@@ -190,7 +190,7 @@ class InputsToDict(FromManyInputs, ABC):
     @classmethod
     def _build_inputs_preview(cls) -> dict[str, tuple[Any | None, Any | NotData]]:
         if isinstance(cls._input_specification, list):
-            return {key: (None, NOT_DATA) for key in cls._input_specification}
+            return dict.fromkeys(cls._input_specification, (None, NOT_DATA))
         else:
             return cls._input_specification
 

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -37,6 +37,7 @@ def Bar(x):
 
 HISTORY: str = ""
 
+
 @Workflow.wrap.as_function_node(use_cache=False)
 def SideEffect(x):
     y = x + 1
@@ -367,7 +368,7 @@ class TestWorkflow(unittest.TestCase):
                         ],
                     )
                 ),
-                msg="Expected all three to run"
+                msg="Expected all three to run",
             )
 
         with self.subTest("Pull"):
@@ -384,7 +385,7 @@ class TestWorkflow(unittest.TestCase):
                         ],
                     )
                 ),
-                msg="Expected only upstream and this"
+                msg="Expected only upstream and this",
             )
 
         with self.subTest("Call"):
@@ -400,7 +401,7 @@ class TestWorkflow(unittest.TestCase):
                         ],
                     )
                 ),
-                msg="Calling maps to a pull (+parent data tree)"  # BUT IT DOESN'T?!
+                msg="Calling maps to a pull (+parent data tree)",  # BUT IT DOESN'T?!
             )
 
         with self.subTest("Push"):
@@ -418,7 +419,7 @@ class TestWorkflow(unittest.TestCase):
                         ],
                     )
                 ),
-                msg="Expected only this and downstream"
+                msg="Expected only this and downstream",
             )
 
     def test_push_pull_with_unconfigured_workflows(self):
@@ -434,8 +435,8 @@ class TestWorkflow(unittest.TestCase):
                 [],
                 wf.n2.signals.output.ran.connections,
                 msg="Sanity check -- we have never run the workflow, so the parent "
-                    "workflow has never had a chance to automatically configure its "
-                    "execution flow.",
+                "workflow has never had a chance to automatically configure its "
+                "execution flow.",
             )
             wf.n1.pull()
             HISTORY = ""
@@ -450,7 +451,7 @@ class TestWorkflow(unittest.TestCase):
                         ],
                     )
                 ),
-                msg="With no signals configured, we expect the run to go nowhere"
+                msg="With no signals configured, we expect the run to go nowhere",
             )
 
         with self.subTest("Just run"):
@@ -458,8 +459,8 @@ class TestWorkflow(unittest.TestCase):
                 [],
                 wf.n2.signals.output.ran.connections,
                 msg="Sanity check -- we have never run the workflow, so the parent "
-                    "workflow has never had a chance to automatically configure its "
-                    "execution flow.",
+                "workflow has never had a chance to automatically configure its "
+                "execution flow.",
             )
             wf.n1.pull()
             HISTORY = ""
@@ -469,14 +470,11 @@ class TestWorkflow(unittest.TestCase):
                 "".join(
                     map(
                         str,
-                        [
-                            wf.n2.outputs.y.value,
-                            wf.n3.outputs.y.value
-                        ],
+                        [wf.n2.outputs.y.value, wf.n3.outputs.y.value],
                     )
                 ),
                 msg="Explicitly pushing should guarantee push-like behaviour even for "
-                    "un-configured workflows.",
+                "un-configured workflows.",
             )
 
 

--- a/tests/unit/nodes/test_for_loop.py
+++ b/tests/unit/nodes/test_for_loop.py
@@ -63,7 +63,7 @@ class TestDictionaryToIndexMaps(unittest.TestCase):
         data = {"key1": [1, 2, 3], "key2": [4, 5]}
         zipped_keys = ("key1", "key2")
         expected_maps = tuple(
-            {key: idx for key in zipped_keys}
+            dict.fromkeys(zipped_keys, idx)
             for idx in range(min(len(data["key1"]), len(data["key2"])))
         )
         self.assertEqual(

--- a/tests/unit/nodes/test_function.py
+++ b/tests/unit/nodes/test_function.py
@@ -5,7 +5,12 @@ from pathlib import Path
 import numpy as np
 from pyiron_workflow.channels import NOT_DATA
 from pyiron_workflow.io import ConnectionCopyError, ValueCopyError
-from pyiron_workflow.nodes.function import Function, as_function_node, function_node, to_function_node
+from pyiron_workflow.nodes.function import (
+    Function,
+    as_function_node,
+    function_node,
+    to_function_node,
+)
 from pyiron_workflow.nodes.multiple_distpatch import MultipleDispatchError
 from pyiron_workflow.topology import get_nodes_in_data_tree
 
@@ -543,34 +548,28 @@ class TestFunction(unittest.TestCase):
 
     def test_inline_creation(self):
         with self.assertRaises(
-                ValueError,
-                msg="Known limitation: Can't have a bad signature, in this case '*args'"
+            ValueError,
+            msg="Known limitation: Can't have a bad signature, in this case '*args'",
         ):
             Sin = to_function_node("Sin", np.sin, "sinx")
 
         with self.assertRaises(
-                ValueError,
-                msg="Known limitation: Must be inspectable "
-                    "https://github.com/numpy/numpy/issues/16384, "
-                    "https://github.com/numpy/numpy/issues/8734"
+            ValueError,
+            msg="Known limitation: Must be inspectable "
+            "https://github.com/numpy/numpy/issues/16384, "
+            "https://github.com/numpy/numpy/issues/8734",
         ):
             ARange = to_function_node("ARange", np.arange, "arange")
 
         with self.assertRaises(
-                NameError,
-                msg="Known limitation: Type hints need to be universally accessible -- "
-                    "`Node` isn't"
+            NameError,
+            msg="Known limitation: Type hints need to be universally accessible -- "
+            "`Node` isn't",
         ):
-            GetNodes = to_function_node(
-                "GetNodes", get_nodes_in_data_tree, "nodes"
-            )
+            GetNodes = to_function_node("GetNodes", get_nodes_in_data_tree, "nodes")
 
         output_label = "trapz"
-        Trapz = to_function_node(
-            "Trapz",
-            np.trapz,
-            output_label
-        )
+        Trapz = to_function_node("Trapz", np.trapz, output_label)
         self.assertIs(
             np.trapz,
             Trapz.node_function,
@@ -588,9 +587,8 @@ class TestFunction(unittest.TestCase):
         self.assertAlmostEqual(
             out,
             reloaded.outputs.trapz.value,
-            msg="Save load cycle should work fine like for any other node"
+            msg="Save load cycle should work fine like for any other node",
         )
-
 
 
 if __name__ == "__main__":

--- a/tests/unit/nodes/test_function.py
+++ b/tests/unit/nodes/test_function.py
@@ -2,10 +2,12 @@ import pickle
 import unittest
 from pathlib import Path
 
+import numpy as np
 from pyiron_workflow.channels import NOT_DATA
 from pyiron_workflow.io import ConnectionCopyError, ValueCopyError
-from pyiron_workflow.nodes.function import Function, as_function_node, function_node
+from pyiron_workflow.nodes.function import Function, as_function_node, function_node, to_function_node
 from pyiron_workflow.nodes.multiple_distpatch import MultipleDispatchError
+from pyiron_workflow.topology import get_nodes_in_data_tree
 
 
 def throw_error(x: int | None = None):
@@ -538,6 +540,57 @@ class TestFunction(unittest.TestCase):
             "directly providing the wrapped node fail cleanly",
         ):
             as_function_node(plus_one, "z")
+
+    def test_inline_creation(self):
+        with self.assertRaises(
+                ValueError,
+                msg="Known limitation: Can't have a bad signature, in this case '*args'"
+        ):
+            Sin = to_function_node("Sin", np.sin, "sinx")
+
+        with self.assertRaises(
+                ValueError,
+                msg="Known limitation: Must be inspectable "
+                    "https://github.com/numpy/numpy/issues/16384, "
+                    "https://github.com/numpy/numpy/issues/8734"
+        ):
+            ARange = to_function_node("ARange", np.arange, "arange")
+
+        with self.assertRaises(
+                NameError,
+                msg="Known limitation: Type hints need to be universally accessible -- "
+                    "`Node` isn't"
+        ):
+            GetNodes = to_function_node(
+                "GetNodes", get_nodes_in_data_tree, "nodes"
+            )
+
+        output_label = "trapz"
+        Trapz = to_function_node(
+            "Trapz",
+            np.trapz,
+            output_label
+        )
+        self.assertIs(
+            np.trapz,
+            Trapz.node_function,
+            msg="We should be wrapping the requested function",
+        )
+        self.assertEqual(
+            output_label,
+            list(Trapz.preview_outputs().keys())[0],
+            msg="We should be able to name the output however we want",
+        )
+
+        n = Trapz()
+        out = n(np.linspace(0, 1, 10))
+        reloaded = pickle.loads(pickle.dumps(n))
+        self.assertAlmostEqual(
+            out,
+            reloaded.outputs.trapz.value,
+            msg="Save load cycle should work fine like for any other node"
+        )
+
 
 
 if __name__ == "__main__":

--- a/tests/unit/nodes/test_function.py
+++ b/tests/unit/nodes/test_function.py
@@ -3,6 +3,7 @@ import unittest
 from pathlib import Path
 
 import numpy as np
+
 from pyiron_workflow.channels import NOT_DATA
 from pyiron_workflow.io import ConnectionCopyError, ValueCopyError
 from pyiron_workflow.nodes.function import (
@@ -551,7 +552,7 @@ class TestFunction(unittest.TestCase):
             ValueError,
             msg="Known limitation: Can't have a bad signature, in this case '*args'",
         ):
-            Sin = to_function_node("Sin", np.sin, "sinx")
+            to_function_node("Sin", np.sin, "sinx")
 
         with self.assertRaises(
             ValueError,
@@ -559,14 +560,14 @@ class TestFunction(unittest.TestCase):
             "https://github.com/numpy/numpy/issues/16384, "
             "https://github.com/numpy/numpy/issues/8734",
         ):
-            ARange = to_function_node("ARange", np.arange, "arange")
+            to_function_node("ARange", np.arange, "arange")
 
         with self.assertRaises(
             NameError,
             msg="Known limitation: Type hints need to be universally accessible -- "
             "`Node` isn't",
         ):
-            GetNodes = to_function_node("GetNodes", get_nodes_in_data_tree, "nodes")
+            to_function_node("GetNodes", get_nodes_in_data_tree, "nodes")
 
         output_label = "trapz"
         Trapz = to_function_node("Trapz", np.trapz, output_label)

--- a/tests/unit/nodes/test_function.py
+++ b/tests/unit/nodes/test_function.py
@@ -562,12 +562,27 @@ class TestFunction(unittest.TestCase):
         ):
             to_function_node("ARange", np.arange, "arange")
 
-        with self.assertRaises(
-            NameError,
-            msg="Known limitation: Type hints need to be universally accessible -- "
-            "`Node` isn't",
-        ):
-            to_function_node("GetNodes", get_nodes_in_data_tree, "nodes")
+        with self.subTest("Non-builtin type hints should be ok via a scoping kwarg"):
+            from pyiron_workflow.node import Node as NonBuiltinTypeHint
+
+            GetNodes = to_function_node(
+                "GetNodes",
+                get_nodes_in_data_tree,
+                "node_set",
+                scope={"Node": NonBuiltinTypeHint},
+            )
+            self.assertEqual(
+                set[NonBuiltinTypeHint],
+                GetNodes.preview_outputs()["node_set"],
+                msg="Although non-builtin type hints are not normally accessible to "
+                "the signature inspection, we should be able to provide them",
+            )
+            self.assertEqual(
+                "Node",
+                GetNodes.preview_outputs()["node_set"].__args__[0].__name__,
+                msg="Sanity check: it shouldn't matter what we import it under, we are "
+                "providing the right class to the new node subclass.",
+            )
 
         output_label = "trapz"
         Trapz = to_function_node("Trapz", np.trapz, output_label)

--- a/tests/unit/nodes/test_transform.py
+++ b/tests/unit/nodes/test_transform.py
@@ -65,7 +65,7 @@ class TestTransformer(unittest.TestCase):
             d = {"c1": 4, "c2": 5}
             default = 42
             hint = int
-            spec = {k: (int, default) for k in d}
+            spec = dict.fromkeys(d, (int, default))
             n = inputs_to_dict(spec, autorun=True)
             self.assertIs(
                 n.inputs[list(d.keys())[0]].type_hint,
@@ -73,7 +73,7 @@ class TestTransformer(unittest.TestCase):
                 msg="Spot check hint recognition",
             )
             self.assertDictEqual(
-                {k: default for k in d},
+                dict.fromkeys(d, default),
                 n.outputs.dict.value,
                 msg="Verify structure and ability to pass defaults",
             )

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -140,18 +140,17 @@ class TestPickleStorage(unittest.TestCase):
     def test_uncloudpickleable(self):
         ureg = UnitRegistry()
         with self.assertRaises(
-                TypeError,
-                msg="Sanity check that this can't even be cloudpickled"
+            TypeError, msg="Sanity check that this can't even be cloudpickled"
         ):
             cloudpickle.dumps(ureg)
 
         interface = PickleStorage(cloudpickle_fallback=True)
         n = UserInput(ureg, label="uncloudpicklable_node")
         with self.assertRaises(
-                TypeError,
-                msg="Exception should be caught and saving should fail"
+            TypeError, msg="Exception should be caught and saving should fail"
         ):
             interface.save(n)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Sometimes we don't have access to the function we want to node-ize to decorate it, and writing out a wrapping function can be annoying, so (under a subset of circumstances) this is a shortcut:

```python
>>> import numpy as np
>>> from pyiron_workflow.nodes.function import to_function_node
>>>
>>> Trapz = to_function_node("Trapz", np.trapz, "trapz")
>>> Trapz.preview_io()
{'inputs': {'y': (None, NOT_DATA),
  'x': (None, None),
  'dx': (None, 1.0),
  'axis': (None, -1)},
 'outputs': {'trapz': None}}
```

- The function must be inspectable
    - e.g. `numpy.arange` fails this requirement
- The function must not use protected or argument names
    - e.g. variadics `*args` and `**kwargs`
- ~The function's annotations must be universally accessible~
    - ~In most cases this means they are restricted to no annotation at all, or a
        type hint from the `builtins` like `int` etc.~

Because of these limitations, I'm leaving it out of the root API for now.

Closes #622 