### PR TITLE
[WIP] Wrap executorlib executors

### DIFF
--- a/pyiron_workflow/executors/wrapped_executorlib.py
+++ b/pyiron_workflow/executors/wrapped_executorlib.py
@@ -1,0 +1,51 @@
+import inspect
+
+from executorlib import BaseExecutor, SingleNodeExecutor
+
+from pyiron_workflow.mixin import lexical, run
+
+
+class CacheOverride(BaseExecutor):
+    def submit(self, fn, /, *args, **kwargs):
+        """
+        We demand that `fn` be the bound-method `on_run` of a `Lexical`+`Runnable`
+        class (a `Node` is, of course, the intended resolution of this demand).
+        """
+        if (
+            inspect.ismethod(fn)
+            and fn.__name__ == "on_run"
+            and isinstance(fn.__self__, lexical.Lexical)  # provides .as_path
+            and isinstance(fn.__self__, run.Runnable)  # provides .on_run
+        ):
+            cache_key_info = {
+                "cache_key": str(fn.__self__.as_path()),
+                "cache_directory": ".",  # Doesn't matter, the path in the key overrides
+            }
+        else:
+            raise TypeError(
+                f"{self.__name__} is only intended to work with the "
+                f"on_run method of pyiron_workflow.Node objects, but got {fn}"
+            )
+
+        if "resource_dict" in kwargs:
+            if "cache_key" in kwargs["resource_dict"]:
+                raise ValueError(
+                    f"pyiron_workflow needs the freedom to specify the cache, so the "
+                    f'requested "cache_directory" '
+                    f"({kwargs["resource_dict"]["cache_key"]}) would get overwritten."
+                )
+            if "cache_directory" in kwargs["resource_dict"]:
+                raise ValueError(
+                    f"pyiron_workflow needs the freedom to specify the cache, so the "
+                    f'requested "cache_directory" '
+                    f"({kwargs["resource_dict"]["cache_directory"]})would get "
+                    f"overwritten."
+                )
+            kwargs["resource_dict"].update(cache_key_info)
+        else:
+            kwargs["resource_dict"] = cache_key_info
+
+        return super().submit(fn, *args, **kwargs)
+
+
+class CacheSingleNodeExecutor(SingleNodeExecutor, CacheOverride): ...

--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -178,6 +178,8 @@ class Composite(LexicalParent[Node], HasCreator, Node, ABC):
     def _on_run(self):
         if len(self.running_children) > 0:  # Start from a broken process
             for label in self.running_children:
+                if self.children[label]._is_using_wrapped_excutorlib_executor():
+                    self.running_children.remove(label)
                 self.children[label].run()
                 # Running children will find serialized result and proceed,
                 # or raise an error because they're already running


### PR DESCRIPTION
To exploit the new caching interface provided in `executorlib-1.5.0` so that nodes can rely on their running state and lexical path to access previously executed results.

Locally with the `SingleNodeExecutor` everything is looking good, but that doesn't natively support terminating the process that submit the job. I'd like to play around with this using the `SlurmClusterExecutor` on the cluster before making further changes.