### PR TITLE
Let `Lexical` objects clean their associated path

### DIFF
--- a/pyiron_workflow/mixin/lexical.py
+++ b/pyiron_workflow/mixin/lexical.py
@@ -163,12 +163,21 @@ class Lexical(UsesState, HasLabel, Generic[ParentType], ABC):
         Unless :param:`remove_files` is True, this will only remove empty directories.
         If non-lexical directories are present, they will always block removal.
 
+        If this object is itself a lexical parent, it will run cleaning recursively on
+        its children.
+
         Args:
             root: Base path from which to resolve the lexical path.
             clean_parents: If True, also attempt to remove parent directories.
             remove_files: If True, delete files within the directory before removal.
         """
         directory = self.as_path(root)
+
+        if isinstance(self, LexicalParent):
+            for child in self.children.values():
+                child.clean_path(
+                    root=root, clean_parents=False, remove_files=remove_files
+                )
 
         if remove_files and directory.is_dir():
             for item in directory.iterdir():

--- a/tests/unit/mixin/test_lexical.py
+++ b/tests/unit/mixin/test_lexical.py
@@ -22,18 +22,7 @@ class ConcreteParent(LexicalParent[ConcreteLexical]):
         return ConcreteLexical
 
 
-class ConcreteLexicalParent(ConcreteParent, ConcreteLexical):
-    def clean_path(
-        self,
-        root: Path | str | None = None,
-        clean_parents: bool = True,
-        remove_files: bool = False,
-    ) -> None:
-        for child in self.children.values():
-            child.clean_path(root=root, clean_parents=False, remove_files=remove_files)
-        super().clean_path(
-            root=root, clean_parents=clean_parents, remove_files=remove_files
-        )
+class ConcreteLexicalParent(ConcreteParent, ConcreteLexical): ...
 
 
 class TestLexical(unittest.TestCase):


### PR DESCRIPTION
Recursively if they are also themselves a lexical parent.

This is particularly handy for cleaning up file trees if lexical objects leveraged their `.as_path` feature to populate the file system (as nodes do).