### PR TITLE
Only intra-graph connections

### DIFF
--- a/notebooks/deepdive.ipynb
+++ b/notebooks/deepdive.ipynb
@@ -17,15 +17,15 @@
    "id": "771da684-348b-47e2-ba7c-3c2244e46ba3",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:40.938676Z",
-     "start_time": "2025-06-18T17:46:40.935402Z"
+     "end_time": "2025-08-13T22:35:55.690634Z",
+     "start_time": "2025-08-13T22:35:55.687720Z"
     }
    },
    "source": [
     "import pyiron_workflow as pwf"
    ],
    "outputs": [],
-   "execution_count": 45
+   "execution_count": 81
   },
   {
    "cell_type": "markdown",
@@ -52,8 +52,8 @@
    "id": "557ebcd7-81c0-486f-8362-ccb48243c350",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:40.956537Z",
-     "start_time": "2025-06-18T17:46:40.949927Z"
+     "end_time": "2025-08-13T22:35:55.703965Z",
+     "start_time": "2025-08-13T22:35:55.698619Z"
     }
    },
    "source": [
@@ -74,12 +74,12 @@
        " pyiron_workflow.node.Node]"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 46
+   "execution_count": 82
   },
   {
    "cell_type": "markdown",
@@ -98,8 +98,8 @@
    "id": "6fe33fae-e481-41e6-b1ce-fe813963ff76",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:40.984183Z",
-     "start_time": "2025-06-18T17:46:40.980715Z"
+     "end_time": "2025-08-13T22:35:55.718367Z",
+     "start_time": "2025-08-13T22:35:55.714796Z"
     }
    },
    "source": [
@@ -112,12 +112,12 @@
        "{'inputs': {'x': (int, 42)}, 'outputs': {'plus': int, 'minus': int}}"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 83,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 47
+   "execution_count": 83
   },
   {
    "cell_type": "markdown",
@@ -132,8 +132,8 @@
    "id": "3fc470e0-971b-4434-82ac-1047be75f2e7",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.010382Z",
-     "start_time": "2025-06-18T17:46:41.007909Z"
+     "end_time": "2025-08-13T22:35:55.737445Z",
+     "start_time": "2025-08-13T22:35:55.734334Z"
     }
    },
    "source": [
@@ -148,12 +148,12 @@
        "(2, 0)"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 48
+   "execution_count": 84
   },
   {
    "cell_type": "markdown",
@@ -168,8 +168,8 @@
    "id": "5aa2ec8d-971b-4827-8d4e-55c70fd8b7fe",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.032470Z",
-     "start_time": "2025-06-18T17:46:41.030402Z"
+     "end_time": "2025-08-13T22:35:55.769498Z",
+     "start_time": "2025-08-13T22:35:55.767403Z"
     }
    },
    "source": [
@@ -182,12 +182,12 @@
        "(101, 99)"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 49
+   "execution_count": 85
   },
   {
    "cell_type": "markdown",
@@ -204,8 +204,8 @@
    "id": "53e846a5-fa08-4357-a030-b194116d5451",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.068505Z",
-     "start_time": "2025-06-18T17:46:41.065271Z"
+     "end_time": "2025-08-13T22:35:55.798091Z",
+     "start_time": "2025-08-13T22:35:55.794763Z"
     }
    },
    "source": [
@@ -227,12 +227,12 @@
        " pyiron_workflow.node.Node]"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 86,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 50
+   "execution_count": 86
   },
   {
    "cell_type": "markdown",
@@ -247,15 +247,15 @@
    "id": "6d054c43-b2df-4be0-b13e-3791718008a5",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.093094Z",
-     "start_time": "2025-06-18T17:46:41.091516Z"
+     "end_time": "2025-08-13T22:35:55.813648Z",
+     "start_time": "2025-08-13T22:35:55.812080Z"
     }
    },
    "source": [
     "assert(my_function_instance.__class__.mro()[1:] == MyFunctionClass.mro()[1:])"
    ],
    "outputs": [],
-   "execution_count": 51
+   "execution_count": 87
   },
   {
    "cell_type": "markdown",
@@ -280,8 +280,8 @@
    "id": "fbba0959-3a9b-4502-9455-664185886945",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.109944Z",
-     "start_time": "2025-06-18T17:46:41.106645Z"
+     "end_time": "2025-08-13T22:35:55.845874Z",
+     "start_time": "2025-08-13T22:35:55.841440Z"
     }
    },
    "source": [
@@ -317,7 +317,7 @@
      ]
     }
    ],
-   "execution_count": 52
+   "execution_count": 88
   },
   {
    "cell_type": "markdown",
@@ -342,8 +342,8 @@
    "id": "d778740d-03e3-41d2-b5f8-0c2b254d0f8c",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.148998Z",
-     "start_time": "2025-06-18T17:46:41.147233Z"
+     "end_time": "2025-08-13T22:35:55.883242Z",
+     "start_time": "2025-08-13T22:35:55.881089Z"
     }
    },
    "source": [
@@ -364,15 +364,15 @@
     "        return False"
    ],
    "outputs": [],
-   "execution_count": 53
+   "execution_count": 89
   },
   {
    "cell_type": "code",
    "id": "8718f00c-3172-41fe-8266-37012ed47ca6",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.176399Z",
-     "start_time": "2025-06-18T17:46:41.174232Z"
+     "end_time": "2025-08-13T22:35:55.892961Z",
+     "start_time": "2025-08-13T22:35:55.891022Z"
     }
    },
    "source": [
@@ -393,15 +393,15 @@
      ]
     }
    ],
-   "execution_count": 54
+   "execution_count": 90
   },
   {
    "cell_type": "code",
    "id": "45d2607a-7bf7-4687-803a-cf19c2784087",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.197424Z",
-     "start_time": "2025-06-18T17:46:41.195748Z"
+     "end_time": "2025-08-13T22:35:55.908805Z",
+     "start_time": "2025-08-13T22:35:55.907130Z"
     }
    },
    "source": [
@@ -412,7 +412,7 @@
     "JustMakeItGo.__name__ = \"JustMakeItGo\"  "
    ],
    "outputs": [],
-   "execution_count": 55
+   "execution_count": 91
   },
   {
    "cell_type": "markdown",
@@ -427,8 +427,8 @@
    "id": "dfc9a84a-bb69-4b24-8c15-6a1de96266b8",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.219602Z",
-     "start_time": "2025-06-18T17:46:41.217955Z"
+     "end_time": "2025-08-13T22:35:55.918539Z",
+     "start_time": "2025-08-13T22:35:55.916967Z"
     }
    },
    "source": [
@@ -437,7 +437,7 @@
     "assert(ReimportedJMIG is JustMakeItGo)"
    ],
    "outputs": [],
-   "execution_count": 56
+   "execution_count": 92
   },
   {
    "cell_type": "markdown",
@@ -452,8 +452,8 @@
    "id": "5850b5ee-eb93-475c-805b-28924723e828",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.235813Z",
-     "start_time": "2025-06-18T17:46:41.233901Z"
+     "end_time": "2025-08-13T22:35:55.925252Z",
+     "start_time": "2025-08-13T22:35:55.923555Z"
     }
    },
    "source": [
@@ -461,7 +461,7 @@
     "assert(jmig(5))"
    ],
    "outputs": [],
-   "execution_count": 57
+   "execution_count": 93
   },
   {
    "cell_type": "markdown",
@@ -484,10 +484,13 @@
    ]
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-13T22:35:55.934776Z",
+     "start_time": "2025-08-13T22:35:55.931160Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "@pwf.as_function_node\n",
     "def TimesTwo(x: int) -> int:\n",
@@ -501,7 +504,9 @@
     "    self.eight = TimesTwo(self.four)\n",
     "    return self.eight"
    ],
-   "id": "7e46773333ae06a3"
+   "id": "7e46773333ae06a3",
+   "outputs": [],
+   "execution_count": 94
   },
   {
    "metadata": {},
@@ -514,10 +519,13 @@
    "id": "10cd844ecaaf149f"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-13T22:35:55.945083Z",
+     "start_time": "2025-08-13T22:35:55.940166Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "from pyiron_workflow.channels import ChannelConnectionError\n",
     "\n",
@@ -528,9 +536,19 @@
     "try:\n",
     "    wf.non_child.inputs.x = wf.macro.four.outputs.twox\n",
     "except ChannelConnectionError as e:\n",
-    "    print(type(e), e)"
+    "    print(e.__class__.__name__, e)"
    ],
-   "id": "786663d25191caf"
+   "id": "786663d25191caf",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ChannelConnectionError Can only connect channels inside the same graph, but /walled_gardens/non_child.x has the owner /walled_gardens/non_child with the parent /walled_gardens and /walled_gardens/macro/four.twox has the owner /walled_gardens/macro/four with the parent /walled_gardens/macro.\n"
+     ]
+    }
+   ],
+   "execution_count": 95
   },
   {
    "metadata": {},
@@ -540,26 +558,43 @@
     "\n",
     "In order to support the syntax of creating connections at instantiation time (potentially before a parent has been assigned), we do allow nodes with _no_ parent to be connected to a node with a parent. In this case, the \"orphan\" node is automatically parented to the same parent as the owner of its connection counterpart.\n",
     "\n",
-    "This is wonderful for workflows, and used during macro instantiation, but has a nasty side effect that you can accidentally extend the body of a macro:"
+    "This is wonderful for workflows, and used during macro instantiation, but has a nasty side effect that you can accidentally extend the body of a macro. Since this doesn't impact the execution topology, which is computed at instantiation-time, these just sit there uselessly:"
    ],
    "id": "d58e3c2f65846503"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-13T22:35:55.958940Z",
+     "start_time": "2025-08-13T22:35:55.952791Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "wf = pwf.Workflow(\"sneaky_extenson\")\n",
-    "non_child = TimesTwo()\n",
+    "non_child = TimesTwo(label=\"non_child\")\n",
     "wf.macro = TwoCubed(2)\n",
     "\n",
     "non_child.inputs.x = wf.macro.four.outputs.twox\n",
     "\n",
     "assert(non_child.parent is wf.macro)\n",
-    "wf()"
+    "wf()\n",
+    "wf.outputs.to_value_dict(), wf.macro.non_child.outputs.to_value_dict()"
    ],
-   "id": "50c072fd7c203577"
+   "id": "50c072fd7c203577",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "({'macro__eight': 16}, {'twox': NOT_DATA})"
+      ]
+     },
+     "execution_count": 96,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 96
   },
   {
    "metadata": {},
@@ -574,10 +609,13 @@
    "id": "9eaa8c66d0a4dbc"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-13T22:35:55.972768Z",
+     "start_time": "2025-08-13T22:35:55.970692Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "assert(wf.macro.inputs.x is not wf.macro.two.inputs.x)\n",
     "assert(wf.macro.inputs.x.value_receiver is wf.macro.two.inputs.x)\n",
@@ -586,7 +624,18 @@
     "wf.macro.inputs.x.value = 5\n",
     "print(wf.macro.inputs.x.value, wf.macro.two.inputs.x.value)"
    ],
-   "id": "8b5d0438d1cd220b"
+   "id": "8b5d0438d1cd220b",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 2\n",
+      "5 5\n"
+     ]
+    }
+   ],
+   "execution_count": 97
   },
   {
    "metadata": {},
@@ -595,10 +644,13 @@
    "id": "c70ce1cbc1d93f99"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-08-13T22:35:55.989309Z",
+     "start_time": "2025-08-13T22:35:55.987070Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "assert(wf.macro.eight.outputs.twox is not wf.macro.outputs.eight)\n",
     "assert(wf.macro.eight.outputs.twox.value_receiver is wf.macro.outputs.eight)\n",
@@ -607,7 +659,18 @@
     "wf.macro.eight.outputs.twox.value = 5\n",
     "print(wf.macro.eight.outputs.twox.value, wf.macro.outputs.eight.value)"
    ],
-   "id": "a3157658a0635230"
+   "id": "a3157658a0635230",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "16 16\n",
+      "5 5\n"
+     ]
+    }
+   ],
+   "execution_count": 98
   },
   {
    "cell_type": "markdown",
@@ -624,8 +687,8 @@
    "id": "db17a6c1-659c-496e-84bf-6508db1dff14",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.369488Z",
-     "start_time": "2025-06-18T17:46:41.363098Z"
+     "end_time": "2025-08-13T22:35:56.008340Z",
+     "start_time": "2025-08-13T22:35:56.001956Z"
     }
    },
    "source": [
@@ -655,7 +718,7 @@
      ]
     }
    ],
-   "execution_count": 63
+   "execution_count": 99
   },
   {
    "cell_type": "markdown",
@@ -676,8 +739,8 @@
    "id": "b3bac532-7e56-40bb-805b-26dd7fd1d649",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.391634Z",
-     "start_time": "2025-06-18T17:46:41.389807Z"
+     "end_time": "2025-08-13T22:35:56.019470Z",
+     "start_time": "2025-08-13T22:35:56.017480Z"
     }
    },
    "source": [
@@ -696,48 +759,48 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "__getattr__ <function OutputDataWithInjection.__getattr__ at 0x10a70a700>\n",
-      "__getitem__ <function OutputDataWithInjection.__getitem__ at 0x10a70a7a0>\n",
-      "__lt__ <function OutputDataWithInjection.__lt__ at 0x10a70a840>\n",
-      "__le__ <function OutputDataWithInjection.__le__ at 0x10a70a8e0>\n",
-      "eq <function OutputDataWithInjection.eq at 0x10a70a980>\n",
-      "__ne__ <function OutputDataWithInjection.__ne__ at 0x10a70aa20>\n",
-      "__gt__ <function OutputDataWithInjection.__gt__ at 0x10a70aac0>\n",
-      "__ge__ <function OutputDataWithInjection.__ge__ at 0x10a70ab60>\n",
-      "bool <function OutputDataWithInjection.bool at 0x10a70ac00>\n",
-      "len <function OutputDataWithInjection.len at 0x10a70aca0>\n",
-      "contains <function OutputDataWithInjection.contains at 0x10a70ad40>\n",
-      "__add__ <function OutputDataWithInjection.__add__ at 0x10a70ade0>\n",
-      "__sub__ <function OutputDataWithInjection.__sub__ at 0x10a70ae80>\n",
-      "__mul__ <function OutputDataWithInjection.__mul__ at 0x10a70af20>\n",
-      "__rmul__ <function OutputDataWithInjection.__rmul__ at 0x10a70afc0>\n",
-      "__matmul__ <function OutputDataWithInjection.__matmul__ at 0x10a70b060>\n",
-      "__truediv__ <function OutputDataWithInjection.__truediv__ at 0x10a70b100>\n",
-      "__floordiv__ <function OutputDataWithInjection.__floordiv__ at 0x10a70b1a0>\n",
-      "__mod__ <function OutputDataWithInjection.__mod__ at 0x10a70b240>\n",
-      "__pow__ <function OutputDataWithInjection.__pow__ at 0x10a70b2e0>\n",
-      "__and__ <function OutputDataWithInjection.__and__ at 0x10a70b380>\n",
-      "__xor__ <function OutputDataWithInjection.__xor__ at 0x10a70b420>\n",
-      "__or__ <function OutputDataWithInjection.__or__ at 0x10a70b4c0>\n",
-      "__neg__ <function OutputDataWithInjection.__neg__ at 0x10a70b560>\n",
-      "__pos__ <function OutputDataWithInjection.__pos__ at 0x10a70b600>\n",
-      "__abs__ <function OutputDataWithInjection.__abs__ at 0x10a70b6a0>\n",
-      "__invert__ <function OutputDataWithInjection.__invert__ at 0x10a70b740>\n",
-      "int <function OutputDataWithInjection.int at 0x10a70b7e0>\n",
-      "float <function OutputDataWithInjection.float at 0x10a70b880>\n",
-      "__round__ <function OutputDataWithInjection.__round__ at 0x10a70b920>\n"
+      "__getattr__ <function OutputDataWithInjection.__getattr__ at 0x105a3e660>\n",
+      "__getitem__ <function OutputDataWithInjection.__getitem__ at 0x105a3e700>\n",
+      "__lt__ <function OutputDataWithInjection.__lt__ at 0x105a3e7a0>\n",
+      "__le__ <function OutputDataWithInjection.__le__ at 0x105a3e840>\n",
+      "eq <function OutputDataWithInjection.eq at 0x105a3e8e0>\n",
+      "__ne__ <function OutputDataWithInjection.__ne__ at 0x105a3e980>\n",
+      "__gt__ <function OutputDataWithInjection.__gt__ at 0x105a3ea20>\n",
+      "__ge__ <function OutputDataWithInjection.__ge__ at 0x105a3eac0>\n",
+      "bool <function OutputDataWithInjection.bool at 0x105a3eb60>\n",
+      "len <function OutputDataWithInjection.len at 0x105a3ec00>\n",
+      "contains <function OutputDataWithInjection.contains at 0x105a3eca0>\n",
+      "__add__ <function OutputDataWithInjection.__add__ at 0x105a3ed40>\n",
+      "__sub__ <function OutputDataWithInjection.__sub__ at 0x105a3ede0>\n",
+      "__mul__ <function OutputDataWithInjection.__mul__ at 0x105a3ee80>\n",
+      "__rmul__ <function OutputDataWithInjection.__rmul__ at 0x105a3ef20>\n",
+      "__matmul__ <function OutputDataWithInjection.__matmul__ at 0x105a3efc0>\n",
+      "__truediv__ <function OutputDataWithInjection.__truediv__ at 0x105a3f060>\n",
+      "__floordiv__ <function OutputDataWithInjection.__floordiv__ at 0x105a3f100>\n",
+      "__mod__ <function OutputDataWithInjection.__mod__ at 0x105a3f1a0>\n",
+      "__pow__ <function OutputDataWithInjection.__pow__ at 0x105a3f240>\n",
+      "__and__ <function OutputDataWithInjection.__and__ at 0x105a3f2e0>\n",
+      "__xor__ <function OutputDataWithInjection.__xor__ at 0x105a3f380>\n",
+      "__or__ <function OutputDataWithInjection.__or__ at 0x105a3f420>\n",
+      "__neg__ <function OutputDataWithInjection.__neg__ at 0x105a3f4c0>\n",
+      "__pos__ <function OutputDataWithInjection.__pos__ at 0x105a3f560>\n",
+      "__abs__ <function OutputDataWithInjection.__abs__ at 0x105a3f600>\n",
+      "__invert__ <function OutputDataWithInjection.__invert__ at 0x105a3f6a0>\n",
+      "int <function OutputDataWithInjection.int at 0x105a3f740>\n",
+      "float <function OutputDataWithInjection.float at 0x105a3f7e0>\n",
+      "__round__ <function OutputDataWithInjection.__round__ at 0x105a3f880>\n"
      ]
     }
    ],
-   "execution_count": 64
+   "execution_count": 100
   },
   {
    "cell_type": "code",
    "id": "8dcc7997-724b-4f96-82fd-d36a35420d67",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.425463Z",
-     "start_time": "2025-06-18T17:46:41.415599Z"
+     "end_time": "2025-08-13T22:35:56.043858Z",
+     "start_time": "2025-08-13T22:35:56.032933Z"
     }
    },
    "source": [
@@ -766,10 +829,10 @@
      "output_type": "stream",
      "text": [
       "fifth_element <GetItem>\n",
-      "injected_Add_6110526772359589225 <Add>\n",
+      "injected_Add_m8031497673720275384 <Add>\n",
       "transformed <Modulo>\n",
       "matches <Equals>\n",
-      "injected_Float_3388954052274814685 <Float>\n"
+      "injected_Float_m8289177187864054581 <Float>\n"
      ]
     },
     {
@@ -778,12 +841,12 @@
        "{'matches': True, 'as_float': 0.0}"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 101,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 65
+   "execution_count": 101
   },
   {
    "cell_type": "markdown",
@@ -812,8 +875,8 @@
    "id": "ae6d7936-3cd1-49e5-893d-1e71a42ced72",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.447420Z",
-     "start_time": "2025-06-18T17:46:41.444368Z"
+     "end_time": "2025-08-13T22:35:56.064167Z",
+     "start_time": "2025-08-13T22:35:56.060892Z"
     }
    },
    "source": [
@@ -846,12 +909,12 @@
        " 'outputs': {'dataclass': __main__.Coupe.dataclass}}"
       ]
      },
-     "execution_count": 66,
+     "execution_count": 102,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 66
+   "execution_count": 102
   },
   {
    "cell_type": "markdown",
@@ -866,8 +929,8 @@
    "id": "70c0a299-90b9-477b-b156-834268858a09",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.487895Z",
-     "start_time": "2025-06-18T17:46:41.479290Z"
+     "end_time": "2025-08-13T22:35:56.106495Z",
+     "start_time": "2025-08-13T22:35:56.078408Z"
     }
    },
    "source": [
@@ -901,12 +964,12 @@
        "{'ticket__ticket': 130, 'red_ticket__ticket': 180}"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 103,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 67
+   "execution_count": 103
   },
   {
    "cell_type": "markdown",
@@ -923,8 +986,8 @@
    "id": "0975cb7b-ac3a-48d5-88e6-fbfd672d98b7",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.523275Z",
-     "start_time": "2025-06-18T17:46:41.519529Z"
+     "end_time": "2025-08-13T22:35:56.125092Z",
+     "start_time": "2025-08-13T22:35:56.117765Z"
     }
    },
    "source": [
@@ -945,7 +1008,7 @@
      ]
     }
    ],
