### PR TITLE
Add a flag to rerun

### DIFF
--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -1208,8 +1208,7 @@
     "reloaded.stringify = Workflow.create.std.String(reloaded.some_number)\n",
     "reloaded.addition = reloaded.stringify + reloaded.some_string\n",
     "\n",
-    "reloaded.failed = False  # Re-set the status to be ready to run again\n",
-    "reloaded()"
+    "reloaded.run(rerun=True)  # Re-set the status with `rerun` to be ready to run again"
    ],
    "outputs": [
     {

--- a/pyiron_workflow/mixin/run.py
+++ b/pyiron_workflow/mixin/run.py
@@ -144,6 +144,7 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
         self,
         check_readiness: bool = True,
         raise_run_exceptions: bool = True,
+        rerun: bool = False,
         before_run_kwargs: dict | None = None,
         run_kwargs: dict | None = None,
         run_exception_kwargs: dict | None = None,
@@ -166,7 +167,12 @@ class Runnable(UsesState, HasLabel, HasRun, ABC):
                 :attr:`ready`. (Default is True.)
             raise_run_exceptions (bool): Whether to raise exceptions encountered while
                 :attr:`running`. (Default is True.)
+            rerun (bool): Whether to force-set :attr:`running` and :attr:`failed` to
+                `False` before running. (Default is False.)
         """
+        if rerun:
+            self.running = False
+            self.failed = False
 
         def _none_to_dict(inp: dict | None) -> dict:
             return {} if inp is None else inp

--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -449,6 +449,7 @@ class Node(
         fetch_input: bool = True,
         check_readiness: bool = True,
         raise_run_exceptions: bool = True,
+        rerun: bool = False,
         emit_ran_signal: bool = True,
         **kwargs,
     ):
@@ -482,6 +483,8 @@ class Node(
                 :attr:`ready` to run after fetching new input. (Default is True.)
             raise_run_exceptions (bool): Whether to raise exceptions encountered during
                 the run, or just ignore them. (Default is True, raise them!)
+            rerun (bool): Whether to force-set :attr:`running` and :attr:`failed` to
+                `False` before running. (Default is False.)
             emit_ran_signal (bool): Whether to fire off all the output `ran` signal
                 afterwards. (Default is True.)
             **kwargs: Keyword arguments matching input channel labels; used to update
@@ -520,6 +523,7 @@ class Node(
         return super().run(
             check_readiness=check_readiness,
             raise_run_exceptions=raise_run_exceptions,
+            rerun=rerun,
             before_run_kwargs={
                 "run_data_tree": run_data_tree,
                 "run_parent_trees_too": run_parent_trees_too,
@@ -755,6 +759,7 @@ class Node(
             run_parent_trees_too=False,
             fetch_input=False,
             check_readiness=False,
+            rerun=False,
             emit_ran_signal=False,
             **kwargs,
         )
@@ -778,6 +783,7 @@ class Node(
             run_parent_trees_too=run_parent_trees_too,
             fetch_input=True,
             check_readiness=True,
+            rerun=False,
             emit_ran_signal=False,
             **kwargs,
         )

--- a/pyiron_workflow/workflow.py
+++ b/pyiron_workflow/workflow.py
@@ -372,6 +372,7 @@ class Workflow(Composite):
         self,
         *args,
         check_readiness: bool = True,
+        rerun: bool = False,
         **kwargs,
     ):
         # Note: Workflows may have neither parents nor siblings, so we don't need to
@@ -388,12 +389,13 @@ class Workflow(Composite):
             run_parent_trees_too=False,
             fetch_input=False,
             check_readiness=check_readiness,
+            rerun=rerun,
             emit_ran_signal=False,
             **kwargs,
         )
 
     def run_in_thread(
-        self, *args, check_readiness: bool = True, **kwargs
+        self, *args, check_readiness: bool = True, rerun: bool = False, **kwargs
     ) -> futures.Future | dict[str, Any]:
         executor_is_empty = self.executor is None
         executor_is_threadpool = self._is_interpretable_as_threadpoolexecuctor(
@@ -408,7 +410,7 @@ class Workflow(Composite):
                 f"thread would override this."
             )
 
-        f = self.run(*args, check_readiness=check_readiness, **kwargs)
+        f = self.run(*args, check_readiness=check_readiness, rerun=rerun, **kwargs)
 
         if executor_is_empty:
             if isinstance(f, futures.Future):

--- a/tests/cluster/slurm_test.py
+++ b/tests/cluster/slurm_test.py
@@ -69,9 +69,8 @@ def interruption():
     print("loading at time", time.time())
     wf = pwf.Workflow("slurm_test")
     state_check(wf, True, True)
-    wf.running = False  # https://github.com/pyiron/pyiron_workflow/issues/706
     print("re-running")
-    out = wf.run_in_thread()
+    out = wf.run_in_thread(rerun=True)
     print("run return", out)
     state_check(wf, True, True)
     print("sleeping", t_overhead + t_sleep)
@@ -84,11 +83,10 @@ def discovery():
     print("loading at time", time.time())
     wf = pwf.Workflow("slurm_test")
     state_check(wf, True, True)
-    wf.running = False  # https://github.com/pyiron/pyiron_workflow/issues/706
     print("sleeping", t_overhead + t_sleep)
     time.sleep(t_overhead + t_sleep)
     print("re-running")
-    out = wf.run_in_thread()
+    out = wf.run_in_thread(rerun=True)
     print("run return", out)
     state_check(wf, True, True)
     print("sleeping", t_sleep / 10)

--- a/tests/unit/mixin/test_run.py
+++ b/tests/unit/mixin/test_run.py
@@ -88,6 +88,19 @@ class TestRunnable(unittest.TestCase):
                 "afterwards",
             )
 
+        with self.subTest("Rerun"):
+            runnable.failed = True
+            runnable.running = True
+            self.assertFalse(runnable.ready)
+            result = runnable.run(rerun=True)
+            self.assertEqual(
+                runnable.expected_run_output,
+                result,
+                msg="We should be able to bypass the readiness check with a flag, and "
+                "in this simple case expect to get perfectly normal behaviour "
+                "afterwards",
+            )
+
     def test_failure(self):
         runnable = FailingRunnable()
 


### PR DESCRIPTION
Which simply sets the `running` and `failed` statuses to `False`. This is particularly useful to rerun workflows that were started in a thread and saved (in their running state) and later reloaded, as shown in the slurm test.

Closes #706 