### PR TITLE
Prevent parent/detatched path conflict

### DIFF
--- a/pyiron_workflow/nodes/composite.py
+++ b/pyiron_workflow/nodes/composite.py
@@ -299,6 +299,7 @@ class Composite(LexicalParent[Node], HasCreator, Node, ABC):
         state = other_self.__getstate__()
         state.pop("_executor")  # Got overridden to None for __getstate__, so keep local
         state.pop("_parent")  # Got overridden to None for __getstate__, so keep local
+        state.pop("_detached_parent_path")
         return state
 
     def disconnect_run(self) -> list[tuple[InputSignal, OutputSignal]]:

--- a/tests/integration/test_executors.py
+++ b/tests/integration/test_executors.py
@@ -1,0 +1,40 @@
+import unittest
+from concurrent import futures
+
+import pyiron_workflow as pwf
+from pyiron_workflow import _tests
+
+_tests.ensure_tests_in_python_path()
+from static import demo_nodes  # noqa: E402
+
+
+class TestNestingExecutors(unittest.TestCase):
+    def test_executors_at_depth(self):
+        def build_wf():
+            wf = pwf.Workflow("exec")
+            wf.six = demo_nodes.AddSix(0)
+            return wf
+
+        expected = {"six__add_six": 6}
+
+        with self.subTest("parent"):
+            wf = build_wf()
+            wf.executor = (futures.ProcessPoolExecutor, (), {})
+            future = wf.run()
+            future.result()
+            self.assertDictEqual(expected, wf.outputs.to_value_dict())
+
+        with self.subTest("child"):
+            wf = build_wf()
+            wf.six.executor = (futures.ProcessPoolExecutor, (), {})
+            self.assertDictEqual(expected, wf.run())
+
+        with self.subTest("grandchild"):
+            wf = build_wf()
+            wf.six.a.executor = (futures.ProcessPoolExecutor, (), {})
+            self.assertDictEqual(expected, wf.run())
+
+        with self.subTest("function"):
+            wf = build_wf()
+            wf.six.a.two.executor = (futures.ProcessPoolExecutor, (), {})
+            self.assertDictEqual(expected, wf.run())

--- a/tests/static/demo_nodes.py
+++ b/tests/static/demo_nodes.py
@@ -19,6 +19,13 @@ def AddThree(self, x: int) -> int:
     return self.three
 
 
+@Workflow.wrap.as_macro_node("add_six")
+def AddSix(self, x: int) -> int:
+    self.a = AddThree(x)
+    self.b = AddThree(self.a)
+    return self.b
+
+
 @Workflow.wrap.as_function_node("add")
 def AddPlusOne(obj, other):
     """The same IO labels as `standard.Add`, but with type hints and a boost."""


### PR DESCRIPTION
For macros with executors. Closes https://github.com/pyiron/pyiron_workflow/issues/710