### PR TITLE
Remove the entire node directory

### DIFF
--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -1,4 +1,5 @@
 import contextlib
+import shutil
 import unittest
 
 from pyiron_workflow.channels import NOT_DATA, InputData
@@ -343,9 +344,7 @@ class TestNode(unittest.TestCase):
         finally:
             # No matter what happens in the tests, clean up after yourself
             if self.n1.as_path().exists():
-                for p in self.n1.as_path().iterdir():
-                    p.unlink()
-                self.n1.as_path().rmdir()
+                shutil.rmtree(self.n1.as_path())
 
     def test_autorun(self):
         self.assertIs(


### PR DESCRIPTION
In one swoop. This accommodates the CI which is (for reasons yet unclear to me) sticking additional information inside the node directory.