### PR TITLE
"Move", don't "copy" connections

### DIFF
--- a/pyiron_workflow/channels.py
+++ b/pyiron_workflow/channels.py
@@ -12,8 +12,6 @@ import inspect
 import typing
 from abc import ABC, abstractmethod
 
-from IPython.lib.deepreload import original_reload
-
 from pyiron_snippets.singleton import Singleton
 
 from pyiron_workflow.compatibility import Self

--- a/pyiron_workflow/io.py
+++ b/pyiron_workflow/io.py
@@ -540,8 +540,8 @@ class HasIO(HasStateDisplay, HasLabel, HasRun, Generic[OutputsType], ABC):
                             # If you run into trouble, unwind what you've done
                             for this, that in new_connections:
                                 this.disconnect(that)
-                            for old, other in old_connections:
-                                old.connect(other)
+                            for old, partner in old_connections:
+                                old.connect(partner)
                             raise ConnectionCopyError(
                                 f"{self.label} could not copy connections from "
                                 f"{other.label} due to the channel {key} on "

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -380,7 +380,7 @@ class Composite(LexicalParent[Node], HasCreator, Node, ABC):
                 f"got {replacement}"
             )
 
-        replacement_node.copy_io(
+        replacement_node.move_io(
             owned_node_instance
         )  # If the replacement is incompatible, we'll
         # fail here before we've changed the parent at all. Since the replacement was

--- a/pyiron_workflow/workflow.py
+++ b/pyiron_workflow/workflow.py
@@ -468,7 +468,7 @@ class Workflow(Composite):
                         # But, if it wasn't connected, we don't even care whether or not
                         # we still have a corresponding channel to copy to
                         new_channel = new[old_channel.label]
-                        new_channel.copy_connections(old_channel)
+                        new_channel.move_connections(old_channel)
                         swapped_conenctions = old_channel.disconnect_all()  # Purge old
                         connection_changes.append(
                             (new_channel, old_channel, swapped_conenctions)

--- a/tests/unit/nodes/test_composite.py
+++ b/tests/unit/nodes/test_composite.py
@@ -244,7 +244,11 @@ class TestComposite(unittest.TestCase):
         with self.subTest("Verify success cases"):
             self.assertEqual(3, self.comp.run().n3__y, msg="Sanity check")
 
-            self.comp.replace_child(n1, replacement)
+            old, new = self.comp.replace_child(n1, replacement)
+            self.assertFalse(old.connected)
+            self.assertIsNone(old.parent)
+            self.assertTrue(new.connected)
+            self.assertIs(new.parent, self.comp)
             out = self.comp.run(n1__x=0)
             self.assertEqual(
                 (0 + 2) + 1 + 1, out.n3__y, msg="Should be able to replace by instance"

--- a/tests/unit/nodes/test_function.py
+++ b/tests/unit/nodes/test_function.py
@@ -274,7 +274,7 @@ class TestFunction(unittest.TestCase):
         upstream, to_copy, downstream, node = _setup()
 
         with self.subTest("Successful copy"):
-            node._copy_connections(to_copy)
+            node.move_connections(to_copy)
             self.assertIn(upstream.outputs.y, node.inputs.x.connections)
             self.assertIn(upstream.signals.output.ran, node.signals.input.run)
             self.assertIn(downstream.inputs.x, node.outputs.y.connections)
@@ -296,7 +296,7 @@ class TestFunction(unittest.TestCase):
 
         with self.subTest("Ensure failed copies fail cleanly"):
             with self.assertRaises(ConnectionCopyError, msg="Wrong labels"):
-                node._copy_connections(wrong_io)
+                node.move_connections(wrong_io)
             self.assertFalse(
                 node.connected,
                 msg="The x-input connection should have been copied, but should be "
@@ -308,16 +308,16 @@ class TestFunction(unittest.TestCase):
                 msg="An unhinted channel is not a valid connection for a hinted "
                 "channel, and should raise and exception",
             ):
-                hinted_node._copy_connections(to_copy)
+                hinted_node.move_connections(to_copy)
         hinted_node.disconnect()  # Make sure you've got a clean slate
         node.disconnect()  # Make sure you've got a clean slate
 
         with self.subTest("Ensure that failures can be continued past"):
-            node._copy_connections(wrong_io, fail_hard=False)
+            node.move_connections(wrong_io, fail_hard=False)
             self.assertIn(upstream.outputs.y, node.inputs.x.connections)
             self.assertIn(downstream.inputs.x, node.outputs.y.connections)
 
-            hinted_node._copy_connections(to_copy, fail_hard=False)
+            hinted_node.move_connections(to_copy, fail_hard=False)
             self.assertFalse(
                 hinted_node.inputs.connected,
                 msg="Without hard failure the copy should be allowed to proceed, but "

--- a/tests/unit/nodes/test_function.py
+++ b/tests/unit/nodes/test_function.py
@@ -261,17 +261,17 @@ class TestFunction(unittest.TestCase):
             )
 
     def test_copy_connections(self):
-        node = function_node(plus_one)
+        def _setup():
+            node = function_node(plus_one)
 
-        upstream = function_node(plus_one)
-        to_copy = function_node(plus_one, x=upstream.outputs.y)
-        downstream = function_node(plus_one, x=to_copy.outputs.y)
-        upstream >> to_copy >> downstream
+            upstream = function_node(plus_one)
+            to_copy = function_node(plus_one, x=upstream.outputs.y)
+            downstream = function_node(plus_one, x=to_copy.outputs.y)
+            upstream >> to_copy >> downstream
 
-        wrong_io = function_node(
-            returns_multiple, x=upstream.outputs.y, y=upstream.outputs.y
-        )
-        downstream.inputs.x.connect(wrong_io.outputs.y)
+            return upstream, to_copy, downstream, node
+
+        upstream, to_copy, downstream, node = _setup()
 
         with self.subTest("Successful copy"):
             node._copy_connections(to_copy)
@@ -284,6 +284,13 @@ class TestFunction(unittest.TestCase):
         def plus_one_hinted(x: int = 0) -> int:
             y = x + 1
             return y
+
+        upstream, to_copy, downstream, node = _setup()
+
+        wrong_io = function_node(
+            returns_multiple, x=upstream.outputs.y, y=upstream.outputs.y
+        )
+        downstream.inputs.x.connect(wrong_io.outputs.y)
 
         hinted_node = function_node(plus_one_hinted)
 

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -243,7 +243,7 @@ class TestDataChannels(unittest.TestCase):
             self.ni1.connections,
             [self.no],
             msg="On failing, copy should revert the copied channel to its orignial "
-                "state",
+            "state",
         )
         self.assertListEqual(
             self.ni2.connections,

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -216,24 +216,35 @@ class TestDataChannels(unittest.TestCase):
             msg="With strict connections turned off, we should allow type-violations",
         )
 
-    def test_copy_connections(self):
+    def test_moving_connections(self):
         self.ni1.connect(self.no)
         self.ni2.connect(self.no_empty)
-        self.ni2.copy_connections(self.ni1)
+
+        self.ni2.move_connections(self.ni1)
+        self.assertFalse(self.ni1.connected)
         self.assertListEqual(
             self.ni2.connections,
-            [*self.ni1.connections, self.no_empty],
-            msg="Copying should be additive, existing connections should still be there",
+            [self.no],
+            msg="Copying should hard-transfer the connection",
         )
 
-        self.ni2.disconnect(*self.ni1.connections)
+    def test_moving_connections_failure(self):
+        self.ni1.connect(self.no)
+        self.ni2.connect(self.no_empty)
+
         self.ni1.connections.append(self.so1)  # Manually include a poorly-typed conn
         with self.assertRaises(
             ChannelConnectionError,
             msg="Should not be able to connect to so1 because of type hint "
             "incompatibility",
         ):
-            self.ni2.copy_connections(self.ni1)
+            self.ni2.move_connections(self.ni1)
+        self.assertListEqual(
+            self.ni1.connections,
+            [self.no],
+            msg="On failing, copy should revert the copied channel to its orignial "
+                "state",
+        )
         self.assertListEqual(
             self.ni2.connections,
             [self.no_empty],

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -1,7 +1,7 @@
+import contextlib
 import unittest
 
 from pyiron_workflow.channels import (
-    DataChannel,
     InputData,
     InputSignal,
     OutputData,
@@ -367,7 +367,9 @@ class TestHasIO(unittest.TestCase):
                     type_hint=copier_hint,  # Different hint!
                 )
                 copier.inputs["extra_input"] = InputData(
-                    "extra_input", copier, default="not on the copied object but that's ok"
+                    "extra_input",
+                    copier,
+                    default="not on the copied object but that's ok",
                 )
                 copier.outputs["used_output"] = OutputData("used_output", copier)
                 copier.signals.input["custom_signal"] = InputSignal(
@@ -427,15 +429,13 @@ class TestHasIO(unittest.TestCase):
         with self.subTest("Passes missing values"):
             copier.move_io(to_copy, connections_fail_hard=True, values_fail_hard=False)
             for inp in copier.inputs:
-                try:
+                with contextlib.suppress(AttributeError):
+                    # We only need to check shared channels
                     self.assertEqual(
                         inp.value,
                         to_copy.inputs[inp.label].value,
-                        msg="All values on shared channels should copy"
+                        msg="All values on shared channels should copy",
                     )
-                except AttributeError:
-                    # We only need to check shared channels
-                    pass
 
         upstream, to_copy, downstream, copier = _setup(copier_hint=float)
 

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -320,7 +320,7 @@ class TestHasIO(unittest.TestCase):
             msg="Left shift should accommodate groups of connections",
         )
 
-    def test_copy_io(self):
+    def test_move_io(self):
         # Setup
         def _setup(copier_hint=None):
             upstream = Dummy(label="upstream")
@@ -386,7 +386,7 @@ class TestHasIO(unittest.TestCase):
                 msg="The copier is missing all sorts of connected channels and should "
                 "fail to copy",
             ):
-                copier.copy_io(
+                copier.move_io(
                     to_copy, connections_fail_hard=True, values_fail_hard=False
                 )
             self.assertFalse(
@@ -398,7 +398,7 @@ class TestHasIO(unittest.TestCase):
         upstream, to_copy, downstream, copier = _setup()
 
         with self.subTest("Force missing connections"):
-            copier.copy_io(to_copy, connections_fail_hard=False, values_fail_hard=False)
+            copier.move_io(to_copy, connections_fail_hard=False, values_fail_hard=False)
             self.assertIn(
                 copier.signals.output.ran,
                 downstream.signals.input.run,
@@ -419,13 +419,13 @@ class TestHasIO(unittest.TestCase):
                 msg="Can't connect channels with incommensurate type hints",
             ),
         ):
-            copier.copy_io(to_copy, connections_fail_hard=True, values_fail_hard=False)
+            copier.move_io(to_copy, connections_fail_hard=True, values_fail_hard=False)
 
         # Bring the copier's type hint in-line with the object being copied
         upstream, to_copy, downstream, copier = _setup(copier_hint=float)
 
         with self.subTest("Passes missing values"):
-            copier.copy_io(to_copy, connections_fail_hard=True, values_fail_hard=False)
+            copier.move_io(to_copy, connections_fail_hard=True, values_fail_hard=False)
             for inp in copier.inputs:
                 try:
                     self.assertEqual(
@@ -447,7 +447,7 @@ class TestHasIO(unittest.TestCase):
                 "copying, so we should fail",
             ),
         ):
-            copier.copy_io(to_copy, connections_fail_hard=True, values_fail_hard=True)
+            copier.move_io(to_copy, connections_fail_hard=True, values_fail_hard=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In the places where we previously copied connections from one node/panel/channel to another, now they are hard-moved. I.e. the connections are _removed_ from the copyee, and the copyer first disconnects all it's connections then takes on those of the copyee.

Since this functionality is almost never used, this had surprisingly little impact. The main use-case is in-situ replacement, but there its obviously totally fine to have this type of full and hard copy.

This is in preparation for #502 -- in the case that the copyer already had an input connection, or that the copyee already had an output connection, a plain copy would otherwise result in an input somewhere getting two inputs.