-   "execution_count": 68
+   "execution_count": 104
   },
   {
    "cell_type": "markdown",
@@ -960,8 +1023,8 @@
    "id": "ed77ecdf-c673-44ea-aa4b-8aa02822f994",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.551619Z",
-     "start_time": "2025-06-18T17:46:41.549413Z"
+     "end_time": "2025-08-13T22:35:56.166748Z",
+     "start_time": "2025-08-13T22:35:56.156033Z"
     }
    },
    "source": [
@@ -972,7 +1035,7 @@
     "repainted.inputs.car = \"a_string_not_a_Car\""
    ],
    "outputs": [],
-   "execution_count": 69
+   "execution_count": 105
   },
   {
    "cell_type": "markdown",
@@ -987,8 +1050,8 @@
    "id": "869cca6f-a4d2-4a83-87f4-1a1bc0a0161a",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.572110Z",
-     "start_time": "2025-06-18T17:46:41.569739Z"
+     "end_time": "2025-08-13T22:35:56.192557Z",
+     "start_time": "2025-08-13T22:35:56.181791Z"
     }
    },
    "source": [
@@ -1007,7 +1070,7 @@
      ]
     }
    ],
-   "execution_count": 70
+   "execution_count": 106
   },
   {
    "cell_type": "markdown",
@@ -1026,8 +1089,8 @@
    "id": "2176aa21-93e8-441a-996d-d7de308f1e15",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.608244Z",
-     "start_time": "2025-06-18T17:46:41.603467Z"
+     "end_time": "2025-08-13T22:35:56.263959Z",
+     "start_time": "2025-08-13T22:35:56.223777Z"
     }
    },
    "source": [
@@ -1096,20 +1159,20 @@
        "</div>"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 107,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 71
+   "execution_count": 107
   },
   {
    "cell_type": "code",
    "id": "d4e384e4-02a7-442e-83db-dbe8bb2d56d8",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.672843Z",
-     "start_time": "2025-06-18T17:46:41.668639Z"
+     "end_time": "2025-08-13T22:35:56.281733Z",
+     "start_time": "2025-08-13T22:35:56.276958Z"
     }
    },
    "source": [
@@ -1127,7 +1190,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'inputs': {'x': (None, NOT_DATA), 'y': (<class 'int'>, 42)}, 'outputs': {'dict': <class 'dict'>}}\n"
+      "{'inputs': {'x': (None, NOT_DATA), 'y': (<class 'int'>, 42)}, 'outputs': {'dict': dict[str, typing.Any]}}\n"
      ]
     },
     {
@@ -1136,20 +1199,20 @@
        "{'x': 'foobar', 'y': 42}"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 108,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 72
+   "execution_count": 108
   },
   {
    "cell_type": "code",
    "id": "27dfa606-6357-471b-9764-598629a401d5",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.746103Z",
-     "start_time": "2025-06-18T17:46:41.743228Z"
+     "end_time": "2025-08-13T22:35:56.324985Z",
+     "start_time": "2025-08-13T22:35:56.322530Z"
     }
    },
    "source": [
@@ -1163,20 +1226,20 @@
        "[1, 2, 3, 'four', 'five']"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 109,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 73
+   "execution_count": 109
   },
   {
    "cell_type": "code",
    "id": "b6aeec11-829d-497f-a86e-c7de057c9247",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.801934Z",
-     "start_time": "2025-06-18T17:46:41.799470Z"
+     "end_time": "2025-08-13T22:35:56.367019Z",
+     "start_time": "2025-08-13T22:35:56.364548Z"
     }
    },
    "source": [
@@ -1190,12 +1253,12 @@
        "{'item_0': 1, 'item_1': 2, 'item_2': 3, 'item_3': 'four', 'item_4': 'five'}"
       ]
      },
-     "execution_count": 74,
+     "execution_count": 110,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 74
+   "execution_count": 110
   },
   {
    "cell_type": "markdown",
@@ -1222,8 +1285,8 @@
    "id": "76081796-532a-49a0-aac1-37872184624a",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.833900Z",
-     "start_time": "2025-06-18T17:46:41.831307Z"
+     "end_time": "2025-08-13T22:35:56.405610Z",
+     "start_time": "2025-08-13T22:35:56.401995Z"
     }
    },
    "source": [
@@ -1233,7 +1296,7 @@
     "assert(wf.inputs.child__user_input is wf.child.inputs.user_input)"
    ],
    "outputs": [],
-   "execution_count": 75
+   "execution_count": 111
   },
   {
    "cell_type": "markdown",
@@ -1248,8 +1311,8 @@
    "id": "5202c396-e0da-418b-be59-cbe877715ad2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.854167Z",
-     "start_time": "2025-06-18T17:46:41.851748Z"
+     "end_time": "2025-08-13T22:35:56.435036Z",
+     "start_time": "2025-08-13T22:35:56.432444Z"
     }
    },
    "source": [
@@ -1265,12 +1328,12 @@
        "{'out': 'some data'}"
       ]
      },
-     "execution_count": 76,
+     "execution_count": 112,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 76
+   "execution_count": 112
   },
   {
    "cell_type": "markdown",
@@ -1287,8 +1350,8 @@
    "id": "139073c2-f4db-477d-9619-d13a9ab6d45c",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.881444Z",
-     "start_time": "2025-06-18T17:46:41.879407Z"
+     "end_time": "2025-08-13T22:35:56.453366Z",
+     "start_time": "2025-08-13T22:35:56.451003Z"
     }
    },
    "source": [
@@ -1302,12 +1365,12 @@
        "('child', 'UserInput')"
       ]
      },
-     "execution_count": 77,
+     "execution_count": 113,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 77
+   "execution_count": 113
   },
   {
    "cell_type": "markdown",
@@ -1324,8 +1387,8 @@
    "id": "50387019-2f3f-4e4b-92da-11a4283b9405",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.911251Z",
-     "start_time": "2025-06-18T17:46:41.909224Z"
+     "end_time": "2025-08-13T22:35:56.464490Z",
+     "start_time": "2025-08-13T22:35:56.462445Z"
     }
    },
    "source": [
@@ -1343,7 +1406,7 @@
      ]
     }
    ],
-   "execution_count": 78
+   "execution_count": 114
   },
   {
    "cell_type": "markdown",
@@ -1358,8 +1421,8 @@
    "id": "eb45a311-ec0a-474f-b17d-3b58ae111b7e",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.942788Z",
-     "start_time": "2025-06-18T17:46:41.940450Z"
+     "end_time": "2025-08-13T22:35:56.477879Z",
+     "start_time": "2025-08-13T22:35:56.475490Z"
     }
    },
    "source": [
@@ -1374,12 +1437,12 @@
        "('child', 'UserInput', 'UserInput0')"
       ]
      },
-     "execution_count": 79,
+     "execution_count": 115,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 79
+   "execution_count": 115
   },
   {
    "cell_type": "markdown",
@@ -1394,8 +1457,8 @@
    "id": "d280ff55-65f1-4a35-adf2-bae284d53fce",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.966023Z",
-     "start_time": "2025-06-18T17:46:41.963989Z"
+     "end_time": "2025-08-13T22:35:56.490529Z",
+     "start_time": "2025-08-13T22:35:56.488687Z"
     }
    },
    "source": [
@@ -1409,12 +1472,12 @@
        "('UserInput', 'UserInput0')"
       ]
      },
-     "execution_count": 80,
+     "execution_count": 116,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 80
+   "execution_count": 116
   },
   {
    "cell_type": "markdown",
@@ -1429,8 +1492,8 @@
    "id": "6d671322-0212-4462-a7eb-2b7e1f870799",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.983457Z",
-     "start_time": "2025-06-18T17:46:41.981608Z"
+     "end_time": "2025-08-13T22:35:56.501935Z",
+     "start_time": "2025-08-13T22:35:56.500171Z"
     }
    },
    "source": [
@@ -1444,12 +1507,12 @@
        "('UserInput0',)"
       ]
      },
-     "execution_count": 81,
+     "execution_count": 117,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 81
+   "execution_count": 117
   },
   {
    "cell_type": "markdown",
@@ -1466,8 +1529,8 @@
    "id": "9d2cab07-0e64-495f-accd-338eef3e2822",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.049573Z",
-     "start_time": "2025-06-18T17:46:42.044276Z"
+     "end_time": "2025-08-13T22:35:56.516250Z",
+     "start_time": "2025-08-13T22:35:56.511749Z"
     }
    },
    "source": [
@@ -1482,29 +1545,29 @@
     {
      "data": {
       "text/plain": [
-       "{'object': <pyiron_workflow.workflow.Workflow at 0x15a4ba3f0>,\n",
-       " 'nodes': {'/graph_as_dict/inp': <pyiron_workflow.nodes.standard.UserInput at 0x15a4b9400>,\n",
-       "  '/graph_as_dict/a': <pyiron_workflow.nodes.standard.Add at 0x15a4ba750>,\n",
-       "  '/graph_as_dict/b': <pyiron_workflow.nodes.standard.Add at 0x15a493ef0>,\n",
-       "  '/graph_as_dict/out': <pyiron_workflow.nodes.standard.Multiply at 0x15a491e20>},\n",
+       "{'object': <pyiron_workflow.workflow.Workflow at 0x148b2aff0>,\n",
+       " 'nodes': {'/graph_as_dict/inp': <pyiron_workflow.nodes.standard.UserInput at 0x1483dc8f0>,\n",
+       "  '/graph_as_dict/a': <pyiron_workflow.nodes.standard.Add at 0x148b2b380>,\n",
+       "  '/graph_as_dict/b': <pyiron_workflow.nodes.standard.Add at 0x148a089e0>,\n",
+       "  '/graph_as_dict/out': <pyiron_workflow.nodes.standard.Multiply at 0x148b2b9e0>},\n",
        " 'edges': {'data': {('/graph_as_dict/inp.user_input',\n",
-       "    '/graph_as_dict/b.obj'): (<pyiron_workflow.mixin.injection.OutputDataWithInjection at 0x15a4ba660>,\n",
-       "    <pyiron_workflow.channels.InputData at 0x15a4b9910>),\n",
+       "    '/graph_as_dict/b.obj'): (<pyiron_workflow.mixin.injection.OutputDataWithInjection at 0x148b2b230>,\n",
+       "    <pyiron_workflow.channels.InputData at 0x148b2b7a0>),\n",
        "   ('/graph_as_dict/inp.user_input',\n",
-       "    '/graph_as_dict/a.obj'): (<pyiron_workflow.mixin.injection.OutputDataWithInjection at 0x15a4ba660>, <pyiron_workflow.channels.InputData at 0x15a492780>),\n",
+       "    '/graph_as_dict/a.obj'): (<pyiron_workflow.mixin.injection.OutputDataWithInjection at 0x148b2b230>, <pyiron_workflow.channels.InputData at 0x148954ad0>),\n",
        "   ('/graph_as_dict/a.add',\n",
-       "    '/graph_as_dict/out.obj'): (<pyiron_workflow.mixin.injection.OutputDataWithInjection at 0x15a492a80>, <pyiron_workflow.channels.InputData at 0x15a4bab10>),\n",
+       "    '/graph_as_dict/out.obj'): (<pyiron_workflow.mixin.injection.OutputDataWithInjection at 0x148affef0>, <pyiron_workflow.channels.InputData at 0x148b2b620>),\n",
        "   ('/graph_as_dict/b.add',\n",
-       "    '/graph_as_dict/out.other'): (<pyiron_workflow.mixin.injection.OutputDataWithInjection at 0x15a4b9760>, <pyiron_workflow.channels.InputData at 0x15a4baed0>)},\n",
+       "    '/graph_as_dict/out.other'): (<pyiron_workflow.mixin.injection.OutputDataWithInjection at 0x148b2b830>, <pyiron_workflow.channels.InputData at 0x148b2bb00>)},\n",
        "  'signal': {}}}"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 118,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 83
+   "execution_count": 118
   },
   {
    "cell_type": "markdown",
@@ -1521,8 +1584,8 @@
    "id": "a1055134-0488-4860-b2c8-e99f79cbdf8a",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.072774Z",
-     "start_time": "2025-06-18T17:46:42.070276Z"
+     "end_time": "2025-08-13T22:35:56.533629Z",
+     "start_time": "2025-08-13T22:35:56.530484Z"
     }
    },
    "source": [
@@ -1542,7 +1605,7 @@
      ]
     }
    ],
-   "execution_count": 84
+   "execution_count": 119
   },
   {
    "cell_type": "markdown",
@@ -1561,13 +1624,13 @@
    "id": "5cba153a-f03d-4449-bdf2-c84862ec45ae",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.098961Z",
-     "start_time": "2025-06-18T17:46:42.096588Z"
+     "end_time": "2025-08-13T22:35:56.548720Z",
+     "start_time": "2025-08-13T22:35:56.546690Z"
     }
    },
    "source": "assert(pwf.std.UserInput().inputs.user_input.value is pwf.api.NOT_DATA)",
    "outputs": [],
-   "execution_count": 85
+   "execution_count": 120
   },
   {
    "cell_type": "markdown",
@@ -1585,8 +1648,8 @@
    "id": "10202174-6543-4ac9-bd9f-3a13c3501842",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.115332Z",
-     "start_time": "2025-06-18T17:46:42.113236Z"
+     "end_time": "2025-08-13T22:35:56.565171Z",
+     "start_time": "2025-08-13T22:35:56.562999Z"
     }
    },
    "source": [
@@ -1610,7 +1673,7 @@
      ]
     }
    ],
-   "execution_count": 86
+   "execution_count": 121
   },
   {
    "metadata": {},
@@ -1621,23 +1684,23 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.133201Z",
-     "start_time": "2025-06-18T17:46:42.131528Z"
+     "end_time": "2025-08-13T22:35:56.588754Z",
+     "start_time": "2025-08-13T22:35:56.587276Z"
     }
    },
    "cell_type": "code",
    "source": "receiver.inputs.user_input = source2",
    "id": "1b5b12054dec7061",
    "outputs": [],
-   "execution_count": 87
+   "execution_count": 122
   },
   {
    "cell_type": "code",
    "id": "4c3f2e88-3a5e-4115-9a36-5d17326c4e7b",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.161861Z",
-     "start_time": "2025-06-18T17:46:42.159804Z"
+     "end_time": "2025-08-13T22:35:56.597434Z",
+     "start_time": "2025-08-13T22:35:56.595483Z"
     }
    },
    "source": [
@@ -1652,25 +1715,25 @@
        "100"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 123,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 88
+   "execution_count": 123
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.195787Z",
-     "start_time": "2025-06-18T17:46:42.194244Z"
+     "end_time": "2025-08-13T22:35:56.614643Z",
+     "start_time": "2025-08-13T22:35:56.612747Z"
     }
    },
    "cell_type": "code",
    "source": "assert(receiver.outputs.user_input.value == source2.outputs.user_input.value)",
    "id": "19de6fcbf6582e5a",
    "outputs": [],
-   "execution_count": 89
+   "execution_count": 124
   },
   {
    "cell_type": "markdown",
@@ -1693,8 +1756,8 @@
    "id": "5a3b01be-6539-4617-98c0-30ef008b394d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.215321Z",
-     "start_time": "2025-06-18T17:46:42.210732Z"
+     "end_time": "2025-08-13T22:35:56.633277Z",
+     "start_time": "2025-08-13T22:35:56.628122Z"
     }
    },
    "source": [
@@ -1718,15 +1781,15 @@
     {
      "data": {
       "text/plain": [
-       "{'always_new__rand': 437, 'cached__rand': 511}"
+       "{'always_new__rand': 458, 'cached__rand': 890}"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 125,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 90
+   "execution_count": 125
   },
   {
    "cell_type": "markdown",
@@ -1741,8 +1804,8 @@
    "id": "3bf5d930-901b-4067-be74-b82847bc82fd",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.231235Z",
-     "start_time": "2025-06-18T17:46:42.228935Z"
+     "end_time": "2025-08-13T22:35:56.647457Z",
+     "start_time": "2025-08-13T22:35:56.644877Z"
     }
    },
    "source": [
@@ -1752,15 +1815,15 @@
     {
      "data": {
       "text/plain": [
-       "{'always_new__rand': 128, 'cached__rand': 511}"
+       "{'always_new__rand': 755, 'cached__rand': 890}"
       ]
      },
-     "execution_count": 91,
+     "execution_count": 126,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 91
+   "execution_count": 126
   },
   {
    "cell_type": "markdown",
@@ -1775,8 +1838,8 @@
    "id": "60adbd5e-94d9-44fd-847c-ebc4b9b3ad2c",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.251145Z",
-     "start_time": "2025-06-18T17:46:42.249257Z"
+     "end_time": "2025-08-13T22:35:56.658024Z",
+     "start_time": "2025-08-13T22:35:56.656398Z"
     }
    },
    "source": [
@@ -1793,7 +1856,7 @@
      ]
     }
    ],
-   "execution_count": 92
+   "execution_count": 127
   },
   {
    "metadata": {},
@@ -1818,15 +1881,15 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-07-19T00:46:50.162923Z",
-     "start_time": "2025-07-19T00:46:49.547844Z"
+     "end_time": "2025-08-13T22:35:56.671250Z",
+     "start_time": "2025-08-13T22:35:56.669712Z"
     }
    },
    "cell_type": "code",
    "source": "from pyiron_workflow import NodeSlurmExecutor",
    "id": "d58d9672eeadca2f",
    "outputs": [],
-   "execution_count": 1
+   "execution_count": 128
   },
   {
    "metadata": {},
@@ -1851,8 +1914,8 @@
    "id": "fe539e8c-c7e0-4b93-b734-93f1c417f5d9",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.277492Z",
-     "start_time": "2025-06-18T17:46:42.270788Z"
+     "end_time": "2025-08-13T22:35:56.690514Z",
+     "start_time": "2025-08-13T22:35:56.683965Z"
     }
    },
    "source": [
@@ -1891,12 +1954,12 @@
        " 'd__collection': ['Alice', 'Bob', 'Chandy', 'Deng']}"
       ]
      },
-     "execution_count": 93,
+     "execution_count": 129,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 93
+   "execution_count": 129
   },
   {
    "cell_type": "markdown",
@@ -1911,8 +1974,8 @@
    "id": "5fa37d8f-867a-4d6e-90ad-e7d9f2b8989f",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.301073Z",
-     "start_time": "2025-06-18T17:46:42.299099Z"
+     "end_time": "2025-08-13T22:35:56.702525Z",
+     "start_time": "2025-08-13T22:35:56.700503Z"
     }
    },
    "source": [
@@ -1925,20 +1988,20 @@
        "{'name': 'Alice', 'collection': ['Alice', 'Bob', 'Chandy', 'Deng']}"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 130,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 94
+   "execution_count": 130
   },
   {
    "cell_type": "code",
    "id": "1ca3009f-e207-4aae-8628-d27a868109d2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.320973Z",
-     "start_time": "2025-06-18T17:46:42.319068Z"
+     "end_time": "2025-08-13T22:35:56.716904Z",
+     "start_time": "2025-08-13T22:35:56.714633Z"
     }
    },
    "source": [
@@ -1952,12 +2015,12 @@
        " 'collection': ['Alice', 'Bob', 'Chandy', 'Deng']}"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 131,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 95
+   "execution_count": 131
   },
   {
    "cell_type": "markdown",
@@ -1980,8 +2043,8 @@
    "id": "954cac45-566e-4135-8b03-6ca2bf337cb2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.344069Z",
-     "start_time": "2025-06-18T17:46:42.342028Z"
+     "end_time": "2025-08-13T22:35:56.747852Z",
+     "start_time": "2025-08-13T22:35:56.745522Z"
     }
    },
    "source": [
@@ -1994,12 +2057,12 @@
        "{'name': 'Alice', 'collection': ['Alice', 'Bob', 'Chandy', 'Deng']}"
       ]
      },
-     "execution_count": 96,
+     "execution_count": 132,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 96
+   "execution_count": 132
   },
   {
    "cell_type": "markdown",
@@ -2014,8 +2077,8 @@
    "id": "ca5e08d3-e3d9-4b6c-99b9-a05521bbaf23",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.367961Z",
-     "start_time": "2025-06-18T17:46:42.364831Z"
+     "end_time": "2025-08-13T22:35:56.814959Z",
+     "start_time": "2025-08-13T22:35:56.811728Z"
     }
    },
    "source": [
@@ -2032,12 +2095,12 @@
        " 'd__collection': ['Alice', 'Bob', 'Chandy', 'Deng']}"
       ]
      },
