### PR TITLE
Remove `Lexical.parent_type`

### DIFF
--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -320,12 +320,6 @@ class Node(
             **kwargs,
         )
 
-    @classmethod
-    def parent_type(cls) -> type[Composite]:
-        from pyiron_workflow.nodes.composite import Composite  # noqa: PLC0415
-
-        return Composite
-
     def _setup_node(self) -> None:
         """
         Called _before_ :meth:`Node.__init__` finishes.

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -189,9 +189,7 @@ class TestWorkflow(unittest.TestCase):
             ):
                 wf.executor = exe
                 wf().result()  # Run it with the executor and wait for it to finish
-                self.assertDictEqual(
-                    reference_output, wf.outputs.to_value_dict()
-                )
+                self.assertDictEqual(reference_output, wf.outputs.to_value_dict())
                 self.assertFalse(
                     wf.running,
                     msg="The workflow should stop. For thread pool this required a "

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -188,8 +188,9 @@ class TestWorkflow(unittest.TestCase):
                 exe_cls() as exe,
             ):
                 wf.executor = exe
+                wf().result()  # Run it with the executor and wait for it to finish
                 self.assertDictEqual(
-                    reference_output, wf().result().outputs.to_value_dict()
+                    reference_output, wf.outputs.to_value_dict()
                 )
                 self.assertFalse(
                     wf.running,

--- a/tests/unit/mixin/test_lexical.py
+++ b/tests/unit/mixin/test_lexical.py
@@ -10,10 +10,7 @@ from pyiron_workflow.mixin.lexical import (
 )
 
 
-class ConcreteLexical(Lexical["ConcreteParent"]):
-    @classmethod
-    def parent_type(cls) -> type[ConcreteLexicalParent]:
-        return ConcreteLexicalParent
+class ConcreteLexical(Lexical["ConcreteParent"]): ...
 
 
 class ConcreteParent(LexicalParent[ConcreteLexical]):

--- a/tests/unit/nodes/test_macro.py
+++ b/tests/unit/nodes/test_macro.py
@@ -239,15 +239,11 @@ class TestMacro(unittest.TestCase):
         returned_nodes = result.result(timeout=120)  # Wait for the process to finish
         sleep(1)
         self.assertFalse(macro.running, msg="Macro should be done running")
-        self.assertIsNot(
-            original_one,
-            returned_nodes.one,
-            msg="Executing in a parallel process should be returning new instances",
-        )
-        self.assertIs(
-            returned_nodes.one,
-            macro.one,
-            msg="Returned nodes should be taken as children",
+        self.assertEqual(
+            len(returned_nodes),
+            0,
+            msg="The returned macro gets its children taken from it and given to the "
+            "parent process macro",
         )
         self.assertIs(
             macro,
@@ -256,6 +252,11 @@ class TestMacro(unittest.TestCase):
             # Once upon a time there was some evidence that this test was failing
             # stochastically, but I just ran the whole test suite 6 times and this test
             # 8 times and it always passed fine, so maybe the issue is resolved...
+        )
+        self.assertIsNot(
+            original_one,
+            macro.one,
+            msg="Executing in a parallel process should be returning new instances",
         )
         self.assertIsNone(
             original_one.parent,

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -188,10 +188,10 @@ class TestWorkflow(unittest.TestCase):
             result, Future, msg="Should be running as a parallel process"
         )
 
-        returned_nodes = result.result(timeout=120)  # Wait for the process to finish
+        _ = result.result(timeout=120)  # Wait for the process to finish
         self.assertIsNot(
             original_a,
-            returned_nodes.a,
+            wf.a,
             msg="Executing in a parallel process should be returning new instances",
         )
         self.assertIs(


### PR DESCRIPTION
Lexical is still generic on the type hint, but only for type hinting not on the actual parent class object. We accomplish this by shifting the entire responsibility of typing/cylcicity/parentage over to the parent -- so LexicalParent still needs to explicitly know its child type, but this way it's a unidirectional dependency and we can get rid of the local import of `Composite` inside `Node`.

Closes #680 