### PR TITLE
Disallow loading into running nodes

### DIFF
--- a/pyiron_workflow/node.py
+++ b/pyiron_workflow/node.py
@@ -966,6 +966,12 @@ class Node(
             FileNotFoundError: when nothing got loaded.
             TypeError: when the saved node has a different class name.
         """
+        if self.running:
+            raise ValueError(
+                "Cannot load a node while it is running. If you are sure loading now "
+                "is the correct thing to do, you can set `self.running=True` where "
+                "`self` is this node object."
+            )
         for selected_backend in available_backends(
             backend=backend, only_requested=only_requested
         ):

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -645,6 +645,27 @@ class TestNode(unittest.TestCase):
                 finally:
                     saves.delete_storage(backend)  # Clean up
 
+    def test_load_running(self):
+        n = ANode(label="to_save", x=42)
+        n.running = True
+        n.save(backend="pickle")
+        reloaded = ANode(label="to_save", autoload="pickle")
+        self.assertTrue(
+            reloaded.running,
+            msg="We should be able to load a node that was saved in the running state.",
+        )
+        self.assertEqual(
+            n.inputs.x.value,
+            reloaded.inputs.x.value,
+            msg="Sanity check that we have loaded the data too",
+        )
+        with self.assertRaises(
+            ValueError,
+            msg="We should not be able to load new data into a currently running "
+            "node",
+        ):
+            reloaded.load()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
QoL improvement to stop you loading over top of an already-running node. Can still be bypassed by manually setting the `running` state back to `False`.