### PR TITLE
Scoping type hints

### DIFF
--- a/pyiron_workflow/__init__.py
+++ b/pyiron_workflow/__init__.py
@@ -45,7 +45,12 @@ from pyiron_workflow.logging import logger
 from pyiron_workflow.nodes import standard as standard_nodes
 from pyiron_workflow.nodes.composite import FailedChildError
 from pyiron_workflow.nodes.for_loop import For, for_node, for_node_factory
-from pyiron_workflow.nodes.function import Function, as_function_node, function_node
+from pyiron_workflow.nodes.function import (
+    Function,
+    as_function_node,
+    function_node,
+    to_function_node,
+)
 from pyiron_workflow.nodes.macro import Macro, as_macro_node, macro_node
 from pyiron_workflow.nodes.transform import (
     as_dataclass_node,

--- a/pyiron_workflow/mixin/preview.py
+++ b/pyiron_workflow/mixin/preview.py
@@ -111,6 +111,8 @@ class ScrapesIO(HasIOPreview, ABC):
         thus be left static from the time of class definition onwards.
     """
 
+    _extra_type_hint_scope: ClassVar[dict[str, type] | None] = None
+
     @classmethod
     @abstractmethod
     def _io_defining_function(cls) -> Callable:
@@ -202,7 +204,11 @@ class ScrapesIO(HasIOPreview, ABC):
         """
         The result of :func:`inspect.signature` on the io-defining function
         """
-        return inspect.signature(cls._io_defining_function(), eval_str=True)
+        return inspect.signature(
+            cls._io_defining_function(),
+            eval_str=True,
+            locals=cls._extra_type_hint_scope,
+        )
 
     @classmethod
     @lru_cache(maxsize=1)

--- a/pyiron_workflow/nodes/function.py
+++ b/pyiron_workflow/nodes/function.py
@@ -486,8 +486,8 @@ def to_function_node(
     ...     scope={"Node": Node},
     ... )
     >>>
-    >>> print(GetNodesInDataTree.outputs.nodes_set.type_hint)
-    set[pyiron_workflow.node.Node]
+    >>> print(GetNodesInDataTree.preview_io())
+    {'inputs': {'node': (<class 'pyiron_workflow.node.Node'>, NOT_DATA)}, 'outputs': {'nodes_set': set[pyiron_workflow.node.Node]}}
 
 
     Args:

--- a/pyiron_workflow/nodes/function.py
+++ b/pyiron_workflow/nodes/function.py
@@ -443,6 +443,7 @@ def to_function_node(
     *output_labels,
     validate_output_labels: bool = True,
     use_cache: bool = True,
+    scope: dict[str, type] | None = None,
 ) -> type[Function]:
     """
     Create a new :class:`Function` node class from an existing function.
@@ -518,6 +519,7 @@ def to_function_node(
         use_cache,
         *output_labels,
     )
+    factory_made._extra_type_hint_scope = scope
     factory_made.preview_io()
     return factory_made
 

--- a/tests/unit/nodes/test_function.py
+++ b/tests/unit/nodes/test_function.py
@@ -571,15 +571,15 @@ class TestFunction(unittest.TestCase):
                 "node_set",
                 scope={"Node": NonBuiltinTypeHint},
             )
-            self.assertIs(
+            self.assertEqual(
                 set[NonBuiltinTypeHint],
-                GetNodes.outputs.node_set.type_hint,
+                GetNodes.preview_outputs()["node_set"],
                 msg="Although non-builtin type hints are not normally accessible to "
                 "the signature inspection, we should be able to provide them",
             )
-            self.assertSetEqual(
+            self.assertEqual(
                 "Node",
-                GetNodes.outputs.node_set.type_hint.__args__[0].__name__,
+                GetNodes.preview_outputs()["node_set"].__args__[0].__name__,
                 msg="Sanity check: it shouldn't matter what we import it under, we are "
                 "providing the right class to the new node subclass.",
             )


### PR DESCRIPTION
This adds a `scope` parameter to the `to_function_node` converter that is used by the underlying `ScrapesIO` class to parse string type hints into python objects when that conversion context would otherwise be missing from the `inspect.signature(..., eval_str=True)` call.