-     "execution_count": 97,
+     "execution_count": 133,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 97
+   "execution_count": 133
   },
   {
    "cell_type": "markdown",
@@ -2052,8 +2115,8 @@
    "id": "6ce2a6ad-b241-48e8-8303-19f2a64c5a26",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.389028Z",
-     "start_time": "2025-06-18T17:46:42.386116Z"
+     "end_time": "2025-08-13T22:35:56.868844Z",
+     "start_time": "2025-08-13T22:35:56.865140Z"
     }
    },
    "source": [
@@ -2063,21 +2126,38 @@
    ],
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "My name is Alice, and I've collected ['Alice', 'Bob', 'Chandy', 'Deng', 'Alice']\n",
+      "My name is Bob, and I've collected ['Alice', 'Bob', 'Chandy', 'Deng', 'Alice', 'Bob']\n",
+      "My name is Chandy, and I've collected ['Alice', 'Bob', 'Chandy', 'Deng', 'Alice', 'Bob', 'Chandy']\n",
+      "My name is Deng, and I've collected ['Alice', 'Bob', 'Chandy', 'Deng', 'Alice', 'Bob', 'Chandy', 'Deng']\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "{'a__my_name_is': \"My name is Alice, and I've collected ['Alice']\",\n",
-       " 'b__my_name_is': \"My name is Bob, and I've collected ['Alice', 'Bob']\",\n",
-       " 'c__my_name_is': \"My name is Chandy, and I've collected ['Alice', 'Bob', 'Chandy']\",\n",
-       " 'd__my_name_is': \"My name is Deng, and I've collected ['Alice', 'Bob', 'Chandy', 'Deng']\",\n",
-       " 'd__collection': ['Alice', 'Bob', 'Chandy', 'Deng']}"
+       "{'a__my_name_is': \"My name is Alice, and I've collected ['Alice', 'Bob', 'Chandy', 'Deng', 'Alice']\",\n",
+       " 'b__my_name_is': \"My name is Bob, and I've collected ['Alice', 'Bob', 'Chandy', 'Deng', 'Alice', 'Bob']\",\n",
+       " 'c__my_name_is': \"My name is Chandy, and I've collected ['Alice', 'Bob', 'Chandy', 'Deng', 'Alice', 'Bob', 'Chandy']\",\n",
+       " 'd__my_name_is': \"My name is Deng, and I've collected ['Alice', 'Bob', 'Chandy', 'Deng', 'Alice', 'Bob', 'Chandy', 'Deng']\",\n",
+       " 'd__collection': ['Alice',\n",
+       "  'Bob',\n",
+       "  'Chandy',\n",
+       "  'Deng',\n",
+       "  'Alice',\n",
+       "  'Bob',\n",
+       "  'Chandy',\n",
+       "  'Deng']}"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 134,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 98
+   "execution_count": 134
   },
   {
    "cell_type": "markdown",
@@ -2096,13 +2176,13 @@
    "id": "6f15aa9c-c51e-4646-bba4-9debb7840031",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.411703Z",
-     "start_time": "2025-06-18T17:46:42.408506Z"
+     "end_time": "2025-08-13T22:35:56.907964Z",
+     "start_time": "2025-08-13T22:35:56.903595Z"
     }
    },
    "source": "pwf.std.If.emitting_channels??",
    "outputs": [],
-   "execution_count": 99
+   "execution_count": 135
   },
   {
    "cell_type": "markdown",
@@ -2125,8 +2205,8 @@
    "id": "3cec7b96-2ad4-48f8-bd30-ac022ee8a758",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:42.507377Z",
-     "start_time": "2025-06-18T17:46:42.501460Z"
+     "end_time": "2025-08-13T22:35:56.923506Z",
+     "start_time": "2025-08-13T22:35:56.917683Z"
     }
    },
    "source": [
@@ -2169,20 +2249,20 @@
        "{'collecting__z': 'collecting'}"
       ]
      },
-     "execution_count": 100,
+     "execution_count": 136,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 100
+   "execution_count": 136
   },
   {
    "cell_type": "code",
    "id": "d27bb0d5-26ea-4675-8fda-e4ce0b489591",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:43.056795Z",
-     "start_time": "2025-06-18T17:46:42.536065Z"
+     "end_time": "2025-08-13T22:35:57.211953Z",
+     "start_time": "2025-08-13T22:35:56.986419Z"
     }
    },
    "source": [
@@ -2193,15 +2273,15 @@
      "data": {
       "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 12.0.0 (0)\n -->\n<!-- Title: clusterrun_control Pages: 1 -->\n<svg width=\"720pt\" height=\"258pt\"\n viewBox=\"0.00 0.00 720.00 257.77\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(0.51554 0.51554) rotate(0) translate(4 496)\">\n<title>clusterrun_control</title>\n<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-496 1392.59,-496 1392.59,4 -4,4\"/>\n<text text-anchor=\"middle\" x=\"694.3\" y=\"-5.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run_control: Workflow</text>\n<g id=\"clust1\" class=\"cluster\">\n<title>clusterrun_controlInputs</title>\n<defs>\n<linearGradient id=\"clust1_l_0\" gradientUnits=\"userSpaceOnUse\" x1=\"8\" y1=\"-257.5\" x2=\"166.75\" y2=\"-257.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust1_l_0)\" stroke=\"#a5a4a5\" points=\"8,-31 8,-484 166.75,-484 166.75,-31 8,-31\"/>\n<text text-anchor=\"middle\" x=\"87.38\" y=\"-466.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust2\" class=\"cluster\">\n<title>clusterrun_controlOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust2_l_1\" gradientUnits=\"userSpaceOnUse\" x1=\"1383\" y1=\"-176.5\" x2=\"1241\" y2=\"-176.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust2_l_1)\" stroke=\"#a5a4a5\" points=\"1241,-85 1241,-268 1383,-268 1383,-85 1241,-85\"/>\n<text text-anchor=\"middle\" x=\"1312\" y=\"-250.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<g id=\"clust3\" class=\"cluster\">\n<title>clusterrun_controlstart</title>\n<defs>\n<linearGradient id=\"clust3_l_2\" gradientUnits=\"userSpaceOnUse\" x1=\"178.75\" y1=\"-296\" x2=\"523.5\" y2=\"-296\" >\n<stop offset=\"0\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust3_l_2)\" stroke=\"#2ca02c\" stroke-width=\"2\" points=\"178.75,-131 178.75,-461 523.5,-461 523.5,-131 178.75,-131\"/>\n<text text-anchor=\"middle\" x=\"351.13\" y=\"-443.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">start: Verbose</text>\n</g>\n<g id=\"clust4\" class=\"cluster\">\n<title>clusterrun_controlstartInputs</title>\n<defs>\n<linearGradient id=\"clust4_l_3\" gradientUnits=\"userSpaceOnUse\" x1=\"186.75\" y1=\"-284.5\" x2=\"345.5\" y2=\"-284.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust4_l_3)\" stroke=\"#a5a4a5\" points=\"186.75,-139 186.75,-430 345.5,-430 345.5,-139 186.75,-139\"/>\n<text text-anchor=\"middle\" x=\"266.13\" y=\"-412.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust5\" class=\"cluster\">\n<title>clusterrun_controlstartOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust5_l_4\" gradientUnits=\"userSpaceOnUse\" x1=\"515.5\" y1=\"-302.5\" x2=\"373.5\" y2=\"-302.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust5_l_4)\" stroke=\"#a5a4a5\" points=\"373.5,-211 373.5,-394 515.5,-394 515.5,-211 373.5,-211\"/>\n<text text-anchor=\"middle\" x=\"444.5\" y=\"-376.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<g id=\"clust6\" class=\"cluster\">\n<title>clusterrun_controlimmediate</title>\n<defs>\n<linearGradient id=\"clust6_l_5\" gradientUnits=\"userSpaceOnUse\" x1=\"531.5\" y1=\"-206\" x2=\"876.25\" y2=\"-206\" >\n<stop offset=\"0\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust6_l_5)\" stroke=\"#2ca02c\" stroke-width=\"2\" points=\"531.5,-41 531.5,-371 876.25,-371 876.25,-41 531.5,-41\"/>\n<text text-anchor=\"middle\" x=\"703.88\" y=\"-353.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">immediate: Verbose</text>\n</g>\n<g id=\"clust7\" class=\"cluster\">\n<title>clusterrun_controlimmediateInputs</title>\n<defs>\n<linearGradient id=\"clust7_l_6\" gradientUnits=\"userSpaceOnUse\" x1=\"539.5\" y1=\"-194.5\" x2=\"698.25\" y2=\"-194.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust7_l_6)\" stroke=\"#a5a4a5\" points=\"539.5,-49 539.5,-340 698.25,-340 698.25,-49 539.5,-49\"/>\n<text text-anchor=\"middle\" x=\"618.88\" y=\"-322.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust8\" class=\"cluster\">\n<title>clusterrun_controlimmediateOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust8_l_7\" gradientUnits=\"userSpaceOnUse\" x1=\"868.25\" y1=\"-248.5\" x2=\"726.25\" y2=\"-248.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust8_l_7)\" stroke=\"#a5a4a5\" points=\"726.25,-157 726.25,-340 868.25,-340 868.25,-157 726.25,-157\"/>\n<text text-anchor=\"middle\" x=\"797.25\" y=\"-322.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<g id=\"clust9\" class=\"cluster\">\n<title>clusterrun_controlcollecting</title>\n<defs>\n<linearGradient id=\"clust9_l_8\" gradientUnits=\"userSpaceOnUse\" x1=\"884.25\" y1=\"-316\" x2=\"1229\" y2=\"-316\" >\n<stop offset=\"0\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust9_l_8)\" stroke=\"#2ca02c\" stroke-width=\"2\" points=\"884.25,-151 884.25,-481 1229,-481 1229,-151 884.25,-151\"/>\n<text text-anchor=\"middle\" x=\"1056.63\" y=\"-463.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">collecting: Verbose</text>\n</g>\n<g id=\"clust10\" class=\"cluster\">\n<title>clusterrun_controlcollectingInputs</title>\n<defs>\n<linearGradient id=\"clust10_l_9\" gradientUnits=\"userSpaceOnUse\" x1=\"892.25\" y1=\"-304.5\" x2=\"1051\" y2=\"-304.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust10_l_9)\" stroke=\"#a5a4a5\" points=\"892.25,-159 892.25,-450 1051,-450 1051,-159 892.25,-159\"/>\n<text text-anchor=\"middle\" x=\"971.63\" y=\"-432.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust11\" class=\"cluster\">\n<title>clusterrun_controlcollectingOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust11_l_10\" gradientUnits=\"userSpaceOnUse\" x1=\"1221\" y1=\"-250.5\" x2=\"1079\" y2=\"-250.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust11_l_10)\" stroke=\"#a5a4a5\" points=\"1079,-159 1079,-342 1221,-342 1221,-159 1079,-159\"/>\n<text text-anchor=\"middle\" x=\"1150\" y=\"-324.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<!-- clusterrun_controlInputsrun -->\n<g id=\"node1\" class=\"node\">\n<title>clusterrun_controlInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"102.38,-69 60.38,-69 60.38,-45 102.38,-45 114.38,-57 102.38,-69\"/>\n<text text-anchor=\"middle\" x=\"87.38\" y=\"-51.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clusterrun_controlOutputsWithInjectionran -->\n<g id=\"node9\" class=\"node\">\n<title>clusterrun_controlOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1326.5,-123 1284.5,-123 1284.5,-99 1326.5,-99 1338.5,-111 1326.5,-123\"/>\n<text text-anchor=\"middle\" x=\"1311.5\" y=\"-105.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clusterrun_controlInputsrun&#45;&gt;clusterrun_controlOutputsWithInjectionran -->\n<!-- clusterrun_controlInputsaccumulate_and_run -->\n<g id=\"node2\" class=\"node\">\n<title>clusterrun_controlInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"146.75,-123 16,-123 16,-99 146.75,-99 158.75,-111 146.75,-123\"/>\n<text text-anchor=\"middle\" x=\"87.38\" y=\"-105.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clusterrun_controlInputsstart__x -->\n<g id=\"node3\" class=\"node\">\n<title>clusterrun_controlInputsstart__x</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"87.38\" cy=\"-327\" rx=\"41.6\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"87.38\" y=\"-321.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">start__x</text>\n</g>\n<!-- clusterrun_controlstartInputsx -->\n<g id=\"node14\" class=\"node\">\n<title>clusterrun_controlstartInputsx</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"266.13\" cy=\"-327\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"266.13\" y=\"-321.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">x</text>\n</g>\n<!-- clusterrun_controlInputsstart__x&#45;&gt;clusterrun_controlstartInputsx -->\n<g id=\"edge11\" class=\"edge\">\n<title>clusterrun_controlInputsstart__x&#45;&gt;clusterrun_controlstartInputsx</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M129.37,-327C144.2,-327 161.57,-327 178.82,-327\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M178.82,-327C196.08,-327 213.23,-327 227.64,-327\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"227.36,-330.5 237.36,-327 227.36,-323.5 227.36,-330.5\"/>\n</g>\n<!-- clusterrun_controlInputsstart__y -->\n<g id=\"node4\" class=\"node\">\n<title>clusterrun_controlInputsstart__y</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"87.38\" cy=\"-381\" rx=\"41.6\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"87.38\" y=\"-375.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">start__y</text>\n</g>\n<!-- clusterrun_controlstartInputsy -->\n<g id=\"node15\" class=\"node\">\n<title>clusterrun_controlstartInputsy</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"266.13\" cy=\"-381\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"266.13\" y=\"-375.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">y</text>\n</g>\n<!-- clusterrun_controlInputsstart__y&#45;&gt;clusterrun_controlstartInputsy -->\n<g id=\"edge12\" class=\"edge\">\n<title>clusterrun_controlInputsstart__y&#45;&gt;clusterrun_controlstartInputsy</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M129.37,-381C144.2,-381 161.57,-381 178.82,-381\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M178.82,-381C196.08,-381 213.23,-381 227.64,-381\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"227.36,-384.5 237.36,-381 227.36,-377.5 227.36,-384.5\"/>\n</g>\n<!-- clusterrun_controlInputsstart__z -->\n<g id=\"node5\" class=\"node\">\n<title>clusterrun_controlInputsstart__z</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"87.38\" cy=\"-273\" rx=\"41.6\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"87.38\" y=\"-267.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">start__z</text>\n</g>\n<!-- clusterrun_controlstartInputsz -->\n<g id=\"node16\" class=\"node\">\n<title>clusterrun_controlstartInputsz</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"266.13\" cy=\"-273\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"266.13\" y=\"-267.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">z</text>\n</g>\n<!-- clusterrun_controlInputsstart__z&#45;&gt;clusterrun_controlstartInputsz -->\n<g id=\"edge13\" class=\"edge\">\n<title>clusterrun_controlInputsstart__z&#45;&gt;clusterrun_controlstartInputsz</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M129.37,-273C144.2,-273 161.57,-273 178.82,-273\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M178.82,-273C196.08,-273 213.23,-273 227.64,-273\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"227.36,-276.5 237.36,-273 227.36,-269.5 227.36,-276.5\"/>\n</g>\n<!-- clusterrun_controlInputsimmediate__y -->\n<g id=\"node6\" class=\"node\">\n<title>clusterrun_controlInputsimmediate__y</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"87.38\" cy=\"-219\" rx=\"65.97\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"87.38\" y=\"-213.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">immediate__y</text>\n</g>\n<!-- clusterrun_controlimmediateInputsy -->\n<g id=\"node23\" class=\"node\">\n<title>clusterrun_controlimmediateInputsy</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"618.88\" cy=\"-183\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"618.88\" y=\"-177.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">y</text>\n</g>\n<!-- clusterrun_controlInputsimmediate__y&#45;&gt;clusterrun_controlimmediateInputsy -->\n<g id=\"edge14\" class=\"edge\">\n<title>clusterrun_controlInputsimmediate__y&#45;&gt;clusterrun_controlimmediateInputsy</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M142.22,-208.74C151.45,-204.84 160.18,-199.44 166.75,-192 183.88,-172.59 158.65,-151.31 178.75,-135 201.36,-116.65 249.2,-113.41 305.32,-117.94\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M305.32,-117.94C402.07,-125.73 523.42,-156.61 582.41,-172.86\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"581.46,-176.23 592.03,-175.54 583.33,-169.49 581.46,-176.23\"/>\n</g>\n<!-- clusterrun_controlInputsimmediate__z -->\n<g id=\"node7\" class=\"node\">\n<title>clusterrun_controlInputsimmediate__z</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"87.38\" cy=\"-165\" rx=\"65.97\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"87.38\" y=\"-159.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">immediate__z</text>\n</g>\n<!-- clusterrun_controlimmediateInputsz -->\n<g id=\"node24\" class=\"node\">\n<title>clusterrun_controlimmediateInputsz</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"618.88\" cy=\"-75\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"618.88\" y=\"-69.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">z</text>\n</g>\n<!-- clusterrun_controlInputsimmediate__z&#45;&gt;clusterrun_controlimmediateInputsz -->\n<g id=\"edge15\" class=\"edge\">\n<title>clusterrun_controlInputsimmediate__z&#45;&gt;clusterrun_controlimmediateInputsz</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M140.13,-153.81C149.77,-149.98 159.17,-144.85 166.75,-138 176.19,-129.46 168.33,-119.3 178.75,-112 231.34,-75.15 296.65,-58.48 360.69,-52.73\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M360.69,-52.73C449.17,-44.78 535.23,-57.67 581.92,-66.91\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"580.94,-70.28 591.44,-68.87 582.35,-63.43 580.94,-70.28\"/>\n</g>\n<!-- clusterrun_controlInputscollecting__z -->\n<g id=\"node8\" class=\"node\">\n<title>clusterrun_controlInputscollecting__z</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"87.38\" cy=\"-435\" rx=\"61.09\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"87.38\" y=\"-429.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">collecting__z</text>\n</g>\n<!-- clusterrun_controlcollectingInputsz -->\n<g id=\"node32\" class=\"node\">\n<title>clusterrun_controlcollectingInputsz</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"971.63\" cy=\"-401\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"971.63\" y=\"-395.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">z</text>\n</g>\n<!-- clusterrun_controlInputscollecting__z&#45;&gt;clusterrun_controlcollectingInputsz -->\n<g id=\"edge16\" class=\"edge\">\n<title>clusterrun_controlInputscollecting__z&#45;&gt;clusterrun_controlcollectingInputsz</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M138.64,-445.21C207.14,-458.2 333.81,-479 443,-479 443,-479 443,-479 473.64,-479\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M473.64,-479C497.97,-479 541.6,-479 619.88,-479 738.8,-479 875.1,-435.75 936.96,-413.66\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"937.99,-417.01 946.2,-410.31 935.61,-410.43 937.99,-417.01\"/>\n</g>\n<!-- clusterrun_controlOutputsWithInjectionfailed -->\n<g id=\"node10\" class=\"node\">\n<title>clusterrun_controlOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1326.5,-177 1284.5,-177 1284.5,-153 1326.5,-153 1338.5,-165 1326.5,-177\"/>\n<text text-anchor=\"middle\" x=\"1311.5\" y=\"-159.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clusterrun_controlOutputsWithInjectioncollecting__z -->\n<g id=\"node11\" class=\"node\">\n<title>clusterrun_controlOutputsWithInjectioncollecting__z</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"1311.5\" cy=\"-219\" rx=\"61.09\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"1311.5\" y=\"-213.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">collecting__z</text>\n</g>\n<!-- clusterrun_controlstartInputsrun -->\n<g id=\"node12\" class=\"node\">\n<title>clusterrun_controlstartInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"281.13,-177 239.13,-177 239.13,-153 281.13,-153 293.13,-165 281.13,-177\"/>\n<text text-anchor=\"middle\" x=\"266.13\" y=\"-159.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clusterrun_controlstartOutputsWithInjectionran -->\n<g id=\"node17\" class=\"node\">\n<title>clusterrun_controlstartOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"459,-249 417,-249 417,-225 459,-225 471,-237 459,-249\"/>\n<text text-anchor=\"middle\" x=\"444\" y=\"-231.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clusterrun_controlstartInputsrun&#45;&gt;clusterrun_controlstartOutputsWithInjectionran -->\n<!-- clusterrun_controlstartInputsaccumulate_and_run -->\n<g id=\"node13\" class=\"node\">\n<title>clusterrun_controlstartInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"325.5,-231 194.75,-231 194.75,-207 325.5,-207 337.5,-219 325.5,-231\"/>\n<text text-anchor=\"middle\" x=\"266.13\" y=\"-213.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clusterrun_controlimmediateInputsrun -->\n<g id=\"node20\" class=\"node\">\n<title>clusterrun_controlimmediateInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"633.88,-249 591.88,-249 591.88,-225 633.88,-225 645.88,-237 633.88,-249\"/>\n<text text-anchor=\"middle\" x=\"618.88\" y=\"-231.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clusterrun_controlstartOutputsWithInjectionran&#45;&gt;clusterrun_controlimmediateInputsrun -->\n<g id=\"edge5\" class=\"edge\">\n<title>clusterrun_controlstartOutputsWithInjectionran&#45;&gt;clusterrun_controlimmediateInputsrun</title>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M471.26,-237C485.77,-237 504.77,-237 524.27,-237\"/>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M524.27,-237C543.76,-237 563.74,-237 580.21,-237\"/>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"580.14,-240.5 590.14,-237 580.14,-233.5 580.14,-240.5\"/>\n</g>\n<!-- clusterrun_controlcollectingInputsaccumulate_and_run -->\n<g id=\"node29\" class=\"node\">\n<title>clusterrun_controlcollectingInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1031,-251 900.25,-251 900.25,-227 1031,-227 1043,-239 1031,-251\"/>\n<text text-anchor=\"middle\" x=\"971.63\" y=\"-233.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clusterrun_controlstartOutputsWithInjectionran&#45;&gt;clusterrun_controlcollectingInputsaccumulate_and_run -->\n<g id=\"edge6\" class=\"edge\">\n<title>clusterrun_controlstartOutputsWithInjectionran&#45;&gt;clusterrun_controlcollectingInputsaccumulate_and_run</title>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M471.41,-238.92C488.99,-241.68 511.07,-248.29 523.5,-264 534.59,-278.01 518.25,-332.01 531.5,-344 555.96,-366.14 612.74,-378.73 674.02,-381.79\"/>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M674.02,-381.79C755.02,-385.84 843.87,-373.23 876.25,-344 889.18,-332.32 873.23,-279.49 884.25,-266 886.3,-263.49 888.58,-261.21 891.04,-259.14\"/>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"892.59,-262.33 898.78,-253.73 888.58,-256.59 892.59,-262.33\"/>\n</g>\n<!-- clusterrun_controlstartOutputsWithInjectionfailed -->\n<g id=\"node18\" class=\"node\">\n<title>clusterrun_controlstartOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"459,-303 417,-303 417,-279 459,-279 471,-291 459,-303\"/>\n<text text-anchor=\"middle\" x=\"444\" y=\"-285.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clusterrun_controlstartOutputsWithInjectionz -->\n<g id=\"node19\" class=\"node\">\n<title>clusterrun_controlstartOutputsWithInjectionz</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"444\" cy=\"-345\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"444\" y=\"-339.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">z</text>\n</g>\n<!-- clusterrun_controlimmediateInputsx -->\n<g id=\"node22\" class=\"node\">\n<title>clusterrun_controlimmediateInputsx</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"618.88\" cy=\"-291\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"618.88\" y=\"-285.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">x</text>\n</g>\n<!-- clusterrun_controlstartOutputsWithInjectionz&#45;&gt;clusterrun_controlimmediateInputsx -->\n<g id=\"edge7\" class=\"edge\">\n<title>clusterrun_controlstartOutputsWithInjectionz&#45;&gt;clusterrun_controlimmediateInputsx</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M469.04,-337.49C483.83,-332.87 503.85,-326.62 524.4,-320.2\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M524.4,-320.2C544.95,-313.78 566.04,-307.19 582.97,-301.9\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"583.82,-305.31 592.32,-298.98 581.73,-298.62 583.82,-305.31\"/>\n</g>\n<!-- clusterrun_controlcollectingInputsx -->\n<g id=\"node30\" class=\"node\">\n<title>clusterrun_controlcollectingInputsx</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"971.63\" cy=\"-347\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"971.63\" y=\"-341.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">x</text>\n</g>\n<!-- clusterrun_controlstartOutputsWithInjectionz&#45;&gt;clusterrun_controlcollectingInputsx -->\n<g id=\"edge8\" class=\"edge\">\n<title>clusterrun_controlstartOutputsWithInjectionz&#45;&gt;clusterrun_controlcollectingInputsx</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M466.44,-355.37C483.59,-363.05 508.49,-372.88 531.5,-377 605.56,-390.26 653.66,-397.09 701.29,-397.37\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M701.29,-397.37C750.66,-397.66 799.52,-390.91 876.25,-377 879.99,-376.32 880.66,-375.23 884.25,-374 900.99,-368.25 919.72,-362.33 935.45,-357.51\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"936.31,-360.91 944.86,-354.65 934.27,-354.21 936.31,-360.91\"/>\n</g>\n<!-- clusterrun_controlimmediateOutputsWithInjectionran -->\n<g id=\"node25\" class=\"node\">\n<title>clusterrun_controlimmediateOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"811.75,-195 769.75,-195 769.75,-171 811.75,-171 823.75,-183 811.75,-195\"/>\n<text text-anchor=\"middle\" x=\"796.75\" y=\"-177.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clusterrun_controlimmediateInputsrun&#45;&gt;clusterrun_controlimmediateOutputsWithInjectionran -->\n<!-- clusterrun_controlimmediateInputsaccumulate_and_run -->\n<g id=\"node21\" class=\"node\">\n<title>clusterrun_controlimmediateInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"678.25,-141 547.5,-141 547.5,-117 678.25,-117 690.25,-129 678.25,-141\"/>\n<text text-anchor=\"middle\" x=\"618.88\" y=\"-123.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clusterrun_controlimmediateOutputsWithInjectionran&#45;&gt;clusterrun_controlcollectingInputsaccumulate_and_run -->\n<g id=\"edge9\" class=\"edge\">\n<title>clusterrun_controlimmediateOutputsWithInjectionran&#45;&gt;clusterrun_controlcollectingInputsaccumulate_and_run</title>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M824.2,-192.03C835.06,-195.71 848.2,-200.13 861.51,-204.54\"/>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M861.51,-204.54C869.17,-207.08 876.88,-209.61 884.25,-212 889.53,-213.71 895,-215.46 900.51,-217.22\"/>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"899.07,-220.43 909.66,-220.11 901.18,-213.76 899.07,-220.43\"/>\n</g>\n<!-- clusterrun_controlimmediateOutputsWithInjectionfailed -->\n<g id=\"node26\" class=\"node\">\n<title>clusterrun_controlimmediateOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"811.75,-249 769.75,-249 769.75,-225 811.75,-225 823.75,-237 811.75,-249\"/>\n<text text-anchor=\"middle\" x=\"796.75\" y=\"-231.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clusterrun_controlimmediateOutputsWithInjectionz -->\n<g id=\"node27\" class=\"node\">\n<title>clusterrun_controlimmediateOutputsWithInjectionz</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"796.75\" cy=\"-291\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"796.75\" y=\"-285.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">z</text>\n</g>\n<!-- clusterrun_controlcollectingInputsy -->\n<g id=\"node31\" class=\"node\">\n<title>clusterrun_controlcollectingInputsy</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"971.63\" cy=\"-293\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"971.63\" y=\"-287.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">y</text>\n</g>\n<!-- clusterrun_controlimmediateOutputsWithInjectionz&#45;&gt;clusterrun_controlcollectingInputsy -->\n<g id=\"edge10\" class=\"edge\">\n<title>clusterrun_controlimmediateOutputsWithInjectionz&#45;&gt;clusterrun_controlcollectingInputsy</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M824.01,-291.3C838.52,-291.47 857.52,-291.69 877.02,-291.92\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M877.02,-291.92C896.51,-292.14 916.49,-292.37 932.96,-292.56\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"932.85,-296.06 942.89,-292.68 932.93,-289.06 932.85,-296.06\"/>\n</g>\n<!-- clusterrun_controlcollectingInputsrun -->\n<g id=\"node28\" class=\"node\">\n<title>clusterrun_controlcollectingInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"986.63,-197 944.63,-197 944.63,-173 986.63,-173 998.63,-185 986.63,-197\"/>\n<text text-anchor=\"middle\" x=\"971.63\" y=\"-179.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clusterrun_controlcollectingOutputsWithInjectionran -->\n<g id=\"node33\" class=\"node\">\n<title>clusterrun_controlcollectingOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1164.5,-197 1122.5,-197 1122.5,-173 1164.5,-173 1176.5,-185 1164.5,-197\"/>\n<text text-anchor=\"middle\" x=\"1149.5\" y=\"-179.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clusterrun_controlcollectingInputsrun&#45;&gt;clusterrun_controlcollectingOutputsWithInjectionran -->\n<!-- clusterrun_controlcollectingOutputsWithInjectionfailed -->\n<g id=\"node34\" class=\"node\">\n<title>clusterrun_controlcollectingOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1164.5,-251 1122.5,-251 1122.5,-227 1164.5,-227 1176.5,-239 1164.5,-251\"/>\n<text text-anchor=\"middle\" x=\"1149.5\" y=\"-233.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clusterrun_controlcollectingOutputsWithInjectionz -->\n<g id=\"node35\" class=\"node\">\n<title>clusterrun_controlcollectingOutputsWithInjectionz</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"1149.5\" cy=\"-293\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"1149.5\" y=\"-287.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">z</text>\n</g>\n<!-- clusterrun_controlcollectingOutputsWithInjectionz&#45;&gt;clusterrun_controlOutputsWithInjectioncollecting__z -->\n<g id=\"edge17\" class=\"edge\">\n<title>clusterrun_controlcollectingOutputsWithInjectionz&#45;&gt;clusterrun_controlOutputsWithInjectioncollecting__z</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M1174.67,-286.01C1189.65,-281.37 1209.23,-274.76 1226.33,-267.2\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M1226.33,-267.2C1227.23,-266.8 1228.12,-266.4 1229,-266 1244.55,-258.92 1261,-249.78 1275.02,-241.44\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"1276.71,-244.51 1283.45,-236.34 1273.09,-238.52 1276.71,-244.51\"/>\n</g>\n</g>\n</svg>\n",
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x11ff98f80>"
+       "<graphviz.graphs.Digraph at 0x1489ce3c0>"
       ]
      },
