### PR TITLE
Use `NotData` from `flowrep`

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -5,6 +5,7 @@ dependencies:
 - bidict =0.23.1
 - cloudpickle =3.1.2
 - executorlib =1.9.2
+- flowrep =0.4.1
 - graphviz =9.0.0
 - hatchling =1.29.0
 - hatch-vcs =0.5.0

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -5,6 +5,7 @@ dependencies:
 - bidict =0.23.1
 - cloudpickle =3.1.2
 - executorlib =1.9.2
+- flowrep =0.4.1
 - graphviz =9.0.0
 - hatchling =1.29.0
 - hatch-vcs =0.5.0

--- a/.ci_support/lower_bound.yml
+++ b/.ci_support/lower_bound.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
 - coveralls
 - coverage
-- bagofholding =0.1.0
+- bagofholding =0.1.11
 - bidict =0.23.1
 - cloudpickle =3.0.0
 - executorlib =1.5.3
@@ -14,7 +14,7 @@ dependencies:
 - pandas =2.2.2
 - pint =0.24
 - python =3.11
-- pyiron_snippets =0.1.4
+- pyiron_snippets =1.2.1
 - python-graphviz =0.20.3
 - rdflib =7.1.4
 - semantikon =0.0.22

--- a/.ci_support/lower_bound.yml
+++ b/.ci_support/lower_bound.yml
@@ -7,6 +7,7 @@ dependencies:
 - bidict =0.23.1
 - cloudpickle =3.0.0
 - executorlib =1.5.3
+- flowrep =0.4.1
 - graphviz =9.0.0
 - hatchling =1.27.0
 - hatch-vcs =0.5.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,6 +11,7 @@ dependencies:
 - bidict =0.23.1
 - cloudpickle =3.1.2
 - executorlib =1.9.2
+- flowrep =0.4.1
 - graphviz =9.0.0
 - hatchling =1.29.0
 - hatch-vcs =0.5.0

--- a/pyiron_workflow/data.py
+++ b/pyiron_workflow/data.py
@@ -2,30 +2,8 @@ from __future__ import annotations
 
 import dataclasses
 
-from pyiron_snippets.singleton import Singleton
-
-
-class NotData(metaclass=Singleton):
-    """
-    This class exists purely to initialize data channel values where no default value
-    is provided; it lets the channel know that it has _no data in it_ and thus should
-    not identify as ready.
-    """
-
-    @classmethod
-    def __repr__(cls):
-        # We use the class directly (not instances of it) where there is not yet data
-        # So give it a decent repr, even as just a class
-        return "NOT_DATA"
-
-    def __reduce__(self):
-        return "NOT_DATA"
-
-    def __bool__(self):
-        return False
-
-
-NOT_DATA = NotData()
+from flowrep.api.schemas import NOT_DATA as NOT_DATA
+from flowrep.api.schemas import NotData as NotData
 
 
 @dataclasses.dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "bidict==0.23.1",
     "cloudpickle==3.1.2",
     "executorlib==1.9.2",
+    "flowrep==0.4.1",
     "graphviz==0.21",
     "pandas==3.0.1",
     "pint==0.25",


### PR DESCRIPTION
This is a shallow need for the dependency, but the plan is to concretely depend on flowrep much more heavily. In the meantime, this avoids duplicating the concept of `NotData`.