### PR TITLE
Accommodate old-style hints

### DIFF
--- a/pyiron_workflow/type_hinting.py
+++ b/pyiron_workflow/type_hinting.py
@@ -44,7 +44,9 @@ def valid_value(value, type_hint, strict_callables: bool = True) -> bool:
 
 
 def type_hint_to_tuple(type_hint) -> tuple:
-    if isinstance(type_hint, types.UnionType):
+    if isinstance(type_hint, types.UnionType) or (
+        hasattr(type_hint, "__origin__") and type_hint.__origin__ is typing.Union
+    ):
         return typing.get_args(type_hint)
     return (type_hint,)
 

--- a/tests/unit/test_type_hinting.py
+++ b/tests/unit/test_type_hinting.py
@@ -6,6 +6,7 @@ from pint import UnitRegistry
 from pyiron_workflow.type_hinting import (
     _get_type_hints,
     type_hint_is_as_or_more_specific_than,
+    type_hint_to_tuple,
     valid_value,
 )
 
@@ -106,6 +107,16 @@ class TestTypeHinting(unittest.TestCase):
                 typing.Annotated[int, "foo"],
                 True,
             ),
+            (
+                typing.Optional[typing.Dict[str, int]],
+                dict[str, int] | None,
+                True,  # Old- and new-styles should be equivalent
+            ),
+            (
+                dict[str, int] | None,
+                typing.Optional[typing.Dict[str, int]],
+                True,  # Thus, we expect the reverse direction to work to prove identity
+            ),
         ]:
             with self.subTest(
                 target=target, reference=reference, expected=is_more_specific
@@ -127,6 +138,22 @@ class TestTypeHinting(unittest.TestCase):
         ]:
             with self.subTest(hint=hint, origin=origin):
                 self.assertEqual(_get_type_hints(hint)[0], origin)
+
+    def test_type_hint_to_tuple(self):
+        for hint, tuple_ in (
+            (dict[str, int] | None, (dict[str, int], type(None))),
+            (typing.Dict[str, int] | None, (typing.Dict[str, int], type(None))),
+            (typing.Optional[dict[str, int]], (dict[str, int], type(None))),
+            (
+                typing.Optional[typing.Dict[str, int]],
+                (typing.Dict[str, int], type(None)),
+            ),
+        ):
+            self.assertEqual(
+                type_hint_to_tuple(hint),
+                tuple_,
+                msg="Old- and new-style hints should both be split into a tuple",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In particular `typing.Optional` is not an instance of `types.Union`, so add a clause to catch that case and test old- and new-style equivalency.

Closes #659 