-     "execution_count": 101,
+     "execution_count": 137,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 101
+   "execution_count": 137
   },
   {
    "cell_type": "markdown",
@@ -2216,8 +2296,8 @@
    "id": "c52fbef3-ea9b-47db-b179-d9044659cd89",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:43.078360Z",
-     "start_time": "2025-06-18T17:46:43.073021Z"
+     "end_time": "2025-08-13T22:35:57.232184Z",
+     "start_time": "2025-08-13T22:35:57.226838Z"
     }
    },
    "source": [
@@ -2249,12 +2329,12 @@
        "{'collecting__z': 'collecting'}"
       ]
      },
-     "execution_count": 102,
+     "execution_count": 138,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 102
+   "execution_count": 138
   },
   {
    "cell_type": "markdown",
@@ -2271,8 +2351,8 @@
    "id": "e7270eef-8642-4859-982b-b3c35dda968f",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:43.094959Z",
-     "start_time": "2025-06-18T17:46:43.092731Z"
+     "end_time": "2025-08-13T22:35:57.246006Z",
+     "start_time": "2025-08-13T22:35:57.243505Z"
     }
    },
    "source": [
@@ -2285,28 +2365,27 @@
        "{'_label': 'immediate',\n",
        " '_parent': None,\n",
        " '_detached_parent_path': '/sugar',\n",
-       " '_signals': <pyiron_workflow.io.Signals at 0x11ff571d0>,\n",
        " 'running': False,\n",
        " 'failed': False,\n",
-       " 'executor': None,\n",
+       " '_executor': None,\n",
        " 'future': None,\n",
        " '_thread_pool_sleep_time': 1e-06,\n",
+       " '_signals': <pyiron_workflow.io.Signals at 0x148b6d1c0>,\n",
        " 'checkpoint': None,\n",
        " 'recovery': 'pickle',\n",
-       " '_serialize_result': False,\n",
-       " '_do_clean': False,\n",
+       " '_remove_executorlib_cache': True,\n",
        " '_cached_inputs': {'x': 'start', 'y': '', 'z': 'immediate'},\n",
        " '_user_data': {},\n",
-       " '_inputs': <pyiron_workflow.io.Inputs at 0x11ff54ec0>,\n",
-       " '_outputs': <pyiron_workflow.mixin.injection.OutputsWithInjection at 0x11fe1e150>}"
+       " '_inputs': <pyiron_workflow.io.Inputs at 0x148b6f530>,\n",
+       " '_outputs': <pyiron_workflow.mixin.injection.OutputsWithInjection at 0x148b6d430>}"
       ]
      },
-     "execution_count": 103,
+     "execution_count": 139,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 103
+   "execution_count": 139
   },
   {
    "cell_type": "markdown",
@@ -2321,8 +2400,8 @@
    "id": "59cac615-02ee-478e-93a5-e6a8b38c37b3",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:43.110218Z",
-     "start_time": "2025-06-18T17:46:43.108333Z"
+     "end_time": "2025-08-13T22:35:57.261094Z",
+     "start_time": "2025-08-13T22:35:57.259192Z"
     }
    },
    "source": [
@@ -2332,17 +2411,17 @@
     {
      "data": {
       "text/plain": [
-       "{'channel_dict': {'x': <pyiron_workflow.channels.InputData at 0x11ff54410>,\n",
-       "  'y': <pyiron_workflow.channels.InputData at 0x11ff542f0>,\n",
-       "  'z': <pyiron_workflow.channels.InputData at 0x11ff54710>}}"
+       "{'channel_dict': {'x': <pyiron_workflow.channels.InputData at 0x148b6d9d0>,\n",
+       "  'y': <pyiron_workflow.channels.InputData at 0x148b6da30>,\n",
+       "  'z': <pyiron_workflow.channels.InputData at 0x148b6f500>}}"
       ]
      },
-     "execution_count": 104,
+     "execution_count": 140,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 104
+   "execution_count": 140
   },
   {
    "cell_type": "markdown",
@@ -2357,8 +2436,8 @@
    "id": "1642ac22-255c-4e50-9a26-a6d6b0cd203d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:43.131064Z",
-     "start_time": "2025-06-18T17:46:43.129062Z"
+     "end_time": "2025-08-13T22:35:57.276324Z",
+     "start_time": "2025-08-13T22:35:57.274019Z"
     }
    },
    "source": [
@@ -2369,18 +2448,18 @@
     {
      "data": {
       "text/plain": [
-       "(<__main__.Verbose at 0x15a46ccb0>,\n",
+       "(<__main__.Verbose at 0x148b03ad0>,\n",
        " [(('immediate', 'x'), ('start', 'z')),\n",
        "  (('collecting', 'x'), ('start', 'z')),\n",
        "  (('collecting', 'y'), ('immediate', 'z'))])"
       ]
      },
-     "execution_count": 105,
+     "execution_count": 141,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 105
+   "execution_count": 141
   },
   {
    "cell_type": "markdown",
@@ -2407,8 +2486,8 @@
    "id": "2784b0c2-035e-44bb-b790-0d5fe2a84331",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:43.153087Z",
-     "start_time": "2025-06-18T17:46:43.148548Z"
+     "end_time": "2025-08-13T22:35:57.287810Z",
+     "start_time": "2025-08-13T22:35:57.285902Z"
     }
    },
    "source": [
@@ -2416,8 +2495,16 @@
     "\n",
     "Runnable._parse_executor??"
    ],
-   "outputs": [],
-   "execution_count": 106
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Object `Runnable._parse_executor` not found.\n"
+     ]
+    }
+   ],
+   "execution_count": 142
   },
   {
    "cell_type": "markdown",
@@ -2441,8 +2528,8 @@
    "id": "e0916c46-132c-4046-827e-a75fff6dbc5b",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:43.170107Z",
-     "start_time": "2025-06-18T17:46:43.165179Z"
+     "end_time": "2025-08-13T22:35:57.308646Z",
+     "start_time": "2025-08-13T22:35:57.303856Z"
     }
    },
    "source": [
@@ -2464,13 +2551,13 @@
     "wf.xf = wf.add_while.outputs.add  # While output maps to body output"
    ],
    "outputs": [],
-   "execution_count": 107
+   "execution_count": 143
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:43.304381Z",
-     "start_time": "2025-06-18T17:46:43.183022Z"
+     "end_time": "2025-08-13T22:35:57.451223Z",
+     "start_time": "2025-08-13T22:35:57.313806Z"
     }
    },
    "cell_type": "code",
