### PR TITLE
Update for changes in `semantikon`

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - python >=3.11,<3.14
 - python-graphviz =0.21
 - rdflib =7.1.4
-- semantikon =0.0.22
+- semantikon =0.0.23
 - setuptools>=68
 - toposort =1.10
 - typeguard =4.4.4

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -12,7 +12,7 @@ dependencies:
 - python >=3.11,<3.14
 - python-graphviz =0.21
 - rdflib =7.1.4
-- semantikon =0.0.22
+- semantikon =0.0.23
 - setuptools>=68
 - toposort =1.10
 - typeguard =4.4.4

--- a/.ci_support/lower_bound.yml
+++ b/.ci_support/lower_bound.yml
@@ -14,6 +14,6 @@ dependencies:
 - pyiron_snippets =0.1.4
 - python-graphviz =0.20.3
 - rdflib =7.1.4
-- semantikon =0.0.22
+- semantikon =0.0.23
 - toposort =1.10
 - typeguard =4.2.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,7 +18,7 @@ dependencies:
 - python >=3.11,<3.14
 - python-graphviz =0.21
 - rdflib =7.1.4
-- semantikon =0.0.22
+- semantikon =0.0.23
 - setuptools>=68
 - toposort =1.10
 - typeguard =4.4.4

--- a/notebooks/ontological_workflows.ipynb
+++ b/notebooks/ontological_workflows.ipynb
@@ -27,8 +27,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:22.795557Z",
-     "start_time": "2025-09-04T20:32:22.171053Z"
+     "end_time": "2025-09-12T15:17:55.850601Z",
+     "start_time": "2025-09-12T15:17:55.840634Z"
     }
    },
    "cell_type": "code",
@@ -79,7 +79,7 @@
    ],
    "id": "996ce3d6152f1beb",
    "outputs": [],
-   "execution_count": 1
+   "execution_count": 28
   },
   {
    "metadata": {},
@@ -94,8 +94,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:23.633454Z",
-     "start_time": "2025-09-04T20:32:22.800111Z"
+     "end_time": "2025-09-12T15:17:55.990573Z",
+     "start_time": "2025-09-12T15:17:55.855512Z"
     }
    },
    "cell_type": "code",
@@ -113,12 +113,12 @@
        "{'eat__verdict': 'Yummy Meal pizza'}"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 2
+   "execution_count": 29
   },
   {
    "metadata": {},
@@ -133,8 +133,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:23.695871Z",
-     "start_time": "2025-09-04T20:32:23.691903Z"
+     "end_time": "2025-09-12T15:17:55.998798Z",
+     "start_time": "2025-09-12T15:17:55.995091Z"
     }
    },
    "cell_type": "code",
@@ -154,11 +154,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/no_type encountered error in child: {'/no_type/eat.accumulate_and_run': TypeError(\"The channel /no_type/eat.meal cannot take the value `<__main__.Garbage object at 0x13fe89070>` (<class '__main__.Garbage'>) because it is not compliant with the type hint typing.Annotated[__main__.Meal, ('uri', rdflib.term.URIRef('http://www.example.org/Pizza'))]\")}\n"
+      "/no_type encountered error in child: {'/no_type/eat.accumulate_and_run': TypeError(\"The channel /no_type/eat.meal cannot take the value `<__main__.Garbage object at 0x132838950>` (<class '__main__.Garbage'>) because it is not compliant with the type hint typing.Annotated[__main__.Meal, ('uri', rdflib.term.URIRef('http://www.example.org/Pizza'))]\")}\n"
      ]
     }
    ],
-   "execution_count": 3
+   "execution_count": 30
   },
   {
    "metadata": {},
@@ -173,8 +173,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:23.708422Z",
-     "start_time": "2025-09-04T20:32:23.704193Z"
+     "end_time": "2025-09-12T15:17:56.024027Z",
+     "start_time": "2025-09-12T15:17:56.020676Z"
     }
    },
    "cell_type": "code",
@@ -196,7 +196,7 @@
      ]
     }
    ],
-   "execution_count": 4
+   "execution_count": 31
   },
   {
    "metadata": {},
@@ -217,8 +217,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:23.717957Z",
-     "start_time": "2025-09-04T20:32:23.714207Z"
+     "end_time": "2025-09-12T15:17:56.040728Z",
+     "start_time": "2025-09-12T15:17:56.036621Z"
     }
    },
    "cell_type": "code",
