### PR TITLE
Let threadpools be

### DIFF
--- a/tests/cluster/slurm_test.py
+++ b/tests/cluster/slurm_test.py
@@ -69,7 +69,6 @@ def interruption():
     print("loading at time", time.time())
     wf = pwf.Workflow("slurm_test")
     state_check(wf, True, True)
-    wf.executor = None  # https://github.com/pyiron/pyiron_workflow/issues/705
     wf.running = False  # https://github.com/pyiron/pyiron_workflow/issues/706
     print("re-running")
     out = wf.run_in_thread()
@@ -85,7 +84,6 @@ def discovery():
     print("loading at time", time.time())
     wf = pwf.Workflow("slurm_test")
     state_check(wf, True, True)
-    wf.executor = None  # https://github.com/pyiron/pyiron_workflow/issues/705
     wf.running = False  # https://github.com/pyiron/pyiron_workflow/issues/706
     print("sleeping", t_overhead + t_sleep)
     time.sleep(t_overhead + t_sleep)


### PR DESCRIPTION
If you try to `Workflow.run_in_thread` and the executor is _already_ a `ThreadPoolExecutor` or instructions for one, just let it be and don't `None` it when you're done.

This is useful if you started a workflow in threaded mode, saved it, and reloaded it later -- we can `run_in_thread` again without any headaches. 

Closes #705 

There is some possibility for implicit complication where a user is expecting a simple thread pool executor and accidentally gets another one that had setting set (e.g. `max_workers > 1`), but I struggle to imagine how this will be particularly harmful, and it is easy enough to just set your executor back to `wf.workflow = None` before calling `wf.run_in_thread()` again.