@@ -2481,15 +2568,15 @@
      "data": {
       "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 12.0.0 (0)\n -->\n<!-- Title: clustermy_while_loop Pages: 1 -->\n<svg width=\"720pt\" height=\"427pt\"\n viewBox=\"0.00 0.00 720.00 427.34\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(0.556924 0.556924) rotate(0) translate(4 763.32)\">\n<title>clustermy_while_loop</title>\n<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-763.32 1288.82,-763.32 1288.82,4 -4,4\"/>\n<text text-anchor=\"middle\" x=\"642.41\" y=\"-5.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">my_while_loop: Workflow</text>\n<g id=\"clust1\" class=\"cluster\">\n<title>clustermy_while_loopInputs</title>\n<defs>\n<linearGradient id=\"clust1_l_0\" gradientUnits=\"userSpaceOnUse\" x1=\"8\" y1=\"-485.5\" x2=\"258.3\" y2=\"-485.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust1_l_0)\" stroke=\"#a5a4a5\" points=\"8,-313 8,-658 258.3,-658 258.3,-313 8,-313\"/>\n<text text-anchor=\"middle\" x=\"133.15\" y=\"-640.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust2\" class=\"cluster\">\n<title>clustermy_while_loopOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust2_l_1\" gradientUnits=\"userSpaceOnUse\" x1=\"1276.82\" y1=\"-625.5\" x2=\"1112.3\" y2=\"-625.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust2_l_1)\" stroke=\"#a5a4a5\" points=\"1112.3,-534 1112.3,-717 1276.82,-717 1276.82,-534 1112.3,-534\"/>\n<text text-anchor=\"middle\" x=\"1194.56\" y=\"-699.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<g id=\"clust3\" class=\"cluster\">\n<title>clustermy_while_loopx0</title>\n<defs>\n<linearGradient id=\"clust3_l_2\" gradientUnits=\"userSpaceOnUse\" x1=\"270.3\" y1=\"-630\" x2=\"631.05\" y2=\"-630\" >\n<stop offset=\"0\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust3_l_2)\" stroke=\"#bfe2bf\" stroke-width=\"2\" points=\"270.3,-519 270.3,-741 631.05,-741 631.05,-519 270.3,-519\"/>\n<text text-anchor=\"middle\" x=\"450.68\" y=\"-723.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">x0: UserInput</text>\n</g>\n<g id=\"clust4\" class=\"cluster\">\n<title>clustermy_while_loopx0Inputs</title>\n<defs>\n<linearGradient id=\"clust4_l_3\" gradientUnits=\"userSpaceOnUse\" x1=\"278.3\" y1=\"-618.5\" x2=\"437.05\" y2=\"-618.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust4_l_3)\" stroke=\"#a5a4a5\" points=\"278.3,-527 278.3,-710 437.05,-710 437.05,-527 278.3,-527\"/>\n<text text-anchor=\"middle\" x=\"357.68\" y=\"-692.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust5\" class=\"cluster\">\n<title>clustermy_while_loopx0OutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust5_l_4\" gradientUnits=\"userSpaceOnUse\" x1=\"623.05\" y1=\"-618.5\" x2=\"481.05\" y2=\"-618.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust5_l_4)\" stroke=\"#a5a4a5\" points=\"481.05,-527 481.05,-710 623.05,-710 623.05,-527 481.05,-527\"/>\n<text text-anchor=\"middle\" x=\"552.05\" y=\"-692.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<g id=\"clust6\" class=\"cluster\">\n<title>clustermy_while_looplimit</title>\n<defs>\n<linearGradient id=\"clust6_l_5\" gradientUnits=\"userSpaceOnUse\" x1=\"270.3\" y1=\"-372\" x2=\"631.05\" y2=\"-372\" >\n<stop offset=\"0\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust6_l_5)\" stroke=\"#bfe2bf\" stroke-width=\"2\" points=\"270.3,-261 270.3,-483 631.05,-483 631.05,-261 270.3,-261\"/>\n<text text-anchor=\"middle\" x=\"450.68\" y=\"-465.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">limit: UserInput</text>\n</g>\n<g id=\"clust7\" class=\"cluster\">\n<title>clustermy_while_looplimitInputs</title>\n<defs>\n<linearGradient id=\"clust7_l_6\" gradientUnits=\"userSpaceOnUse\" x1=\"278.3\" y1=\"-360.5\" x2=\"437.05\" y2=\"-360.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust7_l_6)\" stroke=\"#a5a4a5\" points=\"278.3,-269 278.3,-452 437.05,-452 437.05,-269 278.3,-269\"/>\n<text text-anchor=\"middle\" x=\"357.68\" y=\"-434.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust8\" class=\"cluster\">\n<title>clustermy_while_looplimitOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust8_l_7\" gradientUnits=\"userSpaceOnUse\" x1=\"623.05\" y1=\"-360.5\" x2=\"481.05\" y2=\"-360.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust8_l_7)\" stroke=\"#a5a4a5\" points=\"481.05,-269 481.05,-452 623.05,-452 623.05,-269 481.05,-269\"/>\n<text text-anchor=\"middle\" x=\"552.05\" y=\"-434.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<g id=\"clust9\" class=\"cluster\">\n<title>clustermy_while_loopstep</title>\n<defs>\n<linearGradient id=\"clust9_l_8\" gradientUnits=\"userSpaceOnUse\" x1=\"270.3\" y1=\"-142\" x2=\"631.05\" y2=\"-142\" >\n<stop offset=\"0\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust9_l_8)\" stroke=\"#bfe2bf\" stroke-width=\"2\" points=\"270.3,-31 270.3,-253 631.05,-253 631.05,-31 270.3,-31\"/>\n<text text-anchor=\"middle\" x=\"450.68\" y=\"-235.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">step: UserInput</text>\n</g>\n<g id=\"clust10\" class=\"cluster\">\n<title>clustermy_while_loopstepInputs</title>\n<defs>\n<linearGradient id=\"clust10_l_9\" gradientUnits=\"userSpaceOnUse\" x1=\"278.3\" y1=\"-130.5\" x2=\"437.05\" y2=\"-130.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust10_l_9)\" stroke=\"#a5a4a5\" points=\"278.3,-39 278.3,-222 437.05,-222 437.05,-39 278.3,-39\"/>\n<text text-anchor=\"middle\" x=\"357.68\" y=\"-204.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust11\" class=\"cluster\">\n<title>clustermy_while_loopstepOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust11_l_10\" gradientUnits=\"userSpaceOnUse\" x1=\"623.05\" y1=\"-130.5\" x2=\"481.05\" y2=\"-130.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust11_l_10)\" stroke=\"#a5a4a5\" points=\"481.05,-39 481.05,-222 623.05,-222 623.05,-39 481.05,-39\"/>\n<text text-anchor=\"middle\" x=\"552.05\" y=\"-204.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<g id=\"clust12\" class=\"cluster\">\n<title>clustermy_while_loopadd_while</title>\n<defs>\n<linearGradient id=\"clust12_l_11\" gradientUnits=\"userSpaceOnUse\" x1=\"639.05\" y1=\"-494\" x2=\"1092.3\" y2=\"-494\" >\n<stop offset=\"0\" style=\"stop-color:#dcccc9;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#dcccc9;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust12_l_11)\" stroke=\"#dcccc9\" stroke-width=\"2\" points=\"639.05,-275 639.05,-713 1092.3,-713 1092.3,-275 639.05,-275\"/>\n<text text-anchor=\"middle\" x=\"865.68\" y=\"-695.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">add_while: Do_Add_While_LessThan_With_B2T_add2obj_B2B_add2obj</text>\n</g>\n<g id=\"clust13\" class=\"cluster\">\n<title>clustermy_while_loopadd_whileInputs</title>\n<defs>\n<linearGradient id=\"clust13_l_12\" gradientUnits=\"userSpaceOnUse\" x1=\"700.8\" y1=\"-482.5\" x2=\"859.55\" y2=\"-482.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust13_l_12)\" stroke=\"#a5a4a5\" points=\"700.8,-283 700.8,-682 859.55,-682 859.55,-283 700.8,-283\"/>\n<text text-anchor=\"middle\" x=\"780.18\" y=\"-664.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust14\" class=\"cluster\">\n<title>clustermy_while_loopadd_whileOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust14_l_13\" gradientUnits=\"userSpaceOnUse\" x1=\"1029.55\" y1=\"-469.5\" x2=\"887.55\" y2=\"-469.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust14_l_13)\" stroke=\"#a5a4a5\" points=\"887.55,-378 887.55,-561 1029.55,-561 1029.55,-378 887.55,-378\"/>\n<text text-anchor=\"middle\" x=\"958.55\" y=\"-543.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<!-- clustermy_while_loopInputsrun -->\n<g id=\"node1\" class=\"node\">\n<title>clustermy_while_loopInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"148.15,-621 106.15,-621 106.15,-597 148.15,-597 160.15,-609 148.15,-621\"/>\n<text text-anchor=\"middle\" x=\"133.15\" y=\"-603.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clustermy_while_loopOutputsWithInjectionran -->\n<g id=\"node7\" class=\"node\">\n<title>clustermy_while_loopOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1209.56,-680 1167.56,-680 1167.56,-656 1209.56,-656 1221.56,-668 1209.56,-680\"/>\n<text text-anchor=\"middle\" x=\"1194.56\" y=\"-662.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clustermy_while_loopInputsrun&#45;&gt;clustermy_while_loopOutputsWithInjectionran -->\n<!-- clustermy_while_loopInputsaccumulate_and_run -->\n<g id=\"node2\" class=\"node\">\n<title>clustermy_while_loopInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"192.53,-405 61.78,-405 61.78,-381 192.53,-381 204.53,-393 192.53,-405\"/>\n<text text-anchor=\"middle\" x=\"133.15\" y=\"-387.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clustermy_while_loopInputsx0__user_input -->\n<g id=\"node3\" class=\"node\">\n<title>clustermy_while_loopInputsx0__user_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"133.15\" cy=\"-555\" rx=\"70.36\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"133.15\" y=\"-549.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">x0__user_input</text>\n</g>\n<!-- clustermy_while_loopx0Inputsuser_input -->\n<g id=\"node12\" class=\"node\">\n<title>clustermy_while_loopx0Inputsuser_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"357.68\" cy=\"-661\" rx=\"51.35\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"357.68\" y=\"-655.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">user_input</text>\n</g>\n<!-- clustermy_while_loopInputsx0__user_input&#45;&gt;clustermy_while_loopx0Inputsuser_input -->\n<g id=\"edge10\" class=\"edge\">\n<title>clustermy_while_loopInputsx0__user_input&#45;&gt;clustermy_while_loopx0Inputsuser_input</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M203.62,-556.43C223.55,-560.16 243.79,-567.66 258.3,-582 263.49,-587.12 265.1,-592.37 265.31,-597.68\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M265.31,-597.68C265.78,-609.64 259.14,-621.95 270.3,-634 277.75,-642.04 287.56,-647.7 297.88,-651.69\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"296.72,-654.99 307.31,-654.79 298.9,-648.34 296.72,-654.99\"/>\n</g>\n<!-- clustermy_while_loopInputslimit__user_input -->\n<g id=\"node4\" class=\"node\">\n<title>clustermy_while_loopInputslimit__user_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"133.15\" cy=\"-447\" rx=\"77.18\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"133.15\" y=\"-441.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">limit__user_input</text>\n</g>\n<!-- clustermy_while_looplimitInputsuser_input -->\n<g id=\"node18\" class=\"node\">\n<title>clustermy_while_looplimitInputsuser_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"357.68\" cy=\"-403\" rx=\"51.35\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"357.68\" y=\"-397.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">user_input</text>\n</g>\n<!-- clustermy_while_loopInputslimit__user_input&#45;&gt;clustermy_while_looplimitInputsuser_input -->\n<g id=\"edge11\" class=\"edge\">\n<title>clustermy_while_loopInputslimit__user_input&#45;&gt;clustermy_while_looplimitInputsuser_input</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M193.2,-435.32C209.9,-432.02 228.63,-428.32 247.29,-424.63\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M247.29,-424.63C265.95,-420.94 284.54,-417.26 300.96,-414.02\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"301.57,-417.46 310.7,-412.09 300.21,-410.6 301.57,-417.46\"/>\n</g>\n<!-- clustermy_while_loopInputsstep__user_input -->\n<g id=\"node5\" class=\"node\">\n<title>clustermy_while_loopInputsstep__user_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"133.15\" cy=\"-339\" rx=\"77.67\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"133.15\" y=\"-333.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">step__user_input</text>\n</g>\n<!-- clustermy_while_loopstepInputsuser_input -->\n<g id=\"node24\" class=\"node\">\n<title>clustermy_while_loopstepInputsuser_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"357.68\" cy=\"-173\" rx=\"51.35\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"357.68\" y=\"-167.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">user_input</text>\n</g>\n<!-- clustermy_while_loopInputsstep__user_input&#45;&gt;clustermy_while_loopstepInputsuser_input -->\n<g id=\"edge12\" class=\"edge\">\n<title>clustermy_while_loopInputsstep__user_input&#45;&gt;clustermy_while_loopstepInputsuser_input</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M157.55,-321.55C177.7,-306.51 208.43,-283.59 239.75,-260.23\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M239.75,-260.23C271.08,-236.86 303,-213.04 325.56,-196.22\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"327.45,-199.17 333.38,-190.38 323.27,-193.56 327.45,-199.17\"/>\n</g>\n<!-- clustermy_while_loopInputsadd_while__max_iterations -->\n<g id=\"node6\" class=\"node\">\n<title>clustermy_while_loopInputsadd_while__max_iterations</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"133.15\" cy=\"-501\" rx=\"117.15\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"133.15\" y=\"-495.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">add_while__max_iterations</text>\n</g>\n<!-- clustermy_while_loopadd_whileInputsmax_iterations -->\n<g id=\"node34\" class=\"node\">\n<title>clustermy_while_loopadd_whileInputsmax_iterations</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"780.18\" cy=\"-525\" rx=\"67.92\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"780.18\" y=\"-519.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">max_iterations</text>\n</g>\n<!-- clustermy_while_loopInputsadd_while__max_iterations&#45;&gt;clustermy_while_loopadd_whileInputsmax_iterations -->\n<g id=\"edge13\" class=\"edge\">\n<title>clustermy_while_loopInputsadd_while__max_iterations&#45;&gt;clustermy_while_loopadd_whileInputsmax_iterations</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M247.62,-505.22C312.79,-507.65 397.99,-510.82 481.02,-513.91\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M481.02,-513.91C564.05,-517 644.92,-520 701.44,-522.11\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"701.09,-525.6 711.22,-522.47 701.36,-518.6 701.09,-525.6\"/>\n</g>\n<!-- clustermy_while_loopOutputsWithInjectionfailed -->\n<g id=\"node8\" class=\"node\">\n<title>clustermy_while_loopOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1209.56,-626 1167.56,-626 1167.56,-602 1209.56,-602 1221.56,-614 1209.56,-626\"/>\n<text text-anchor=\"middle\" x=\"1194.56\" y=\"-608.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clustermy_while_loopOutputsWithInjectionadd_while__add -->\n<g id=\"node9\" class=\"node\">\n<title>clustermy_while_loopOutputsWithInjectionadd_while__add</title>\n<ellipse fill=\"none\" stroke=\"#edb22c\" stroke-width=\"2\" cx=\"1194.56\" cy=\"-560\" rx=\"74.26\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"1194.56\" y=\"-554.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">add_while__add</text>\n</g>\n<!-- clustermy_while_loopx0Inputsrun -->\n<g id=\"node10\" class=\"node\">\n<title>clustermy_while_loopx0Inputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"372.68,-565 330.68,-565 330.68,-541 372.68,-541 384.68,-553 372.68,-565\"/>\n<text text-anchor=\"middle\" x=\"357.68\" y=\"-547.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clustermy_while_loopx0OutputsWithInjectionran -->\n<g id=\"node13\" class=\"node\">\n<title>clustermy_while_loopx0OutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"566.55,-565 524.55,-565 524.55,-541 566.55,-541 578.55,-553 566.55,-565\"/>\n<text text-anchor=\"middle\" x=\"551.55\" y=\"-547.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clustermy_while_loopx0Inputsrun&#45;&gt;clustermy_while_loopx0OutputsWithInjectionran -->\n<!-- clustermy_while_loopx0Inputsaccumulate_and_run -->\n<g id=\"node11\" class=\"node\">\n<title>clustermy_while_loopx0Inputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"417.05,-619 286.3,-619 286.3,-595 417.05,-595 429.05,-607 417.05,-619\"/>\n<text text-anchor=\"middle\" x=\"357.68\" y=\"-601.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clustermy_while_loopx0OutputsWithInjectionfailed -->\n<g id=\"node14\" class=\"node\">\n<title>clustermy_while_loopx0OutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"566.55,-619 524.55,-619 524.55,-595 566.55,-595 578.55,-607 566.55,-619\"/>\n<text text-anchor=\"middle\" x=\"551.55\" y=\"-601.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clustermy_while_loopx0OutputsWithInjectionuser_input -->\n<g id=\"node15\" class=\"node\">\n<title>clustermy_while_loopx0OutputsWithInjectionuser_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"551.55\" cy=\"-661\" rx=\"51.35\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"551.55\" y=\"-655.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">user_input</text>\n</g>\n<!-- clustermy_while_loopadd_whileInputstest_obj -->\n<g id=\"node30\" class=\"node\">\n<title>clustermy_while_loopadd_whileInputstest_obj</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"780.18\" cy=\"-633\" rx=\"41.11\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"780.18\" y=\"-627.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">test_obj</text>\n</g>\n<!-- clustermy_while_loopx0OutputsWithInjectionuser_input&#45;&gt;clustermy_while_loopadd_whileInputstest_obj -->\n<g id=\"edge6\" class=\"edge\">\n<title>clustermy_while_loopx0OutputsWithInjectionuser_input&#45;&gt;clustermy_while_loopadd_whileInputstest_obj</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M600.62,-655.06C619.46,-652.73 641.95,-649.96 664.51,-647.17\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M664.51,-647.17C687.07,-644.38 709.7,-641.58 728.83,-639.22\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"729.22,-642.7 738.72,-638 728.37,-635.75 729.22,-642.7\"/>\n</g>\n<!-- clustermy_while_loopadd_whileInputsbody_obj -->\n<g id=\"node32\" class=\"node\">\n<title>clustermy_while_loopadd_whileInputsbody_obj</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"780.18\" cy=\"-579\" rx=\"45.98\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"780.18\" y=\"-573.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">body_obj</text>\n</g>\n<!-- clustermy_while_loopx0OutputsWithInjectionuser_input&#45;&gt;clustermy_while_loopadd_whileInputsbody_obj -->\n<g id=\"edge7\" class=\"edge\">\n<title>clustermy_while_loopx0OutputsWithInjectionuser_input&#45;&gt;clustermy_while_loopadd_whileInputsbody_obj</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M598.33,-653.27C610.32,-649.27 622.33,-643.2 631.05,-634 639.96,-624.61 629.51,-614.74 639.05,-606 640.7,-604.49 642.41,-603.06 644.16,-601.69\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M644.16,-601.69C666.3,-584.48 696.63,-578.3 722.94,-576.64\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"723.01,-580.14 732.86,-576.25 722.72,-573.15 723.01,-580.14\"/>\n</g>\n<!-- clustermy_while_looplimitInputsrun -->\n<g id=\"node16\" class=\"node\">\n<title>clustermy_while_looplimitInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"372.68,-307 330.68,-307 330.68,-283 372.68,-283 384.68,-295 372.68,-307\"/>\n<text text-anchor=\"middle\" x=\"357.68\" y=\"-289.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clustermy_while_looplimitOutputsWithInjectionran -->\n<g id=\"node19\" class=\"node\">\n<title>clustermy_while_looplimitOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"566.55,-307 524.55,-307 524.55,-283 566.55,-283 578.55,-295 566.55,-307\"/>\n<text text-anchor=\"middle\" x=\"551.55\" y=\"-289.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clustermy_while_looplimitInputsrun&#45;&gt;clustermy_while_looplimitOutputsWithInjectionran -->\n<!-- clustermy_while_looplimitInputsaccumulate_and_run -->\n<g id=\"node17\" class=\"node\">\n<title>clustermy_while_looplimitInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"417.05,-361 286.3,-361 286.3,-337 417.05,-337 429.05,-349 417.05,-361\"/>\n<text text-anchor=\"middle\" x=\"357.68\" y=\"-343.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clustermy_while_looplimitOutputsWithInjectionfailed -->\n<g id=\"node20\" class=\"node\">\n<title>clustermy_while_looplimitOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"566.55,-361 524.55,-361 524.55,-337 566.55,-337 578.55,-349 566.55,-361\"/>\n<text text-anchor=\"middle\" x=\"551.55\" y=\"-343.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clustermy_while_looplimitOutputsWithInjectionuser_input -->\n<g id=\"node21\" class=\"node\">\n<title>clustermy_while_looplimitOutputsWithInjectionuser_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"551.55\" cy=\"-403\" rx=\"51.35\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"551.55\" y=\"-397.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">user_input</text>\n</g>\n<!-- clustermy_while_loopadd_whileInputstest_other -->\n<g id=\"node31\" class=\"node\">\n<title>clustermy_while_loopadd_whileInputstest_other</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"780.18\" cy=\"-471\" rx=\"49.4\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"780.18\" y=\"-465.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">test_other</text>\n</g>\n<!-- clustermy_while_looplimitOutputsWithInjectionuser_input&#45;&gt;clustermy_while_loopadd_whileInputstest_other -->\n<g id=\"edge8\" class=\"edge\">\n<title>clustermy_while_looplimitOutputsWithInjectionuser_input&#45;&gt;clustermy_while_loopadd_whileInputstest_other</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M580.25,-418.33C596.88,-426.97 618.68,-437.33 639.05,-444 642.33,-445.07 645.66,-446.11 649.04,-447.11\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M649.04,-447.11C673.14,-454.25 699.37,-459.55 721.93,-463.32\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"721.08,-466.73 731.51,-464.86 722.19,-459.82 721.08,-466.73\"/>\n</g>\n<!-- clustermy_while_loopstepInputsrun -->\n<g id=\"node22\" class=\"node\">\n<title>clustermy_while_loopstepInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"372.68,-77 330.68,-77 330.68,-53 372.68,-53 384.68,-65 372.68,-77\"/>\n<text text-anchor=\"middle\" x=\"357.68\" y=\"-59.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clustermy_while_loopstepOutputsWithInjectionran -->\n<g id=\"node25\" class=\"node\">\n<title>clustermy_while_loopstepOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"566.55,-77 524.55,-77 524.55,-53 566.55,-53 578.55,-65 566.55,-77\"/>\n<text text-anchor=\"middle\" x=\"551.55\" y=\"-59.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clustermy_while_loopstepInputsrun&#45;&gt;clustermy_while_loopstepOutputsWithInjectionran -->\n<!-- clustermy_while_loopstepInputsaccumulate_and_run -->\n<g id=\"node23\" class=\"node\">\n<title>clustermy_while_loopstepInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"417.05,-131 286.3,-131 286.3,-107 417.05,-107 429.05,-119 417.05,-131\"/>\n<text text-anchor=\"middle\" x=\"357.68\" y=\"-113.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clustermy_while_loopstepOutputsWithInjectionfailed -->\n<g id=\"node26\" class=\"node\">\n<title>clustermy_while_loopstepOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"566.55,-131 524.55,-131 524.55,-107 566.55,-107 578.55,-119 566.55,-131\"/>\n<text text-anchor=\"middle\" x=\"551.55\" y=\"-113.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clustermy_while_loopstepOutputsWithInjectionuser_input -->\n<g id=\"node27\" class=\"node\">\n<title>clustermy_while_loopstepOutputsWithInjectionuser_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"551.55\" cy=\"-173\" rx=\"51.35\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"551.55\" y=\"-167.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">user_input</text>\n</g>\n<!-- clustermy_while_loopadd_whileInputsbody_other -->\n<g id=\"node33\" class=\"node\">\n<title>clustermy_while_loopadd_whileInputsbody_other</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"780.18\" cy=\"-417\" rx=\"54.27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"780.18\" y=\"-411.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">body_other</text>\n</g>\n<!-- clustermy_while_loopstepOutputsWithInjectionuser_input&#45;&gt;clustermy_while_loopadd_whileInputsbody_other -->\n<g id=\"edge9\" class=\"edge\">\n<title>clustermy_while_loopstepOutputsWithInjectionuser_input&#45;&gt;clustermy_while_loopadd_whileInputsbody_other</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M572.78,-189.61C591.61,-206.42 618.59,-234.26 631.05,-265 635.92,-277 634.01,-300.37 632.42,-324.04\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M632.42,-324.04C630.6,-351.24 629.22,-378.83 639.05,-390 657.98,-411.49 688.38,-419.07 716.03,-420.94\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"715.62,-424.42 725.76,-421.34 715.91,-417.43 715.62,-424.42\"/>\n</g>\n<!-- clustermy_while_loopadd_whileInputsrun -->\n<g id=\"node28\" class=\"node\">\n<title>clustermy_while_loopadd_whileInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"795.18,-321 753.18,-321 753.18,-297 795.18,-297 807.18,-309 795.18,-321\"/>\n<text text-anchor=\"middle\" x=\"780.18\" y=\"-303.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clustermy_while_loopadd_whileOutputsWithInjectionran -->\n<g id=\"node35\" class=\"node\">\n<title>clustermy_while_loopadd_whileOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"973.05,-416 931.05,-416 931.05,-392 973.05,-392 985.05,-404 973.05,-416\"/>\n<text text-anchor=\"middle\" x=\"958.05\" y=\"-398.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clustermy_while_loopadd_whileInputsrun&#45;&gt;clustermy_while_loopadd_whileOutputsWithInjectionran -->\n<!-- clustermy_while_loopadd_whileInputsaccumulate_and_run -->\n<g id=\"node29\" class=\"node\">\n<title>clustermy_while_loopadd_whileInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"839.55,-375 708.8,-375 708.8,-351 839.55,-351 851.55,-363 839.55,-375\"/>\n<text text-anchor=\"middle\" x=\"780.18\" y=\"-357.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clustermy_while_loopadd_whileOutputsWithInjectionfailed -->\n<g id=\"node36\" class=\"node\">\n<title>clustermy_while_loopadd_whileOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"973.05,-470 931.05,-470 931.05,-446 973.05,-446 985.05,-458 973.05,-470\"/>\n<text text-anchor=\"middle\" x=\"958.05\" y=\"-452.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clustermy_while_loopadd_whileOutputsWithInjectionadd -->\n<g id=\"node37\" class=\"node\">\n<title>clustermy_while_loopadd_whileOutputsWithInjectionadd</title>\n<ellipse fill=\"none\" stroke=\"#edb22c\" stroke-width=\"2\" cx=\"958.05\" cy=\"-512\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"958.05\" y=\"-506.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">add</text>\n</g>\n<!-- clustermy_while_loopadd_whileOutputsWithInjectionadd&#45;&gt;clustermy_while_loopOutputsWithInjectionadd_while__add -->\n<g id=\"edge14\" class=\"edge\">\n<title>clustermy_while_loopadd_whileOutputsWithInjectionadd&#45;&gt;clustermy_while_loopOutputsWithInjectionadd_while__add</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M984.15,-517.14C1000.89,-520.56 1024.39,-525.37 1049.64,-530.54\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M1049.64,-530.54C1074.88,-535.71 1101.87,-541.23 1125.57,-546.08\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"1124.72,-549.48 1135.22,-548.06 1126.12,-542.62 1124.72,-549.48\"/>\n</g>\n</g>\n</svg>\n",
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x10b9fae40>"
+       "<graphviz.graphs.Digraph at 0x148b00b60>"
       ]
      },