@@ -236,12 +236,12 @@
        "{'eat__verdict': 'Yummy Meal pizza'}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 5
+   "execution_count": 32
   },
   {
    "metadata": {},
@@ -256,8 +256,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:23.766856Z",
-     "start_time": "2025-09-04T20:32:23.724845Z"
+     "end_time": "2025-09-12T15:17:56.125043Z",
+     "start_time": "2025-09-12T15:17:56.057272Z"
     }
    },
    "cell_type": "code",
@@ -276,11 +276,11 @@
      "output_type": "stream",
      "text": [
       "The upstream channel /failed_ontology/make.rice cannot connect to the downstream channel /failed_ontology/eat_pizza.meal because the upstream type hint (typing.Annotated[__main__.Meal, ('uri', rdflib.term.URIRef('http://www.example.org/Rice'))]) and downstream type hint (typing.Annotated[__main__.Meal, ('uri', rdflib.term.URIRef('http://www.example.org/Pizza'))]) produce a non-empty ontological validation report:\n",
-      "{'missing_triples': [], 'incompatible_connections': [(rdflib.term.URIRef('failed_ontology.eat_pizza.inputs.meal'), rdflib.term.URIRef('failed_ontology.make.outputs.rice'), [rdflib.term.URIRef('http://www.example.org/Pizza'), rdflib.term.URIRef('http://www.example.org/Rice')], [rdflib.term.URIRef('http://www.example.org/Rice')])], 'distinct_units': {}}\n"
+      "{'missing_triples': [], 'incompatible_connections': [(rdflib.term.URIRef('failed_ontology.eat_pizza.inputs.meal'), rdflib.term.URIRef('failed_ontology.make.outputs.rice'), [rdflib.term.URIRef('http://www.example.org/Pizza')], [rdflib.term.URIRef('http://www.example.org/Rice')])], 'distinct_units': {}}\n"
      ]
     }
    ],
-   "execution_count": 6
+   "execution_count": 33
   },
   {
    "metadata": {},
@@ -295,8 +295,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:23.812357Z",
-     "start_time": "2025-09-04T20:32:23.772125Z"
+     "end_time": "2025-09-12T15:17:56.209281Z",
+     "start_time": "2025-09-12T15:17:56.142961Z"
     }
    },
    "cell_type": "code",
@@ -315,11 +315,11 @@
      "output_type": "stream",
      "text": [
       "The upstream channel /relaxed_ontology/make.rice cannot connect to the downstream channel /relaxed_ontology/eat.meal because the upstream type hint (typing.Annotated[__main__.Meal, ('uri', rdflib.term.URIRef('http://www.example.org/Rice'))]) and downstream type hint (typing.Annotated[__main__.Meal, ('uri', rdflib.term.URIRef('http://www.example.org/Meal'))]) produce a non-empty ontological validation report:\n",
-      "{'missing_triples': [], 'incompatible_connections': [(rdflib.term.URIRef('relaxed_ontology.eat.inputs.meal'), rdflib.term.URIRef('relaxed_ontology.make.outputs.rice'), [rdflib.term.URIRef('http://www.example.org/Meal'), rdflib.term.URIRef('http://www.example.org/Rice')], [rdflib.term.URIRef('http://www.example.org/Rice')])], 'distinct_units': {}}\n"
+      "{'missing_triples': [], 'incompatible_connections': [(rdflib.term.URIRef('relaxed_ontology.eat.inputs.meal'), rdflib.term.URIRef('relaxed_ontology.make.outputs.rice'), [rdflib.term.URIRef('http://www.example.org/Meal')], [rdflib.term.URIRef('http://www.example.org/Rice')])], 'distinct_units': {}}\n"
      ]
     }
    ],
-   "execution_count": 7
+   "execution_count": 34
   },
   {
    "metadata": {},
@@ -334,8 +334,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:23.886198Z",
-     "start_time": "2025-09-04T20:32:23.815872Z"
+     "end_time": "2025-09-12T15:17:56.332796Z",
+     "start_time": "2025-09-12T15:17:56.213505Z"
     }
    },
    "cell_type": "code",
@@ -357,12 +357,12 @@
        "{'eat__verdict': 'Yummy Meal meal'}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 8
