### PR TITLE
Change node name(s)

### DIFF
--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -68,9 +68,9 @@ class TwOutputs(ANode):
 
 class TestNode(unittest.TestCase):
     def setUp(self):
-        self.n1 = ANode(label="start", x=0)
-        self.n2 = ANode(label="middle", x=self.n1.outputs.y)
-        self.n3 = ANode(label="end", x=self.n2.outputs.y)
+        self.n1 = ANode(label="start_node", x=0)
+        self.n2 = ANode(label="middle_node", x=self.n1.outputs.y)
+        self.n3 = ANode(label="end_node", x=self.n2.outputs.y)
 
     def test_set_input_values(self):
         n = ANode()

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -1,4 +1,5 @@
 import contextlib
+import shutil
 import unittest
 
 from pyiron_workflow.channels import NOT_DATA, InputData
@@ -357,9 +358,7 @@ class TestNode(unittest.TestCase):
                         for pp in p.iterdir():
                             print(pp)
             if self.n1.as_path().exists():
-                for p in self.n1.as_path().iterdir():
-                    p.unlink()
-                self.n1.as_path().rmdir()
+                shutil.rmtree(self.n1.as_path())
 
     def test_autorun(self):
         self.assertIs(

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -356,6 +356,8 @@ class TestNode(unittest.TestCase):
                     if p.is_dir():
                         for pp in p.iterdir():
                             print(pp)
+            if self.n1.as_path().exists():
+                for p in self.n1.as_path().iterdir():
                     p.unlink()
                 self.n1.as_path().rmdir()
 

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -317,6 +317,13 @@ class TestNode(unittest.TestCase):
 
     def test_draw(self):
         try:
+            print("Initially")
+            if self.n1.as_path().exists():
+                for p in self.n1.as_path().iterdir():
+                    print(p, type(p))
+                    if p.is_dir():
+                        for pp in p.iterdir():
+                            print(pp)
             self.n1.draw()
             self.assertFalse(self.n1.as_path().exists())
 
@@ -342,8 +349,13 @@ class TestNode(unittest.TestCase):
             )
         finally:
             # No matter what happens in the tests, clean up after yourself
+            print("Finally")
             if self.n1.as_path().exists():
                 for p in self.n1.as_path().iterdir():
+                    print(p, type(p))
+                    if p.is_dir():
+                        for pp in p.iterdir():
+                            print(pp)
                     p.unlink()
                 self.n1.as_path().rmdir()
 


### PR DESCRIPTION
To try to avoid name conflict on CI?

We keep getting [test failure](https://github.com/pyiron/pyiron_workflow/actions/runs/14766254506/job/41458195231) in the `test_node.TestNode.test_draw` location of all places:

```
======================================================================
ERROR: test_draw (unit.test_node.TestNode.test_draw)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/pyiron_workflow/pyiron_workflow/tests/unit/test_node.py", line 347, in test_draw
    p.unlink()
  File "/home/runner/work/pyiron_workflow/pyiron_workflow/cached-miniforge/my-env/lib/python3.12/pathlib.py", line 1342, in unlink
    os.unlink(self)
IsADirectoryError: [Errno 21] Is a directory: '/home/runner/work/pyiron_workflow/pyiron_workflow/start/cached-miniforge'

----------------------------------------------------------------------
```

When I run these tests locally, the node is being created in the directory where the tests are launched from, e.g.

```
/Users/.../pyiron_workflow/tests/start/start_graph.png
/Users/.../pyiron_workflow/tests/start/start_graph.pdf
/Users/.../pyiron_workflow/tests/start/foo.png
```

I'm rather hoping that `start` was just too generic for the node name and there is some _other_ directory of the same name (which we allow for at save-time, although perhaps we need a guardrail here?) so using a more specific name will avoid the conflict.