-     "execution_count": 108,
+     "execution_count": 144,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 108
+   "execution_count": 144
   },
   {
    "metadata": {},
@@ -2500,8 +2587,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:43.325482Z",
-     "start_time": "2025-06-18T17:46:43.317388Z"
+     "end_time": "2025-08-13T22:35:57.473933Z",
+     "start_time": "2025-08-13T22:35:57.465465Z"
     }
    },
    "cell_type": "code",
@@ -2514,12 +2601,12 @@
        "{'add_while__add': 6}"
       ]
      },
-     "execution_count": 109,
+     "execution_count": 145,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 109
+   "execution_count": 145
   },
   {
    "metadata": {},
@@ -2530,8 +2617,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:43.347852Z",
-     "start_time": "2025-06-18T17:46:43.345557Z"
+     "end_time": "2025-08-13T22:35:57.483728Z",
+     "start_time": "2025-08-13T22:35:57.481402Z"
     }
    },
    "cell_type": "code",
@@ -2551,12 +2638,12 @@
        " 'body_3')"
       ]
      },
-     "execution_count": 110,
+     "execution_count": 146,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 110
+   "execution_count": 146
   },
   {
    "metadata": {},
@@ -2567,8 +2654,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:43.362740Z",
-     "start_time": "2025-06-18T17:46:43.360889Z"
+     "end_time": "2025-08-13T22:35:57.498018Z",
+     "start_time": "2025-08-13T22:35:57.496113Z"
     }
    },
    "cell_type": "code",
@@ -2581,18 +2668,18 @@
        "6"
       ]
      },
-     "execution_count": 111,
+     "execution_count": 147,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 111
+   "execution_count": 147
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:43.385159Z",
-     "start_time": "2025-06-18T17:46:43.382886Z"
+     "end_time": "2025-08-13T22:35:57.513671Z",
+     "start_time": "2025-08-13T22:35:57.511743Z"
     }
    },
    "cell_type": "code",
@@ -2605,12 +2692,12 @@
        "NOT_DATA"
       ]
      },
-     "execution_count": 112,
+     "execution_count": 148,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 112
+   "execution_count": 148
   },
   {
    "cell_type": "markdown",
@@ -2623,8 +2710,8 @@
    "id": "4a7eece3-20dd-4f57-88f2-5a1076daeb08",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:43.415347Z",
-     "start_time": "2025-06-18T17:46:43.411013Z"
+     "end_time": "2025-08-13T22:35:57.527902Z",
+     "start_time": "2025-08-13T22:35:57.523894Z"
     }
    },
    "source": [
@@ -2640,12 +2727,12 @@
        "{'add_while__add': 6}"
       ]
      },