+   "execution_count": 35
   },
   {
    "metadata": {},
@@ -377,8 +377,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:23.896847Z",
-     "start_time": "2025-09-04T20:32:23.889463Z"
+     "end_time": "2025-09-12T15:17:56.342201Z",
+     "start_time": "2025-09-12T15:17:56.335705Z"
     }
    },
    "cell_type": "code",
@@ -424,7 +424,7 @@
    ],
    "id": "dceaab6f57226f07",
    "outputs": [],
-   "execution_count": 9
+   "execution_count": 36
   },
   {
    "metadata": {},
@@ -441,8 +441,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:24.161793Z",
-     "start_time": "2025-09-04T20:32:23.900061Z"
+     "end_time": "2025-09-12T15:17:56.752725Z",
+     "start_time": "2025-09-12T15:17:56.349889Z"
     }
    },
    "cell_type": "code",
@@ -461,12 +461,12 @@
        "{'money__price': 10}"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 10
+   "execution_count": 37
   },
   {
    "metadata": {},
@@ -481,8 +481,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:24.441222Z",
-     "start_time": "2025-09-04T20:32:24.170811Z"
+     "end_time": "2025-09-12T15:17:57.215696Z",
+     "start_time": "2025-09-12T15:17:56.759043Z"
     }
    },
    "cell_type": "code",
@@ -505,12 +505,12 @@
        "{'money': 10}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 11
+   "execution_count": 38
   },
   {
    "metadata": {},
@@ -525,8 +525,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:24.498841Z",
-     "start_time": "2025-09-04T20:32:24.444620Z"
+     "end_time": "2025-09-12T15:17:57.303813Z",
+     "start_time": "2025-09-12T15:17:57.220611Z"
     }
    },
    "cell_type": "code",