-     "execution_count": 113,
+     "execution_count": 149,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 113
+   "execution_count": 149
   },
   {
    "cell_type": "markdown",
@@ -2664,8 +2751,8 @@
    "id": "be3e780b-b3cb-43d9-917f-ed3b2210e521",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:44.133194Z",
-     "start_time": "2025-06-18T17:46:43.436742Z"
+     "end_time": "2025-08-13T22:35:58.800668Z",
+     "start_time": "2025-08-13T22:35:57.535855Z"
     }
    },
    "source": [
@@ -2695,16 +2782,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "exception calling callback for <Future at 0x15a50b3b0 state=finished raised TypeError>\n",
+      "exception calling callback for <Future at 0x148a08110 state=finished raised TypeError>\n",
       "concurrent.futures.process._RemoteTraceback: \n",
       "\"\"\"\n",
       "Traceback (most recent call last):\n",
       "  File \"/Users/liamhuber/dev/miniforge3/envs/pyiron12/lib/python3.12/concurrent/futures/process.py\", line 263, in _process_worker\n",
       "    r = call_item.fn(*call_item.args, **call_item.kwargs)\n",
       "        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
-      "  File \"/Users/liamhuber/dev/pyiron/pyiron_workflow/pyiron_workflow/node.py\", line 398, in on_run\n",
-      "    result = self._on_run(*args, **kwargs)\n",
-      "             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
+      "  File \"/Users/liamhuber/dev/pyiron/pyiron_workflow/pyiron_workflow/node.py\", line 461, in on_run\n",
+      "    return self._on_run(*args, **kwargs)\n",
+      "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
       "  File \"/Users/liamhuber/dev/pyiron/pyiron_workflow/pyiron_workflow/nodes/function.py\", line 318, in _on_run\n",
       "    return self.node_function(**kwargs)\n",
       "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n",
@@ -2719,9 +2806,9 @@
       "Traceback (most recent call last):\n",
       "  File \"/Users/liamhuber/dev/miniforge3/envs/pyiron12/lib/python3.12/concurrent/futures/_base.py\", line 340, in _invoke_callbacks\n",
       "    callback(self)\n",
-      "  File \"/Users/liamhuber/dev/pyiron/pyiron_workflow/pyiron_workflow/mixin/run.py\", line 305, in _finish_run\n",
+      "  File \"/Users/liamhuber/dev/pyiron/pyiron_workflow/pyiron_workflow/mixin/run.py\", line 353, in _finish_run\n",
       "    raise e\n",
-      "  File \"/Users/liamhuber/dev/pyiron/pyiron_workflow/pyiron_workflow/mixin/run.py\", line 300, in _finish_run\n",
+      "  File \"/Users/liamhuber/dev/pyiron/pyiron_workflow/pyiron_workflow/mixin/run.py\", line 344, in _finish_run\n",
       "    run_output = run_output.result()\n",
       "                 ^^^^^^^^^^^^^^^^^^^\n",
       "  File \"/Users/liamhuber/dev/miniforge3/envs/pyiron12/lib/python3.12/concurrent/futures/_base.py\", line 449, in result\n",
@@ -2736,15 +2823,15 @@
      "data": {
       "image/svg+xml": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n<!-- Generated by graphviz version 12.0.0 (0)\n -->\n<!-- Title: clustertest Pages: 1 -->\n<svg width=\"720pt\" height=\"206pt\"\n viewBox=\"0.00 0.00 720.00 205.86\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n<g id=\"graph0\" class=\"graph\" transform=\"scale(0.314286 0.314286) rotate(0) translate(4 651)\">\n<title>clustertest</title>\n<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-651 2286.91,-651 2286.91,4 -4,4\"/>\n<text text-anchor=\"middle\" x=\"1141.46\" y=\"-5.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">test: Workflow</text>\n<g id=\"clust1\" class=\"cluster\">\n<title>clustertestInputs</title>\n<defs>\n<linearGradient id=\"clust1_l_0\" gradientUnits=\"userSpaceOnUse\" x1=\"8\" y1=\"-230.5\" x2=\"247.58\" y2=\"-230.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust1_l_0)\" stroke=\"#a5a4a5\" points=\"8,-31 8,-430 247.58,-430 247.58,-31 8,-31\"/>\n<text text-anchor=\"middle\" x=\"127.79\" y=\"-412.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust2\" class=\"cluster\">\n<title>clustertestOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust2_l_1\" gradientUnits=\"userSpaceOnUse\" x1=\"2274.91\" y1=\"-334.5\" x2=\"2035.33\" y2=\"-334.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust2_l_1)\" stroke=\"#a5a4a5\" points=\"2035.33,-189 2035.33,-480 2274.91,-480 2274.91,-189 2035.33,-189\"/>\n<text text-anchor=\"middle\" x=\"2155.12\" y=\"-462.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<g id=\"clust3\" class=\"cluster\">\n<title>clustertesta</title>\n<defs>\n<linearGradient id=\"clust3_l_2\" gradientUnits=\"userSpaceOnUse\" x1=\"259.58\" y1=\"-430\" x2=\"604.33\" y2=\"-430\" >\n<stop offset=\"0\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust3_l_2)\" stroke=\"#2ca02c\" stroke-width=\"2\" points=\"259.58,-319 259.58,-541 604.33,-541 604.33,-319 259.58,-319\"/>\n<text text-anchor=\"middle\" x=\"431.96\" y=\"-523.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">a: UserInput</text>\n</g>\n<g id=\"clust4\" class=\"cluster\">\n<title>clustertestaInputs</title>\n<defs>\n<linearGradient id=\"clust4_l_3\" gradientUnits=\"userSpaceOnUse\" x1=\"267.58\" y1=\"-418.5\" x2=\"426.33\" y2=\"-418.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust4_l_3)\" stroke=\"#a5a4a5\" points=\"267.58,-327 267.58,-510 426.33,-510 426.33,-327 267.58,-327\"/>\n<text text-anchor=\"middle\" x=\"346.96\" y=\"-492.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust5\" class=\"cluster\">\n<title>clustertestaOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust5_l_4\" gradientUnits=\"userSpaceOnUse\" x1=\"596.33\" y1=\"-418.5\" x2=\"454.33\" y2=\"-418.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust5_l_4)\" stroke=\"#a5a4a5\" points=\"454.33,-327 454.33,-510 596.33,-510 596.33,-327 454.33,-327\"/>\n<text text-anchor=\"middle\" x=\"525.33\" y=\"-492.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<g id=\"clust6\" class=\"cluster\">\n<title>clustertestb</title>\n<defs>\n<linearGradient id=\"clust6_l_5\" gradientUnits=\"userSpaceOnUse\" x1=\"612.33\" y1=\"-344\" x2=\"957.08\" y2=\"-344\" >\n<stop offset=\"0\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust6_l_5)\" stroke=\"#2ca02c\" stroke-width=\"2\" points=\"612.33,-233 612.33,-455 957.08,-455 957.08,-233 612.33,-233\"/>\n<text text-anchor=\"middle\" x=\"784.71\" y=\"-437.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">b: UserInput</text>\n</g>\n<g id=\"clust7\" class=\"cluster\">\n<title>clustertestbInputs</title>\n<defs>\n<linearGradient id=\"clust7_l_6\" gradientUnits=\"userSpaceOnUse\" x1=\"620.33\" y1=\"-332.5\" x2=\"779.08\" y2=\"-332.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust7_l_6)\" stroke=\"#a5a4a5\" points=\"620.33,-241 620.33,-424 779.08,-424 779.08,-241 620.33,-241\"/>\n<text text-anchor=\"middle\" x=\"699.71\" y=\"-406.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust8\" class=\"cluster\">\n<title>clustertestbOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust8_l_7\" gradientUnits=\"userSpaceOnUse\" x1=\"949.08\" y1=\"-332.5\" x2=\"807.08\" y2=\"-332.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust8_l_7)\" stroke=\"#a5a4a5\" points=\"807.08,-241 807.08,-424 949.08,-424 949.08,-241 807.08,-241\"/>\n<text text-anchor=\"middle\" x=\"878.08\" y=\"-406.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<g id=\"clust9\" class=\"cluster\">\n<title>clustertestc_fails</title>\n<defs>\n<linearGradient id=\"clust9_l_8\" gradientUnits=\"userSpaceOnUse\" x1=\"965.08\" y1=\"-387\" x2=\"1309.83\" y2=\"-387\" >\n<stop offset=\"0\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust9_l_8)\" stroke=\"#ff0000\" stroke-width=\"2\" points=\"965.08,-249 965.08,-525 1309.83,-525 1309.83,-249 965.08,-249\"/>\n<text text-anchor=\"middle\" x=\"1137.46\" y=\"-507.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">c_fails: Add</text>\n</g>\n<g id=\"clust10\" class=\"cluster\">\n<title>clustertestc_failsInputs</title>\n<defs>\n<linearGradient id=\"clust10_l_9\" gradientUnits=\"userSpaceOnUse\" x1=\"973.08\" y1=\"-375.5\" x2=\"1131.83\" y2=\"-375.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust10_l_9)\" stroke=\"#a5a4a5\" points=\"973.08,-257 973.08,-494 1131.83,-494 1131.83,-257 973.08,-257\"/>\n<text text-anchor=\"middle\" x=\"1052.46\" y=\"-476.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust11\" class=\"cluster\">\n<title>clustertestc_failsOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust11_l_10\" gradientUnits=\"userSpaceOnUse\" x1=\"1301.83\" y1=\"-384.5\" x2=\"1159.83\" y2=\"-384.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust11_l_10)\" stroke=\"#a5a4a5\" points=\"1159.83,-293 1159.83,-476 1301.83,-476 1301.83,-293 1159.83,-293\"/>\n<text text-anchor=\"middle\" x=\"1230.83\" y=\"-458.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<g id=\"clust12\" class=\"cluster\">\n<title>clustertestd_if_success</title>\n<defs>\n<linearGradient id=\"clust12_l_11\" gradientUnits=\"userSpaceOnUse\" x1=\"1317.83\" y1=\"-528\" x2=\"1670.58\" y2=\"-528\" >\n<stop offset=\"0\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust12_l_11)\" stroke=\"#bfe2bf\" stroke-width=\"2\" points=\"1317.83,-417 1317.83,-639 1670.58,-639 1670.58,-417 1317.83,-417\"/>\n<text text-anchor=\"middle\" x=\"1494.21\" y=\"-621.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">d_if_success: UserInput</text>\n</g>\n<g id=\"clust13\" class=\"cluster\">\n<title>clustertestd_if_successInputs</title>\n<defs>\n<linearGradient id=\"clust13_l_12\" gradientUnits=\"userSpaceOnUse\" x1=\"1325.83\" y1=\"-516.5\" x2=\"1484.58\" y2=\"-516.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust13_l_12)\" stroke=\"#a5a4a5\" points=\"1325.83,-425 1325.83,-608 1484.58,-608 1484.58,-425 1325.83,-425\"/>\n<text text-anchor=\"middle\" x=\"1405.21\" y=\"-590.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust14\" class=\"cluster\">\n<title>clustertestd_if_successOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust14_l_13\" gradientUnits=\"userSpaceOnUse\" x1=\"1662.58\" y1=\"-516.5\" x2=\"1520.58\" y2=\"-516.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust14_l_13)\" stroke=\"#a5a4a5\" points=\"1520.58,-425 1520.58,-608 1662.58,-608 1662.58,-425 1520.58,-425\"/>\n<text text-anchor=\"middle\" x=\"1591.58\" y=\"-590.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<g id=\"clust15\" class=\"cluster\">\n<title>clustertestd_if_failure</title>\n<defs>\n<linearGradient id=\"clust15_l_14\" gradientUnits=\"userSpaceOnUse\" x1=\"1317.83\" y1=\"-270\" x2=\"1670.58\" y2=\"-270\" >\n<stop offset=\"0\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust15_l_14)\" stroke=\"#2ca02c\" stroke-width=\"2\" points=\"1317.83,-159 1317.83,-381 1670.58,-381 1670.58,-159 1317.83,-159\"/>\n<text text-anchor=\"middle\" x=\"1494.21\" y=\"-363.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">d_if_failure: UserInput</text>\n</g>\n<g id=\"clust16\" class=\"cluster\">\n<title>clustertestd_if_failureInputs</title>\n<defs>\n<linearGradient id=\"clust16_l_15\" gradientUnits=\"userSpaceOnUse\" x1=\"1325.83\" y1=\"-258.5\" x2=\"1484.58\" y2=\"-258.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust16_l_15)\" stroke=\"#a5a4a5\" points=\"1325.83,-167 1325.83,-350 1484.58,-350 1484.58,-167 1325.83,-167\"/>\n<text text-anchor=\"middle\" x=\"1405.21\" y=\"-332.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust17\" class=\"cluster\">\n<title>clustertestd_if_failureOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust17_l_16\" gradientUnits=\"userSpaceOnUse\" x1=\"1662.58\" y1=\"-258.5\" x2=\"1520.58\" y2=\"-258.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust17_l_16)\" stroke=\"#a5a4a5\" points=\"1520.58,-167 1520.58,-350 1662.58,-350 1662.58,-167 1520.58,-167\"/>\n<text text-anchor=\"middle\" x=\"1591.58\" y=\"-332.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<g id=\"clust18\" class=\"cluster\">\n<title>clusterteste_fails</title>\n<defs>\n<linearGradient id=\"clust18_l_17\" gradientUnits=\"userSpaceOnUse\" x1=\"1678.58\" y1=\"-243\" x2=\"2023.33\" y2=\"-243\" >\n<stop offset=\"0\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#bfe2bf;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust18_l_17)\" stroke=\"#ff0000\" stroke-width=\"2\" points=\"1678.58,-105 1678.58,-381 2023.33,-381 2023.33,-105 1678.58,-105\"/>\n<text text-anchor=\"middle\" x=\"1850.96\" y=\"-363.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">e_fails: Add</text>\n</g>\n<g id=\"clust19\" class=\"cluster\">\n<title>clusterteste_failsInputs</title>\n<defs>\n<linearGradient id=\"clust19_l_18\" gradientUnits=\"userSpaceOnUse\" x1=\"1686.58\" y1=\"-231.5\" x2=\"1845.33\" y2=\"-231.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust19_l_18)\" stroke=\"#a5a4a5\" points=\"1686.58,-113 1686.58,-350 1845.33,-350 1845.33,-113 1686.58,-113\"/>\n<text text-anchor=\"middle\" x=\"1765.96\" y=\"-332.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">Inputs</text>\n</g>\n<g id=\"clust20\" class=\"cluster\">\n<title>clusterteste_failsOutputsWithInjection</title>\n<defs>\n<linearGradient id=\"clust20_l_19\" gradientUnits=\"userSpaceOnUse\" x1=\"2015.33\" y1=\"-258.5\" x2=\"1873.33\" y2=\"-258.5\" >\n<stop offset=\"0\" style=\"stop-color:#a5a4a5;stop-opacity:1.;\"/>\n<stop offset=\"1\" style=\"stop-color:#e4e3e4;stop-opacity:1.;\"/>\n</linearGradient>\n</defs>\n<polygon fill=\"url(#clust20_l_19)\" stroke=\"#a5a4a5\" points=\"1873.33,-167 1873.33,-350 2015.33,-350 2015.33,-167 1873.33,-167\"/>\n<text text-anchor=\"middle\" x=\"1944.33\" y=\"-332.7\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">OutputsWithInjection</text>\n</g>\n<!-- clustertestInputsrun -->\n<g id=\"node1\" class=\"node\">\n<title>clustertestInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"142.79,-69 100.79,-69 100.79,-45 142.79,-45 154.79,-57 142.79,-69\"/>\n<text text-anchor=\"middle\" x=\"127.79\" y=\"-51.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clustertestOutputsWithInjectionran -->\n<g id=\"node8\" class=\"node\">\n<title>clustertestOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"2170.12,-227 2128.12,-227 2128.12,-203 2170.12,-203 2182.12,-215 2170.12,-227\"/>\n<text text-anchor=\"middle\" x=\"2155.12\" y=\"-209.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clustertestInputsrun&#45;&gt;clustertestOutputsWithInjectionran -->\n<!-- clustertestInputsaccumulate_and_run -->\n<g id=\"node2\" class=\"node\">\n<title>clustertestInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"187.17,-123 56.42,-123 56.42,-99 187.17,-99 199.17,-111 187.17,-123\"/>\n<text text-anchor=\"middle\" x=\"127.79\" y=\"-105.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clustertestInputsa__user_input -->\n<g id=\"node3\" class=\"node\">\n<title>clustertestInputsa__user_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"127.79\" cy=\"-327\" rx=\"65.97\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"127.79\" y=\"-321.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">a__user_input</text>\n</g>\n<!-- clustertestaInputsuser_input -->\n<g id=\"node15\" class=\"node\">\n<title>clustertestaInputsuser_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"346.96\" cy=\"-461\" rx=\"51.35\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"346.96\" y=\"-455.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">user_input</text>\n</g>\n<!-- clustertestInputsa__user_input&#45;&gt;clustertestaInputsuser_input -->\n<g id=\"edge16\" class=\"edge\">\n<title>clustertestInputsa__user_input&#45;&gt;clustertestaInputsuser_input</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M194.12,-328.07C213.82,-331.68 233.84,-339.2 247.58,-354 256.83,-363.97 257.45,-373.93 255.92,-383.95\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M255.92,-383.95C253.39,-400.42 245.04,-417.02 259.58,-434 266.71,-442.32 276.37,-448.12 286.65,-452.14\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"285.48,-455.44 296.07,-455.25 287.67,-448.79 285.48,-455.44\"/>\n</g>\n<!-- clustertestInputsb__user_input -->\n<g id=\"node4\" class=\"node\">\n<title>clustertestInputsb__user_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"127.79\" cy=\"-273\" rx=\"65.97\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"127.79\" y=\"-267.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">b__user_input</text>\n</g>\n<!-- clustertestbInputsuser_input -->\n<g id=\"node21\" class=\"node\">\n<title>clustertestbInputsuser_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"699.71\" cy=\"-267\" rx=\"51.35\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"699.71\" y=\"-261.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">user_input</text>\n</g>\n<!-- clustertestInputsb__user_input&#45;&gt;clustertestbInputsuser_input -->\n<g id=\"edge17\" class=\"edge\">\n<title>clustertestInputsb__user_input&#45;&gt;clustertestbInputsuser_input</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M194.17,-272.31C249.6,-271.73 333.16,-270.85 416.42,-269.97\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M416.42,-269.97C499.68,-269.1 582.63,-268.22 636.85,-267.65\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"636.75,-271.15 646.72,-267.55 636.68,-264.15 636.75,-271.15\"/>\n</g>\n<!-- clustertestInputsd_if_success__user_input -->\n<g id=\"node5\" class=\"node\">\n<title>clustertestInputsd_if_success__user_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"127.79\" cy=\"-381\" rx=\"111.79\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"127.79\" y=\"-375.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">d_if_success__user_input</text>\n</g>\n<!-- clustertestd_if_successInputsuser_input -->\n<g id=\"node34\" class=\"node\">\n<title>clustertestd_if_successInputsuser_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"1405.21\" cy=\"-559\" rx=\"51.35\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"1405.21\" y=\"-553.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">user_input</text>\n</g>\n<!-- clustertestInputsd_if_success__user_input&#45;&gt;clustertestd_if_successInputsuser_input -->\n<g id=\"edge18\" class=\"edge\">\n<title>clustertestInputsd_if_success__user_input&#45;&gt;clustertestd_if_successInputsuser_input</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M140.8,-399.14C161.34,-428.54 206.19,-486.12 259.58,-514 365.18,-569.14 404.69,-559 523.83,-559 523.83,-559 523.83,-559 546.43,-559\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M546.43,-559C588.5,-559 708.91,-559 1053.46,-559 1154.54,-559 1272.02,-559 1342.12,-559\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"1341.87,-562.5 1351.87,-559 1341.87,-555.5 1341.87,-562.5\"/>\n</g>\n<!-- clustertestInputsd_if_failure__user_input -->\n<g id=\"node6\" class=\"node\">\n<title>clustertestInputsd_if_failure__user_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"127.79\" cy=\"-219\" rx=\"103.99\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"127.79\" y=\"-213.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">d_if_failure__user_input</text>\n</g>\n<!-- clustertestd_if_failureInputsuser_input -->\n<g id=\"node40\" class=\"node\">\n<title>clustertestd_if_failureInputsuser_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"1405.21\" cy=\"-193\" rx=\"51.35\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"1405.21\" y=\"-187.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">user_input</text>\n</g>\n<!-- clustertestInputsd_if_failure__user_input&#45;&gt;clustertestd_if_failureInputsuser_input -->\n<g id=\"edge19\" class=\"edge\">\n<title>clustertestInputsd_if_failure__user_input&#45;&gt;clustertestd_if_failureInputsuser_input</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M226.97,-213.2C306.88,-208.98 422.6,-204 523.83,-204 523.83,-204 523.83,-204 587.21,-204\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M587.21,-204C652.45,-204 784.83,-204 1053.46,-204 1154.88,-204 1272.73,-199.35 1342.74,-196.09\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"1342.64,-199.6 1352.47,-195.64 1342.31,-192.61 1342.64,-199.6\"/>\n</g>\n<!-- clustertestInputse_fails__other -->\n<g id=\"node7\" class=\"node\">\n<title>clustertestInputse_fails__other</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"127.79\" cy=\"-165\" rx=\"65.48\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"127.79\" y=\"-159.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">e_fails__other</text>\n</g>\n<!-- clusterteste_failsInputsother -->\n<g id=\"node47\" class=\"node\">\n<title>clusterteste_failsInputsother</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"1765.96\" cy=\"-139\" rx=\"30.38\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"1765.96\" y=\"-133.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">other</text>\n</g>\n<!-- clustertestInputse_fails__other&#45;&gt;clusterteste_failsInputsother -->\n<g id=\"edge20\" class=\"edge\">\n<title>clustertestInputse_fails__other&#45;&gt;clusterteste_failsInputsother</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M189.62,-158.76C267.13,-151.35 405.29,-140 523.83,-140 523.83,-140 523.83,-140 627.78,-140\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M627.78,-140C735.87,-140 956.38,-140 1406.21,-140 1521.37,-140 1657.32,-139.48 1723.96,-139.19\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"1723.69,-142.69 1733.68,-139.15 1723.66,-135.69 1723.69,-142.69\"/>\n</g>\n<!-- clustertestOutputsWithInjectionfailed -->\n<g id=\"node9\" class=\"node\">\n<title>clustertestOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"2170.12,-281 2128.12,-281 2128.12,-257 2170.12,-257 2182.12,-269 2170.12,-281\"/>\n<text text-anchor=\"middle\" x=\"2155.12\" y=\"-263.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clustertestOutputsWithInjectionc_fails__add -->\n<g id=\"node10\" class=\"node\">\n<title>clustertestOutputsWithInjectionc_fails__add</title>\n<ellipse fill=\"none\" stroke=\"#edb22c\" stroke-width=\"2\" cx=\"2155.12\" cy=\"-377\" rx=\"59.63\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"2155.12\" y=\"-371.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">c_fails__add</text>\n</g>\n<!-- clustertestOutputsWithInjectiond_if_success__user_input -->\n<g id=\"node11\" class=\"node\">\n<title>clustertestOutputsWithInjectiond_if_success__user_input</title>\n<ellipse fill=\"none\" stroke=\"#edb22c\" stroke-width=\"2\" cx=\"2155.12\" cy=\"-431\" rx=\"111.79\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"2155.12\" y=\"-425.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">d_if_success__user_input</text>\n</g>\n<!-- clustertestOutputsWithInjectione_fails__add -->\n<g id=\"node12\" class=\"node\">\n<title>clustertestOutputsWithInjectione_fails__add</title>\n<ellipse fill=\"none\" stroke=\"#edb22c\" stroke-width=\"2\" cx=\"2155.12\" cy=\"-323\" rx=\"60.12\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"2155.12\" y=\"-317.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">e_fails__add</text>\n</g>\n<!-- clustertestaInputsrun -->\n<g id=\"node13\" class=\"node\">\n<title>clustertestaInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"361.96,-365 319.96,-365 319.96,-341 361.96,-341 373.96,-353 361.96,-365\"/>\n<text text-anchor=\"middle\" x=\"346.96\" y=\"-347.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clustertestaOutputsWithInjectionran -->\n<g id=\"node16\" class=\"node\">\n<title>clustertestaOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"539.83,-365 497.83,-365 497.83,-341 539.83,-341 551.83,-353 539.83,-365\"/>\n<text text-anchor=\"middle\" x=\"524.83\" y=\"-347.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clustertestaInputsrun&#45;&gt;clustertestaOutputsWithInjectionran -->\n<!-- clustertestaInputsaccumulate_and_run -->\n<g id=\"node14\" class=\"node\">\n<title>clustertestaInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"406.33,-419 275.58,-419 275.58,-395 406.33,-395 418.33,-407 406.33,-419\"/>\n<text text-anchor=\"middle\" x=\"346.96\" y=\"-401.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clustertestbInputsrun -->\n<g id=\"node19\" class=\"node\">\n<title>clustertestbInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"714.71,-387 672.71,-387 672.71,-363 714.71,-363 726.71,-375 714.71,-387\"/>\n<text text-anchor=\"middle\" x=\"699.71\" y=\"-369.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clustertestaOutputsWithInjectionran&#45;&gt;clustertestbInputsrun -->\n<g id=\"edge8\" class=\"edge\">\n<title>clustertestaOutputsWithInjectionran&#45;&gt;clustertestbInputsrun</title>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M552.09,-356.34C566.66,-358.2 585.77,-360.63 605.35,-363.12\"/>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M605.35,-363.12C624.94,-365.61 645,-368.17 661.48,-370.26\"/>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"660.62,-373.68 670.98,-371.47 661.51,-366.74 660.62,-373.68\"/>\n</g>\n<!-- clustertestaOutputsWithInjectionfailed -->\n<g id=\"node17\" class=\"node\">\n<title>clustertestaOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"539.83,-419 497.83,-419 497.83,-395 539.83,-395 551.83,-407 539.83,-419\"/>\n<text text-anchor=\"middle\" x=\"524.83\" y=\"-401.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clustertestaOutputsWithInjectionuser_input -->\n<g id=\"node18\" class=\"node\">\n<title>clustertestaOutputsWithInjectionuser_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"524.83\" cy=\"-461\" rx=\"51.35\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"524.83\" y=\"-455.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">user_input</text>\n</g>\n<!-- clustertestc_failsInputsobj -->\n<g id=\"node27\" class=\"node\">\n<title>clustertestc_failsInputsobj</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"1052.46\" cy=\"-445\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"1052.46\" y=\"-439.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">obj</text>\n</g>\n<!-- clustertestaOutputsWithInjectionuser_input&#45;&gt;clustertestc_failsInputsobj -->\n<g id=\"edge9\" class=\"edge\">\n<title>clustertestaOutputsWithInjectionuser_input&#45;&gt;clustertestc_failsInputsobj</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M576.23,-459.47C628.66,-457.87 714.79,-455.25 799.42,-452.67\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M799.42,-452.67C884.05,-450.1 967.19,-447.57 1013.65,-446.15\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"1013.6,-449.65 1023.49,-445.85 1013.39,-442.66 1013.6,-449.65\"/>\n</g>\n<!-- clustertestbOutputsWithInjectionran -->\n<g id=\"node22\" class=\"node\">\n<title>clustertestbOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"892.58,-279 850.58,-279 850.58,-255 892.58,-255 904.58,-267 892.58,-279\"/>\n<text text-anchor=\"middle\" x=\"877.58\" y=\"-261.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clustertestbInputsrun&#45;&gt;clustertestbOutputsWithInjectionran -->\n<!-- clustertestbInputsaccumulate_and_run -->\n<g id=\"node20\" class=\"node\">\n<title>clustertestbInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"759.08,-333 628.33,-333 628.33,-309 759.08,-309 771.08,-321 759.08,-333\"/>\n<text text-anchor=\"middle\" x=\"699.71\" y=\"-315.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clustertestc_failsInputsrun -->\n<g id=\"node25\" class=\"node\">\n<title>clustertestc_failsInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1067.46,-295 1025.46,-295 1025.46,-271 1067.46,-271 1079.46,-283 1067.46,-295\"/>\n<text text-anchor=\"middle\" x=\"1052.46\" y=\"-277.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clustertestbOutputsWithInjectionran&#45;&gt;clustertestc_failsInputsrun -->\n<g id=\"edge10\" class=\"edge\">\n<title>clustertestbOutputsWithInjectionran&#45;&gt;clustertestc_failsInputsrun</title>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M904.84,-269.43C919.35,-270.77 938.35,-272.53 957.85,-274.34\"/>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M957.85,-274.34C977.34,-276.14 997.32,-277.99 1013.79,-279.51\"/>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1013.45,-283 1023.73,-280.43 1014.09,-276.03 1013.45,-283\"/>\n</g>\n<!-- clustertestbOutputsWithInjectionfailed -->\n<g id=\"node23\" class=\"node\">\n<title>clustertestbOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"892.58,-333 850.58,-333 850.58,-309 892.58,-309 904.58,-321 892.58,-333\"/>\n<text text-anchor=\"middle\" x=\"877.58\" y=\"-315.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clustertestbOutputsWithInjectionuser_input -->\n<g id=\"node24\" class=\"node\">\n<title>clustertestbOutputsWithInjectionuser_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"877.58\" cy=\"-375\" rx=\"51.35\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"877.58\" y=\"-369.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">user_input</text>\n</g>\n<!-- clustertestc_failsInputsother -->\n<g id=\"node28\" class=\"node\">\n<title>clustertestc_failsInputsother</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"1052.46\" cy=\"-391\" rx=\"30.38\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"1052.46\" y=\"-385.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">other</text>\n</g>\n<!-- clustertestbOutputsWithInjectionuser_input&#45;&gt;clustertestc_failsInputsother -->\n<g id=\"edge11\" class=\"edge\">\n<title>clustertestbOutputsWithInjectionuser_input&#45;&gt;clustertestc_failsInputsother</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M927.66,-379.54C940.8,-380.76 955.37,-382.11 969.76,-383.44\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M969.76,-383.44C984.15,-384.77 998.37,-386.09 1010.81,-387.24\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"1010.25,-390.7 1020.53,-388.14 1010.9,-383.73 1010.25,-390.7\"/>\n</g>\n<!-- clustertestc_failsOutputsWithInjectionran -->\n<g id=\"node29\" class=\"node\">\n<title>clustertestc_failsOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1245.33,-439 1203.33,-439 1203.33,-415 1245.33,-415 1257.33,-427 1245.33,-439\"/>\n<text text-anchor=\"middle\" x=\"1230.33\" y=\"-421.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clustertestc_failsInputsrun&#45;&gt;clustertestc_failsOutputsWithInjectionran -->\n<!-- clustertestc_failsInputsaccumulate_and_run -->\n<g id=\"node26\" class=\"node\">\n<title>clustertestc_failsInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1111.83,-349 981.08,-349 981.08,-325 1111.83,-325 1123.83,-337 1111.83,-349\"/>\n<text text-anchor=\"middle\" x=\"1052.46\" y=\"-331.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clustertestd_if_successInputsrun -->\n<g id=\"node32\" class=\"node\">\n<title>clustertestd_if_successInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1420.21,-463 1378.21,-463 1378.21,-439 1420.21,-439 1432.21,-451 1420.21,-463\"/>\n<text text-anchor=\"middle\" x=\"1405.21\" y=\"-445.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clustertestc_failsOutputsWithInjectionran&#45;&gt;clustertestd_if_successInputsrun -->\n<g id=\"edge12\" class=\"edge\">\n<title>clustertestc_failsOutputsWithInjectionran&#45;&gt;clustertestd_if_successInputsrun</title>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M1257.59,-430.65C1272.16,-432.67 1291.27,-435.32 1310.85,-438.04\"/>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M1310.85,-438.04C1330.44,-440.76 1350.5,-443.54 1366.98,-445.83\"/>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1366.1,-449.24 1376.49,-447.15 1367.06,-442.31 1366.1,-449.24\"/>\n</g>\n<!-- clustertestc_failsOutputsWithInjectionfailed -->\n<g id=\"node30\" class=\"node\">\n<title>clustertestc_failsOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1245.33,-331 1203.33,-331 1203.33,-307 1245.33,-307 1257.33,-319 1245.33,-331\"/>\n<text text-anchor=\"middle\" x=\"1230.33\" y=\"-313.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clustertestd_if_failureInputsrun -->\n<g id=\"node38\" class=\"node\">\n<title>clustertestd_if_failureInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1420.21,-313 1378.21,-313 1378.21,-289 1420.21,-289 1432.21,-301 1420.21,-313\"/>\n<text text-anchor=\"middle\" x=\"1405.21\" y=\"-295.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clustertestc_failsOutputsWithInjectionfailed&#45;&gt;clustertestd_if_failureInputsrun -->\n<g id=\"edge13\" class=\"edge\">\n<title>clustertestc_failsOutputsWithInjectionfailed&#45;&gt;clustertestd_if_failureInputsrun</title>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M1257.59,-316.27C1272.1,-314.76 1291.1,-312.78 1310.6,-310.75\"/>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M1310.6,-310.75C1330.09,-308.72 1350.07,-306.64 1366.54,-304.92\"/>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1366.9,-308.4 1376.48,-303.89 1366.17,-301.44 1366.9,-308.4\"/>\n</g>\n<!-- clustertestc_failsOutputsWithInjectionadd -->\n<g id=\"node31\" class=\"node\">\n<title>clustertestc_failsOutputsWithInjectionadd</title>\n<ellipse fill=\"none\" stroke=\"#edb22c\" stroke-width=\"2\" cx=\"1230.33\" cy=\"-373\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"1230.33\" y=\"-367.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">add</text>\n</g>\n<!-- clustertestc_failsOutputsWithInjectionadd&#45;&gt;clustertestOutputsWithInjectionc_fails__add -->\n<g id=\"edge21\" class=\"edge\">\n<title>clustertestc_failsOutputsWithInjectionadd&#45;&gt;clustertestOutputsWithInjectionc_fails__add</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M1257.39,-376.19C1316.48,-383.13 1465.19,-399 1590.08,-399 1590.08,-399 1590.08,-399 1607.34,-399\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M1607.34,-399C1627.57,-399 1671.51,-399 1766.96,-399 1879.02,-399 2009.04,-389.7 2086.28,-383.19\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"2086.58,-386.68 2096.24,-382.34 2085.98,-379.71 2086.58,-386.68\"/>\n</g>\n<!-- clustertestd_if_successOutputsWithInjectionran -->\n<g id=\"node35\" class=\"node\">\n<title>clustertestd_if_successOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1606.08,-463 1564.08,-463 1564.08,-439 1606.08,-439 1618.08,-451 1606.08,-463\"/>\n<text text-anchor=\"middle\" x=\"1591.08\" y=\"-445.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clustertestd_if_successInputsrun&#45;&gt;clustertestd_if_successOutputsWithInjectionran -->\n<!-- clustertestd_if_successInputsaccumulate_and_run -->\n<g id=\"node33\" class=\"node\">\n<title>clustertestd_if_successInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1464.58,-517 1333.83,-517 1333.83,-493 1464.58,-493 1476.58,-505 1464.58,-517\"/>\n<text text-anchor=\"middle\" x=\"1405.21\" y=\"-499.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clustertestd_if_successOutputsWithInjectionfailed -->\n<g id=\"node36\" class=\"node\">\n<title>clustertestd_if_successOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1606.08,-517 1564.08,-517 1564.08,-493 1606.08,-493 1618.08,-505 1606.08,-517\"/>\n<text text-anchor=\"middle\" x=\"1591.08\" y=\"-499.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clustertestd_if_successOutputsWithInjectionuser_input -->\n<g id=\"node37\" class=\"node\">\n<title>clustertestd_if_successOutputsWithInjectionuser_input</title>\n<ellipse fill=\"none\" stroke=\"#edb22c\" stroke-width=\"2\" cx=\"1591.08\" cy=\"-559\" rx=\"51.35\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"1591.08\" y=\"-553.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">user_input</text>\n</g>\n<!-- clustertestd_if_successOutputsWithInjectionuser_input&#45;&gt;clustertestOutputsWithInjectiond_if_success__user_input -->\n<g id=\"edge22\" class=\"edge\">\n<title>clustertestd_if_successOutputsWithInjectionuser_input&#45;&gt;clustertestOutputsWithInjectiond_if_success__user_input</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M1634.79,-549.27C1682.11,-538.5 1762.89,-520.1 1846.83,-500.98\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M1846.83,-500.98C1930.76,-481.87 2017.85,-462.03 2077.79,-448.38\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"2078.24,-451.87 2087.22,-446.24 2076.69,-445.04 2078.24,-451.87\"/>\n</g>\n<!-- clustertestd_if_failureOutputsWithInjectionran -->\n<g id=\"node41\" class=\"node\">\n<title>clustertestd_if_failureOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1606.08,-205 1564.08,-205 1564.08,-181 1606.08,-181 1618.08,-193 1606.08,-205\"/>\n<text text-anchor=\"middle\" x=\"1591.08\" y=\"-187.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clustertestd_if_failureInputsrun&#45;&gt;clustertestd_if_failureOutputsWithInjectionran -->\n<!-- clustertestd_if_failureInputsaccumulate_and_run -->\n<g id=\"node39\" class=\"node\">\n<title>clustertestd_if_failureInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1464.58,-259 1333.83,-259 1333.83,-235 1464.58,-235 1476.58,-247 1464.58,-259\"/>\n<text text-anchor=\"middle\" x=\"1405.21\" y=\"-241.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clusterteste_failsInputsrun -->\n<g id=\"node44\" class=\"node\">\n<title>clusterteste_failsInputsrun</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1780.96,-259 1738.96,-259 1738.96,-235 1780.96,-235 1792.96,-247 1780.96,-259\"/>\n<text text-anchor=\"middle\" x=\"1765.96\" y=\"-241.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">run</text>\n</g>\n<!-- clustertestd_if_failureOutputsWithInjectionran&#45;&gt;clusterteste_failsInputsrun -->\n<g id=\"edge14\" class=\"edge\">\n<title>clustertestd_if_failureOutputsWithInjectionran&#45;&gt;clusterteste_failsInputsrun</title>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M1618.34,-201.2C1632.97,-205.77 1652.19,-211.77 1671.86,-217.92\"/>\n<path fill=\"none\" stroke=\"#21bfd8\" d=\"M1671.86,-217.92C1691.53,-224.07 1711.67,-230.36 1728.16,-235.51\"/>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1726.7,-238.72 1737.29,-238.36 1728.79,-232.04 1726.7,-238.72\"/>\n</g>\n<!-- clustertestd_if_failureOutputsWithInjectionfailed -->\n<g id=\"node42\" class=\"node\">\n<title>clustertestd_if_failureOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1606.08,-259 1564.08,-259 1564.08,-235 1606.08,-235 1618.08,-247 1606.08,-259\"/>\n<text text-anchor=\"middle\" x=\"1591.08\" y=\"-241.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clustertestd_if_failureOutputsWithInjectionuser_input -->\n<g id=\"node43\" class=\"node\">\n<title>clustertestd_if_failureOutputsWithInjectionuser_input</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"1591.08\" cy=\"-301\" rx=\"51.35\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"1591.08\" y=\"-295.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">user_input</text>\n</g>\n<!-- clusterteste_failsInputsobj -->\n<g id=\"node46\" class=\"node\">\n<title>clusterteste_failsInputsobj</title>\n<ellipse fill=\"#edb22c\" stroke=\"#edb22c\" cx=\"1765.96\" cy=\"-301\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"1765.96\" y=\"-295.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">obj</text>\n</g>\n<!-- clustertestd_if_failureOutputsWithInjectionuser_input&#45;&gt;clusterteste_failsInputsobj -->\n<g id=\"edge15\" class=\"edge\">\n<title>clustertestd_if_failureOutputsWithInjectionuser_input&#45;&gt;clusterteste_failsInputsobj</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M1642.55,-301C1656.08,-301 1671.04,-301 1685.73,-301\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M1685.73,-301C1700.41,-301 1714.82,-301 1727.23,-301\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"1727.21,-304.5 1737.21,-301 1727.21,-297.5 1727.21,-304.5\"/>\n</g>\n<!-- clusterteste_failsOutputsWithInjectionran -->\n<g id=\"node48\" class=\"node\">\n<title>clusterteste_failsOutputsWithInjectionran</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1958.83,-205 1916.83,-205 1916.83,-181 1958.83,-181 1970.83,-193 1958.83,-205\"/>\n<text text-anchor=\"middle\" x=\"1943.83\" y=\"-187.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">ran</text>\n</g>\n<!-- clusterteste_failsInputsrun&#45;&gt;clusterteste_failsOutputsWithInjectionran -->\n<!-- clusterteste_failsInputsaccumulate_and_run -->\n<g id=\"node45\" class=\"node\">\n<title>clusterteste_failsInputsaccumulate_and_run</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1825.33,-205 1694.58,-205 1694.58,-181 1825.33,-181 1837.33,-193 1825.33,-205\"/>\n<text text-anchor=\"middle\" x=\"1765.96\" y=\"-187.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">accumulate_and_run</text>\n</g>\n<!-- clusterteste_failsOutputsWithInjectionfailed -->\n<g id=\"node49\" class=\"node\">\n<title>clusterteste_failsOutputsWithInjectionfailed</title>\n<polygon fill=\"#21bfd8\" stroke=\"#21bfd8\" points=\"1958.83,-259 1916.83,-259 1916.83,-235 1958.83,-235 1970.83,-247 1958.83,-259\"/>\n<text text-anchor=\"middle\" x=\"1943.83\" y=\"-241.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">failed</text>\n</g>\n<!-- clusterteste_failsOutputsWithInjectionadd -->\n<g id=\"node50\" class=\"node\">\n<title>clusterteste_failsOutputsWithInjectionadd</title>\n<ellipse fill=\"none\" stroke=\"#edb22c\" stroke-width=\"2\" cx=\"1943.83\" cy=\"-301\" rx=\"27\" ry=\"18\"/>\n<text text-anchor=\"middle\" x=\"1943.83\" y=\"-295.2\" font-family=\"Helvetica,sans-Serif\" font-size=\"14.00\">add</text>\n</g>\n<!-- clusterteste_failsOutputsWithInjectionadd&#45;&gt;clustertestOutputsWithInjectione_fails__add -->\n<g id=\"edge23\" class=\"edge\">\n<title>clusterteste_failsOutputsWithInjectionadd&#45;&gt;clustertestOutputsWithInjectione_fails__add</title>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M1970.91,-303.74C1985.28,-305.25 2004.29,-307.25 2024.63,-309.39\"/>\n<path fill=\"none\" stroke=\"#edb22c\" d=\"M2024.63,-309.39C2044.98,-311.53 2066.65,-313.81 2086.33,-315.87\"/>\n<polygon fill=\"#edb22c\" stroke=\"#edb22c\" points=\"2085.91,-319.35 2096.22,-316.91 2086.64,-312.39 2085.91,-319.35\"/>\n</g>\n</g>\n</svg>\n",
       "text/plain": [
-       "<graphviz.graphs.Digraph at 0x15a4c0770>"
+       "<graphviz.graphs.Digraph at 0x148b2ac30>"
       ]
      },
-     "execution_count": 114,
+     "execution_count": 150,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 114
+   "execution_count": 150
   },
   {
    "cell_type": "markdown",
@@ -2763,8 +2850,8 @@
    "id": "75aac7e5-7fe8-4a69-b0f3-1510cf52ef5e",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:44.154762Z",
-     "start_time": "2025-06-18T17:46:44.149302Z"
+     "end_time": "2025-08-13T22:35:58.826207Z",
+     "start_time": "2025-08-13T22:35:58.821629Z"
     }
    },
    "source": [
@@ -2780,20 +2867,20 @@
        "{'without__in': True}"
       ]
      },