@@ -544,12 +544,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The upstream channel /my_wrong_workflow/washed_clothes.clothes cannot connect to the downstream channel /my_wrong_workflow/sell.clothes because the upstream type hint (typing.Annotated[__main__.Clothes, ('triples', (rdflib.term.URIRef('http://www.example.org/hasProperty'), rdflib.term.URIRef('http://www.example.org/cleaned')), 'derived_from', 'inputs.clothes')]) and downstream type hint (typing.Annotated[__main__.Clothes, ('uri', rdflib.term.URIRef('http://www.example.org/Clothes'), 'restrictions', (((rdflib.term.URIRef('http://www.w3.org/2002/07/owl#onProperty'), rdflib.term.URIRef('http://www.example.org/hasProperty')), (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#someValuesFrom'), rdflib.term.URIRef('http://www.example.org/cleaned'))), ((rdflib.term.URIRef('http://www.w3.org/2002/07/owl#onProperty'), rdflib.term.URIRef('http://www.example.org/hasProperty')), (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#someValuesFrom'), rdflib.term.URIRef('http://www.example.org/color')))))]) produce a non-empty ontological validation report:\n",
+      "The upstream channel /my_wrong_workflow/washed_clothes.clothes cannot connect to the downstream channel /my_wrong_workflow/sell.clothes because the upstream type hint (typing.Annotated[__main__.Clothes, ('uri', rdflib.term.URIRef('http://www.example.org/Clothes'), 'triples', (rdflib.term.URIRef('http://www.example.org/hasProperty'), rdflib.term.URIRef('http://www.example.org/cleaned')), 'derived_from', 'inputs.clothes')]) and downstream type hint (typing.Annotated[__main__.Clothes, ('uri', rdflib.term.URIRef('http://www.example.org/Clothes'), 'restrictions', (((rdflib.term.URIRef('http://www.w3.org/2002/07/owl#onProperty'), rdflib.term.URIRef('http://www.example.org/hasProperty')), (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#someValuesFrom'), rdflib.term.URIRef('http://www.example.org/cleaned'))), ((rdflib.term.URIRef('http://www.w3.org/2002/07/owl#onProperty'), rdflib.term.URIRef('http://www.example.org/hasProperty')), (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#someValuesFrom'), rdflib.term.URIRef('http://www.example.org/color')))))]) produce a non-empty ontological validation report:\n",
       "{'missing_triples': [(rdflib.term.URIRef('my_wrong_workflow.sell.inputs.clothes'), rdflib.term.URIRef('http://www.example.org/hasProperty'), rdflib.term.URIRef('http://www.example.org/color'))], 'incompatible_connections': [], 'distinct_units': {}}\n"
      ]
     }
    ],
-   "execution_count": 12
+   "execution_count": 39
   },
   {
    "metadata": {},
@@ -566,8 +566,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:24.566973Z",
-     "start_time": "2025-09-04T20:32:24.508485Z"
+     "end_time": "2025-09-12T15:17:57.393224Z",
+     "start_time": "2025-09-12T15:17:57.308032Z"
     }
    },
    "cell_type": "code",
@@ -589,12 +589,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The upstream channel /my_wrong_macro/washed_clothes.clothes cannot connect to the downstream channel /my_wrong_macro/sell.clothes because the upstream type hint (typing.Annotated[__main__.Clothes, ('triples', (rdflib.term.URIRef('http://www.example.org/hasProperty'), rdflib.term.URIRef('http://www.example.org/cleaned')), 'derived_from', 'inputs.clothes')]) and downstream type hint (typing.Annotated[__main__.Clothes, ('uri', rdflib.term.URIRef('http://www.example.org/Clothes'), 'restrictions', (((rdflib.term.URIRef('http://www.w3.org/2002/07/owl#onProperty'), rdflib.term.URIRef('http://www.example.org/hasProperty')), (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#someValuesFrom'), rdflib.term.URIRef('http://www.example.org/cleaned'))), ((rdflib.term.URIRef('http://www.w3.org/2002/07/owl#onProperty'), rdflib.term.URIRef('http://www.example.org/hasProperty')), (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#someValuesFrom'), rdflib.term.URIRef('http://www.example.org/color')))))]) produce a non-empty ontological validation report:\n",
+      "The upstream channel /my_wrong_macro/washed_clothes.clothes cannot connect to the downstream channel /my_wrong_macro/sell.clothes because the upstream type hint (typing.Annotated[__main__.Clothes, ('uri', rdflib.term.URIRef('http://www.example.org/Clothes'), 'triples', (rdflib.term.URIRef('http://www.example.org/hasProperty'), rdflib.term.URIRef('http://www.example.org/cleaned')), 'derived_from', 'inputs.clothes')]) and downstream type hint (typing.Annotated[__main__.Clothes, ('uri', rdflib.term.URIRef('http://www.example.org/Clothes'), 'restrictions', (((rdflib.term.URIRef('http://www.w3.org/2002/07/owl#onProperty'), rdflib.term.URIRef('http://www.example.org/hasProperty')), (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#someValuesFrom'), rdflib.term.URIRef('http://www.example.org/cleaned'))), ((rdflib.term.URIRef('http://www.w3.org/2002/07/owl#onProperty'), rdflib.term.URIRef('http://www.example.org/hasProperty')), (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#someValuesFrom'), rdflib.term.URIRef('http://www.example.org/color')))))]) produce a non-empty ontological validation report:\n",
       "{'missing_triples': [(rdflib.term.URIRef('my_wrong_macro.sell.inputs.clothes'), rdflib.term.URIRef('http://www.example.org/hasProperty'), rdflib.term.URIRef('http://www.example.org/color'))], 'incompatible_connections': [], 'distinct_units': {}}\n"
      ]
     }
    ],
-   "execution_count": 13
+   "execution_count": 40
   },
   {
    "metadata": {},
@@ -609,8 +609,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:24.572923Z",
-     "start_time": "2025-09-04T20:32:24.570058Z"
+     "end_time": "2025-09-12T15:17:57.399302Z",
+     "start_time": "2025-09-12T15:17:57.396390Z"
     }
    },
    "cell_type": "code",
@@ -627,7 +627,7 @@
    ],
    "id": "3055fbc547280d91",
    "outputs": [],
-   "execution_count": 14
+   "execution_count": 41
   },
   {
    "metadata": {},
@@ -638,8 +638,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:24.659414Z",
-     "start_time": "2025-09-04T20:32:24.578908Z"
+     "end_time": "2025-09-12T15:17:57.496940Z",
+     "start_time": "2025-09-12T15:17:57.408824Z"
     }
    },
    "cell_type": "code",
@@ -658,12 +658,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The upstream channel /my_wf_with_cancellation/dyed_clothes.clothes cannot connect to the downstream channel /my_wf_with_cancellation/sell.clothes because the upstream type hint (typing.Annotated[__main__.Clothes, ('triples', (rdflib.term.URIRef('http://www.example.org/hasProperty'), rdflib.term.URIRef('http://www.example.org/color')), 'derived_from', 'inputs.clothes', 'extra', {'cancel': (rdflib.term.URIRef('http://www.example.org/hasProperty'), rdflib.term.URIRef('http://www.example.org/cleaned'))})]) and downstream type hint (typing.Annotated[__main__.Clothes, ('uri', rdflib.term.URIRef('http://www.example.org/Clothes'), 'restrictions', (((rdflib.term.URIRef('http://www.w3.org/2002/07/owl#onProperty'), rdflib.term.URIRef('http://www.example.org/hasProperty')), (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#someValuesFrom'), rdflib.term.URIRef('http://www.example.org/cleaned'))), ((rdflib.term.URIRef('http://www.w3.org/2002/07/owl#onProperty'), rdflib.term.URIRef('http://www.example.org/hasProperty')), (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#someValuesFrom'), rdflib.term.URIRef('http://www.example.org/color')))))]) produce a non-empty ontological validation report:\n",
+      "The upstream channel /my_wf_with_cancellation/dyed_clothes.clothes cannot connect to the downstream channel /my_wf_with_cancellation/sell.clothes because the upstream type hint (typing.Annotated[__main__.Clothes, ('uri', rdflib.term.URIRef('http://www.example.org/Clothes'), 'triples', (rdflib.term.URIRef('http://www.example.org/hasProperty'), rdflib.term.URIRef('http://www.example.org/color')), 'derived_from', 'inputs.clothes', 'extra', {'cancel': (rdflib.term.URIRef('http://www.example.org/hasProperty'), rdflib.term.URIRef('http://www.example.org/cleaned'))})]) and downstream type hint (typing.Annotated[__main__.Clothes, ('uri', rdflib.term.URIRef('http://www.example.org/Clothes'), 'restrictions', (((rdflib.term.URIRef('http://www.w3.org/2002/07/owl#onProperty'), rdflib.term.URIRef('http://www.example.org/hasProperty')), (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#someValuesFrom'), rdflib.term.URIRef('http://www.example.org/cleaned'))), ((rdflib.term.URIRef('http://www.w3.org/2002/07/owl#onProperty'), rdflib.term.URIRef('http://www.example.org/hasProperty')), (rdflib.term.URIRef('http://www.w3.org/2002/07/owl#someValuesFrom'), rdflib.term.URIRef('http://www.example.org/color')))))]) produce a non-empty ontological validation report:\n",
       "{'missing_triples': [(rdflib.term.URIRef('my_wf_with_cancellation.sell.inputs.clothes'), rdflib.term.URIRef('http://www.example.org/hasProperty'), rdflib.term.URIRef('http://www.example.org/cleaned'))], 'incompatible_connections': [], 'distinct_units': {}}\n"
      ]
     }
    ],
-   "execution_count": 15
+   "execution_count": 42
   },
   {
    "metadata": {},
@@ -678,8 +678,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:24.668308Z",
-     "start_time": "2025-09-04T20:32:24.662811Z"
+     "end_time": "2025-09-12T15:17:57.506378Z",
+     "start_time": "2025-09-12T15:17:57.500847Z"
     }
    },
    "cell_type": "code",
@@ -699,12 +699,12 @@
        "{'money__price': 10}"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 16
+   "execution_count": 43
   },
   {
    "metadata": {},
@@ -719,8 +719,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:24.717709Z",
-     "start_time": "2025-09-04T20:32:24.675991Z"
+     "end_time": "2025-09-12T15:17:57.593370Z",
+     "start_time": "2025-09-12T15:17:57.521877Z"
     }
    },
    "cell_type": "code",
@@ -742,7 +742,7 @@
      ]
     }
    ],
-   "execution_count": 17
+   "execution_count": 44
   },
   {
    "metadata": {},
@@ -753,8 +753,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:24.764227Z",
-     "start_time": "2025-09-04T20:32:24.721407Z"
+     "end_time": "2025-09-12T15:17:57.673606Z",
+     "start_time": "2025-09-12T15:17:57.600956Z"
     }
    },
    "cell_type": "code",
@@ -767,12 +767,12 @@
        "[__main__.prepare_pizza]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 18