-     "execution_count": 115,
+     "execution_count": 151,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 115
+   "execution_count": 151
   },
   {
    "cell_type": "code",
    "id": "3ce9be3f-2ac9-49d1-a482-dc0c6735aa59",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:44.178375Z",
-     "start_time": "2025-06-18T17:46:44.175873Z"
+     "end_time": "2025-08-13T22:35:58.837473Z",
+     "start_time": "2025-08-13T22:35:58.835338Z"
     }
    },
    "source": [
@@ -2801,15 +2888,15 @@
     "storage.save(wf, \"../someplace_else\")"
    ],
    "outputs": [],
-   "execution_count": 116
+   "execution_count": 152
   },
   {
    "cell_type": "code",
    "id": "2e70af5b-9e74-4b1a-a26c-b9f427401f4d",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:44.192939Z",
-     "start_time": "2025-06-18T17:46:44.190579Z"
+     "end_time": "2025-08-13T22:35:58.847966Z",
+     "start_time": "2025-08-13T22:35:58.845346Z"
     }
    },
    "source": [
@@ -2821,7 +2908,7 @@
     "    storage.delete(filename=\"../someplace_else\")"
    ],
    "outputs": [],
-   "execution_count": 117
+   "execution_count": 153
   },
   {
    "cell_type": "markdown",
@@ -2838,8 +2925,8 @@
    "id": "8adf1d56-6d81-4b20-9efe-ae0a67348cf9",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:44.209464Z",
-     "start_time": "2025-06-18T17:46:44.207929Z"
+     "end_time": "2025-08-13T22:35:58.855420Z",
+     "start_time": "2025-08-13T22:35:58.853983Z"
     }
    },
    "source": [
@@ -2849,15 +2936,15 @@
     "    return inner_function"
    ],
    "outputs": [],
-   "execution_count": 118
+   "execution_count": 154
   },
   {
    "cell_type": "code",
    "id": "6b1f54c9-872b-40c6-9370-bd0032d5d075",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:44.225996Z",
-     "start_time": "2025-06-18T17:46:44.222800Z"
+     "end_time": "2025-08-13T22:35:58.863920Z",
+     "start_time": "2025-08-13T22:35:58.860605Z"
     }
    },
    "source": [
@@ -2872,12 +2959,12 @@
        "{'unpickleable__x': 2}"
       ]
      },
-     "execution_count": 119,
+     "execution_count": 155,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 119
+   "execution_count": 155
   },
   {
    "cell_type": "markdown",
@@ -2892,8 +2979,8 @@
    "id": "2938411c-df0a-4483-ae32-2fec2413248b",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:44.252101Z",
-     "start_time": "2025-06-18T17:46:44.249417Z"
+     "end_time": "2025-08-13T22:35:58.878498Z",
+     "start_time": "2025-08-13T22:35:58.875889Z"
     }
    },
    "source": [
@@ -2917,7 +3004,7 @@
      ]
     }
    ],
-   "execution_count": 120
+   "execution_count": 156
   },
   {
    "cell_type": "markdown",
@@ -2934,8 +3021,8 @@
    "id": "f40bfd6f-3fbf-4c2b-aeee-534ed4bcc970",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:44.280939Z",
-     "start_time": "2025-06-18T17:46:44.279559Z"
+     "end_time": "2025-08-13T22:35:58.891836Z",
+     "start_time": "2025-08-13T22:35:58.890563Z"
     }
    },
    "source": [],

--- a/notebooks/deepdive.ipynb
+++ b/notebooks/deepdive.ipynb
@@ -484,14 +484,10 @@
    ]
   },
   {
+   "metadata": {},
    "cell_type": "code",
-   "id": "cadd24f1-4a53-4a87-8ed1-29d870ae2fc3",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.246808Z",
-     "start_time": "2025-06-18T17:46:41.243312Z"
-    }
-   },
+   "outputs": [],
+   "execution_count": null,
    "source": [
     "@pwf.as_function_node\n",
     "def TimesTwo(x: int) -> int:\n",
@@ -505,170 +501,113 @@
     "    self.eight = TimesTwo(self.four)\n",
     "    return self.eight"
    ],
+   "id": "7e46773333ae06a3"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "### Only intra-graph connections\n",
+    "\n",
+    "Connections can only be formed between sibling nodes that belong to the same graph. This prevents two workflow objects from being connected and allows macros to define an explicit interface between the subgraph they hold and the outside world. Trying to connect two non-sibling nodes will raise an exception, e.g. here we try to connect a node to the child of its \"nephew\" in a macro:"
+   ],
+   "id": "10cd844ecaaf149f"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
    "outputs": [],
-   "execution_count": 58
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3c00e0d6-7a24-4e66-87fa-a3a9b0032ed5",
-   "metadata": {},
+   "execution_count": null,
    "source": [
-    "### No outside connections\n",
+    "from pyiron_workflow.channels import ChannelConnectionError\n",
     "\n",
-    "Macros define an explicit interface between the subgraph they hold and the outside world, that means you can't use data (or signal) connections directly between macro child nodes and other nodes. At time of writing, you will be permitted to _form_ the connections, but will get a relatively clear error if you try to actually leverage them.\n",
-    "\n",
-    "This is the case whether you're working directly with nodes:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "id": "7095159b-1314-4347-b208-e8ee781980f0",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.261246Z",
-     "start_time": "2025-06-18T17:46:41.256546Z"
-    }
-   },
-   "source": [
-    "non_child = TimesTwo(label=\"non_child\")\n",
-    "macro = TwoCubed(2, label=\"macro\")\n",
-    "\n",
-    "non_child.inputs.x = macro.four.outputs.twox\n",
-    "\n",
-    "try:\n",
-    "    non_child()\n",
-    "except ValueError as e:\n",
-    "    print(\"ValueError:\", e)"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ValueError: Nodes in a data digraph must all be siblings -- i.e. have the same `parent` attribute. Some of these do not: /macro/four5809566208\n",
-      "/non_child4831133968\n",
-      "/macro/two4831587136\n"
-     ]
-    }
-   ],
-   "execution_count": 59
-  },
-  {
-   "cell_type": "markdown",
-   "id": "42ac1c23-c5b2-40b7-bb5e-beb308615507",
-   "metadata": {},
-   "source": [
-    "Or whether they're packaged in a workflow:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "id": "bc2ec413-7a83-4f23-b5a1-f307de413870",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.294810Z",
-     "start_time": "2025-06-18T17:46:41.289745Z"
-    }
-   },
-   "source": [
     "wf = pwf.Workflow(\"walled_gardens\")\n",
     "wf.non_child = TimesTwo()\n",
     "wf.macro = TwoCubed(2)\n",
-    "wf.non_child.inputs.x = wf.macro.four.outputs.twox\n",
     "\n",
     "try:\n",
-    "    wf()\n",
-    "except KeyError as e:\n",
-    "    print(\"KeyError:\", e)"
+    "    wf.non_child.inputs.x = wf.macro.four.outputs.twox\n",
+    "except ChannelConnectionError as e:\n",
+    "    print(type(e), e)"
    ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "KeyError: 'The channel /walled_gardens/non_child.x has a connection to the upstream channel /walled_gardens/macro/four.twox, but the upstream owner four was not found among nodes. All nodes in the data flow dependency tree must be included.'\n"
-     ]
-    }
-   ],
-   "execution_count": 60
+   "id": "786663d25191caf"
   },
   {
-   "cell_type": "markdown",
-   "id": "2c5e5d7d-8136-4af0-b0ba-80bd04d915ad",
    "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "### Connecting orphans\n",
+    "\n",
+    "In order to support the syntax of creating connections at instantiation time (potentially before a parent has been assigned), we do allow nodes with _no_ parent to be connected to a node with a parent. In this case, the \"orphan\" node is automatically parented to the same parent as the owner of its connection counterpart.\n",
+    "\n",
+    "This is wonderful for workflows, and used during macro instantiation, but has a nasty side effect that you can accidentally extend the body of a macro:"
+   ],
+   "id": "d58e3c2f65846503"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "wf = pwf.Workflow(\"sneaky_extenson\")\n",
+    "non_child = TimesTwo()\n",
+    "wf.macro = TwoCubed(2)\n",
+    "\n",
+    "non_child.inputs.x = wf.macro.four.outputs.twox\n",
+    "\n",
+    "assert(non_child.parent is wf.macro)\n",
+    "wf()"
+   ],
+   "id": "50c072fd7c203577"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "### Value syncing\n",
     "\n",
     "The prohibition against outside connections guarantees that the macro doesn't receive outside interference, but then how _does_ the macro communicate outside information in and inside information back out?\n",
     "\n",
     "In addition to the regular \"connections\" data and signal channels have, data channels also quietly have a `.value_receiver` method. These guarantee that whenever the value of that channel is updated, the new value is immediately propagated to its receiving partner. Macro's use this for input:"
-   ]
+   ],
+   "id": "9eaa8c66d0a4dbc"
   },
   {
-   "cell_type": "code",
-   "id": "1f9408d0-174d-4140-af45-30cc147b9d3f",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.314373Z",
-     "start_time": "2025-06-18T17:46:41.312631Z"
-    }
-   },
-   "source": [
-    "assert(macro.inputs.x is not macro.two.inputs.x)\n",
-    "assert(macro.inputs.x.value_receiver is macro.two.inputs.x)\n",
-    "\n",
-    "print(macro.inputs.x.value, macro.two.inputs.x.value)\n",
-    "macro.inputs.x.value = 5\n",
-    "print(macro.inputs.x.value, macro.two.inputs.x.value)"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2 2\n",
-      "5 5\n"
-     ]
-    }
-   ],
-   "execution_count": 61
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8041d9e1-6075-4678-b383-54a329fd7e5e",
    "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
    "source": [
-    "And output:"
-   ]
+    "assert(wf.macro.inputs.x is not wf.macro.two.inputs.x)\n",
+    "assert(wf.macro.inputs.x.value_receiver is wf.macro.two.inputs.x)\n",
+    "\n",
+    "print(wf.macro.inputs.x.value, wf.macro.two.inputs.x.value)\n",
+    "wf.macro.inputs.x.value = 5\n",
+    "print(wf.macro.inputs.x.value, wf.macro.two.inputs.x.value)"
+   ],
+   "id": "8b5d0438d1cd220b"
   },
   {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "And output:",
+   "id": "c70ce1cbc1d93f99"
+  },
+  {
+   "metadata": {},
    "cell_type": "code",
-   "id": "8504c0fd-8b79-4eaa-b6d4-374989e5d67b",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-06-18T17:46:41.337616Z",
-     "start_time": "2025-06-18T17:46:41.335679Z"
-    }
-   },
+   "outputs": [],
+   "execution_count": null,
    "source": [
-    "assert(macro.eight.outputs.twox is not macro.outputs.eight)\n",
-    "assert(macro.eight.outputs.twox.value_receiver is macro.outputs.eight)\n",
+    "assert(wf.macro.eight.outputs.twox is not wf.macro.outputs.eight)\n",
+    "assert(wf.macro.eight.outputs.twox.value_receiver is wf.macro.outputs.eight)\n",
     "\n",
-    "print(macro.eight.outputs.twox.value, macro.outputs.eight.value)\n",
-    "macro.eight.outputs.twox.value = 5\n",
-    "print(macro.eight.outputs.twox.value, macro.outputs.eight.value)"
+    "print(wf.macro.eight.outputs.twox.value, wf.macro.outputs.eight.value)\n",
+    "wf.macro.eight.outputs.twox.value = 5\n",
+    "print(wf.macro.eight.outputs.twox.value, wf.macro.outputs.eight.value)"
    ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "NOT_DATA NOT_DATA\n",
-      "5 5\n"
-     ]
-    }
-   ],
-   "execution_count": 62
+   "id": "a3157658a0635230"
   },
   {
    "cell_type": "markdown",

--- a/tests/unit/test_channels.py
+++ b/tests/unit/test_channels.py
@@ -35,7 +35,7 @@ class DummyParent:
 
 
 class DummyOwner:
-    def __init__(self, parent: DummyParent, label: str):
+    def __init__(self, parent: DummyParent | None, label: str):
         self.foo = [0]
         self.locked = False
         self.label = label
@@ -583,6 +583,43 @@ class TestSignalChannels(unittest.TestCase):
                     self.assertRaises(BadCallbackError),
                 ):
                     InputSignal(label="inp", owner=owner, callback=callback)
+
+
+class TestChannelParenting(unittest.TestCase):
+    def setUp(self) -> None:
+        self.p1 = DummyParent("parent_label1")
+        self.p2 = DummyParent("parent_label2")
+        self.owner1a = DummyOwner(self.p1, "owner1a")
+        self.owner1b = DummyOwner(self.p1, "owner1b")
+        self.owner2a = DummyOwner(self.p2, "owner2a")
+        self.owner_orphan1 = DummyOwner(None, "owner_orphan")
+        self.owner_orphan2 = DummyOwner(None, "owner_orphan")
+
+        self.inp1 = InputChannel(label="inp1a", owner=self.owner1a)
+        self.out2 = OutputChannel(label="out1b", owner=self.owner1b)
+        self.out_a = OutputChannel(label="out2a", owner=self.owner2a)
+        self.inp_orphan = InputChannel(label="inp_orphan", owner=self.owner_orphan1)
+        self.out_orphan = OutputChannel(label="out_orphan", owner=self.owner_orphan2)
+
+    def test_without_parents(self):
+        # Neither parented to start with
+        # Connection works fine
+        # Parent is still None for both at the end
+        pass
+
+    def test_parenting_an_orphan(self):
+        # Parented to None-parent connection, and vice versa
+        # Connection works fine
+        # None-parent adopts the parent of the parented owner at the end
+        pass
+
+    def test_same_parent(self):
+        # Works fine
+        pass
+
+    def test_different_parents(self):
+        # Raises exception
+        pass
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_io.py
+++ b/tests/unit/test_io.py
@@ -16,6 +16,7 @@ class Dummy:
         self._inputs = Inputs()
         self._outputs = Outputs()
         self._locked = False
+        self.parent = None
 
     @property
     def inputs(self) -> Inputs:


### PR DESCRIPTION
Enforce the exclusive connection of nodes with the same (or `None`) parent.

This was always the intent. In order facilitate passing connections (but not a `parent=`) at instantiation time, when connections are made from a parented node to an orphan node, the orphan gets its counterpart's parent. This results in one gross side effect: making connections from an un-parented node to a node _inside_ a macro _after_ the macro has finished instantiating adds the un-parented node as a child of the macro! This has no functional impact since the execution graph of the macro is not updated post-instantiation, so that node just sits there taking up memory, but it is still sub-optimal.

Closes #587 