+   "execution_count": 45
   },
   {
    "metadata": {},
@@ -787,8 +787,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:24.773883Z",
-     "start_time": "2025-09-04T20:32:24.767569Z"
+     "end_time": "2025-09-12T15:17:57.685801Z",
+     "start_time": "2025-09-12T15:17:57.678728Z"
     }
    },
    "cell_type": "code",
@@ -807,12 +807,12 @@
        "[]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 19
+   "execution_count": 46
   },
   {
    "metadata": {},
@@ -823,8 +823,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:24.958865Z",
-     "start_time": "2025-09-04T20:32:24.779408Z"
+     "end_time": "2025-09-12T15:17:57.956281Z",
+     "start_time": "2025-09-12T15:17:57.693531Z"
     }
    },
    "cell_type": "code",
@@ -841,12 +841,12 @@
        "[__main__.wash, __main__.dye, __main__.dye_with_cancel]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 20
+   "execution_count": 47
   },
   {
    "metadata": {},
@@ -857,8 +857,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:25.296602Z",
-     "start_time": "2025-09-04T20:32:24.962807Z"
+     "end_time": "2025-09-12T15:17:58.545855Z",
+     "start_time": "2025-09-12T15:17:57.961545Z"
     }
    },
    "cell_type": "code",
@@ -880,7 +880,7 @@
      ]
     }
    ],
-   "execution_count": 21
+   "execution_count": 48
   },
   {
    "metadata": {},
@@ -891,8 +891,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:25.388366Z",
-     "start_time": "2025-09-04T20:32:25.312200Z"
+     "end_time": "2025-09-12T15:17:58.648898Z",
+     "start_time": "2025-09-12T15:17:58.551401Z"
     }
    },
    "cell_type": "code",
@@ -944,15 +944,16 @@
     {
      "data": {
       "text/plain": [
-       "[]"
+       "[(<__main__.TakesDownstream at 0x132987350>,\n",
+       "  <pyiron_workflow.channels.InputData at 0x132986420>)]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 22
+   "execution_count": 49
   },
   {
    "metadata": {},
@@ -967,8 +968,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:28.168211Z",
-     "start_time": "2025-09-04T20:32:25.627729Z"
+     "end_time": "2025-09-12T15:18:02.119036Z",
+     "start_time": "2025-09-12T15:17:58.666670Z"
     }
    },
    "cell_type": "code",
@@ -1034,26 +1035,18 @@
    "id": "d3bfd2d5b856d187",
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/liamhuber/dev/pyiron/semantikon/semantikon/ontology.py:48: FutureWarning: semantikon_class is experimental - triples may change in the future\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
        "{'platter__contents': ['jam', 'honey', 'butter'],\n",
        " 'platter__lunch': ['jam sandwich', 'honey sandwich', 'butter sandwich']}"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 24
+   "execution_count": 50
   },
   {
    "metadata": {},
@@ -1070,8 +1063,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:28.276798Z",
-     "start_time": "2025-09-04T20:32:28.191943Z"
+     "end_time": "2025-09-12T15:18:02.276165Z",
+     "start_time": "2025-09-12T15:18:02.139675Z"
     }
    },
    "cell_type": "code",
@@ -1093,7 +1086,7 @@
    ],
    "id": "7fa30c5bb66141ee",
    "outputs": [],
-   "execution_count": 25
+   "execution_count": 51
   },
   {
    "metadata": {},
@@ -1104,8 +1097,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:28.327523Z",
-     "start_time": "2025-09-04T20:32:28.281527Z"
+     "end_time": "2025-09-12T15:18:02.353940Z",
+     "start_time": "2025-09-12T15:18:02.280458Z"
     }
    },
    "cell_type": "code",
@@ -1132,7 +1125,7 @@
      ]
     }
    ],
-   "execution_count": 26
+   "execution_count": 52
   },
   {
    "metadata": {},
@@ -1143,8 +1136,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:28.424358Z",
-     "start_time": "2025-09-04T20:32:28.336554Z"
+     "end_time": "2025-09-12T15:18:02.507222Z",
+     "start_time": "2025-09-12T15:18:02.365891Z"
     }
    },
    "cell_type": "code",
@@ -1165,12 +1158,12 @@
        "{'speed__s': 10.0}"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 27
+   "execution_count": 53
   },
   {
    "metadata": {},
@@ -1197,8 +1190,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:28.433508Z",
-     "start_time": "2025-09-04T20:32:28.431929Z"
+     "end_time": "2025-09-12T15:18:02.520567Z",
+     "start_time": "2025-09-12T15:18:02.519351Z"
     }
    },
    "cell_type": "code",

--- a/notebooks/ontological_workflows.ipynb
+++ b/notebooks/ontological_workflows.ipynb
@@ -375,12 +375,6 @@
    "id": "574ac2f3813504ca"
   },
   {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": "",
-   "id": "69923a637cd8bc00"
-  },
-  {
    "metadata": {
     "ExecuteTime": {
      "end_time": "2025-09-12T15:17:56.342201Z",

--- a/notebooks/ontological_workflows.ipynb
+++ b/notebooks/ontological_workflows.ipynb
@@ -632,7 +632,7 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "We fail, as expected. The error messages for failed ontology validations are still extremely opaque, but we can see that the upstream node `'cancel'`s the `.../cleaned` property, while the downstream type hint still requires `#someValuesFrom` `.../cleaned`.",
+   "source": "We fail, as expected. The error messages for failed ontology validations are still extremely opaque, but we can see that the upstream node `'cancel'`s the `.../cleaned` property, while the downstream type hint still requires `hasProperty` `cleaned`.",
    "id": "599404a35b15ef6b"
   },
   {

--- a/notebooks/ontological_workflows.ipynb
+++ b/notebooks/ontological_workflows.ipynb
@@ -391,6 +391,7 @@
     "@pwf.as_function_node\n",
     "def wash(clothes: u(Clothes, uri=EX.Clothes)) -> u(\n",
     "    Clothes,\n",
+    "    uri=EX.Clothes,\n",
     "    triples=(EX.hasProperty, EX.cleaned),\n",
     "    derived_from=\"inputs.clothes\"\n",
     "):\n",
@@ -400,6 +401,7 @@
     "@pwf.as_function_node\n",
     "def dye(clothes: u(Clothes, uri=EX.Clothes), color=\"blue\") -> u(\n",
     "    Clothes,\n",
+    "    uri=EX.Clothes,\n",
     "    triples=(EX.hasProperty, EX.color),\n",
     "    derived_from=\"inputs.clothes\",\n",
     "):\n",
@@ -616,8 +618,9 @@
     "@pwf.as_function_node\n",
     "def dye_with_cancel(clothes: Clothes, color=\"blue\") -> u(\n",
     "    Clothes,\n",
-    "    triples=(EX.hasProperty, EX.color),\n",
+    "    uri=EX.Clothes,\n",
     "    derived_from=\"inputs.clothes\",\n",
+    "    triples=(EX.hasProperty, EX.color),\n",
     "    cancel=(EX.hasProperty, EX.cleaned)\n",
     "):\n",
     "    return clothes"
@@ -882,7 +885,7 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "There is also one sneaky edge case where it _looks_ like a given node fulfills certain requirements, but because of the interaction of `derived_from` and inherited `requirements` in `semantikon` (Cf. [this issue](https://github.com/pyiron/semantikon/issues/262)), we can fail to find a suggestion we might expect to be there:",
+   "source": "Note that inter-node connections do _not_ cause restrictions to propagate. Nicely, that means that if we have a node guarnateeing our immediate demands, we can get suggestions for it, even if it would itself introduce new demands. See below, where the middle node `GivesAndTakes` promises to fulfill the requirements of `TakesDownstream` even though it has its own needs:",
    "id": "38b026f5e536acdb"
   },
   {
@@ -910,6 +913,7 @@
     "    ),\n",
     ") -> u(\n",
     "    str,\n",
+    "    uri=EX.Data,\n",
     "    derived_from=\"inputs.y\",\n",
     "    triples=(EX.has, EX.Downstream)\n",
     "):\n",
@@ -1013,7 +1017,12 @@
     "@pwf.as_function_node\n",
     "def ItsStuck(\n",
     "    jar: u(Jar.dataclass, uri=EX.Jar)\n",
-    ") -> u(Jar.dataclass, derived_from=\"inputs.jar\", triples=(EX.lidState, EX.stuck)):\n",
+    ") -> u(\n",
+    "        Jar.dataclass,\n",
+    "        uri=EX.Jar,\n",
+    "        derived_from=\"inputs.jar\",\n",
+    "        triples=(EX.lidState, EX.stuck)\n",
+    "):\n",
     "    return jar\n",
     "\n",
     "@pwf.as_function_node\n",
@@ -1200,7 +1209,7 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "(Note that inheriting units with `derived_from=` in the annotation is not currently working like other ontological properties: https://github.com/pyiron/semantikon/issues/256)",
+   "source": "Note that units are not inherited when `derived_from=` is used in the annotation; this is to easily allow for unit-converting nodes.",
    "id": "dafffcc1823b711f"
   },
   {

--- a/notebooks/ontological_workflows.ipynb
+++ b/notebooks/ontological_workflows.ipynb
@@ -957,40 +957,6 @@
   {
    "metadata": {},
    "cell_type": "markdown",
-   "source": "If we first supply the middle node with its needs in the live graph, we'll get the expected downstream input as a suggestion:",
-   "id": "60aa5cd26788b1ae"
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2025-09-04T20:32:25.614018Z",
-     "start_time": "2025-09-04T20:32:25.401642Z"
-    }
-   },
-   "cell_type": "code",
-   "source": [
-    "wf.middle.inputs.y = wf.up\n",
-    "suggest.suggest_connections(wf.middle.outputs.y)"
-   ],
-   "id": "3f288e5a3d1faa9e",
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[(<__main__.TakesDownstream at 0x13f7c1b20>,\n",
-       "  <pyiron_workflow.channels.InputData at 0x13f769a90>)]"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "execution_count": 23
-  },
-  {
-   "metadata": {},
-   "cell_type": "markdown",
    "source": [
     "## Complex workflows\n",
     "\n",

--- a/notebooks/ontological_workflows.ipynb
+++ b/notebooks/ontological_workflows.ipynb
@@ -370,9 +370,15 @@
    "source": [
     "# Ontological triples\n",
     "\n",
-    "Alright, for our simple pizza example things are working beautifully. Let's try it with the clothes example."
+    "Alright, for our simple pizza example things are working beautifully. Let's try it with the clothes example. Note that the `derived_from` annotation does not cause the `uri` annotation to be inherited, so even when we derive our output from our input, we re-state the URI."
    ],
    "id": "574ac2f3813504ca"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "",
+   "id": "69923a637cd8bc00"
   },
   {
    "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "pint==0.25",
     "pyiron_snippets==0.2.0",
     "rdflib==7.1.4",
-    "semantikon==0.0.22",
+    "semantikon==0.0.23",
     "toposort==1.10",
     "typeguard==4.4.4",
 ]

--- a/tests/unit/test_knowledge.py
+++ b/tests/unit/test_knowledge.py
@@ -397,7 +397,12 @@ class Clothes:
 @pwf.as_function_node
 def Wash(
     clothes: u(Clothes, uri=EX.Clothes),
-) -> u(Clothes, triples=(EX.hasProperty, EX.cleaned), derived_from="inputs.clothes"):
+) -> u(
+    Clothes,
+    uri=EX.Clothes,
+    triples=(EX.hasProperty, EX.cleaned),
+    derived_from="inputs.clothes",
+):
     ...
     return clothes
 
@@ -405,8 +410,9 @@ def Wash(
 @pwf.as_function_node
 def Dye(clothes: u(Clothes, uri=EX.Clothes), color="blue") -> u(
     Clothes,
-    triples=(EX.hasProperty, EX.color),
+    uri=EX.Clothes,
     derived_from="inputs.clothes",
+    triples=(EX.hasProperty, EX.color),
 ):
     ...
     return clothes
@@ -436,8 +442,9 @@ def Sell(
 @pwf.as_function_node
 def DyeWithCancel(clothes: Clothes, color="blue") -> u(
     Clothes,
-    triples=(EX.hasProperty, EX.color),
+    uri=EX.Clothes,
     derived_from="inputs.clothes",
+    triples=(EX.hasProperty, EX.color),
     cancel=(EX.hasProperty, EX.cleaned),
 ):
     return clothes


### PR DESCRIPTION
In https://github.com/pyiron/semantikon/pull/266, inheritance of `uri=` is removed when `derived_from=`, and the bug of inheriting `restrictions=` on connections is resolved. Here I make the small adjustments necessary to stay up-to-date with that.

Pending the next `semantikon` release.