### PR TITLE
Dataclass decorator

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - bidict =0.23.1
 - cloudpickle =3.1.2
 - executorlib =1.9.3
-- flowrep =0.5.1
+- flowrep =0.5.2
 - graphviz =12.2.1
 - hatchling =1.29.0
 - hatch-vcs =0.5.0

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -16,7 +16,7 @@ dependencies:
 - python >=3.11,<3.14
 - python-graphviz =0.21
 - rdflib =7.6.0
-- semantikon =1.3.1
+- semantikon =1.3.2
 - toposort =1.10
 - typeguard =4.5.2
 - python-workflow-definition =0.1.5

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - bidict =0.23.1
 - cloudpickle =3.1.2
 - executorlib =1.9.3
-- flowrep =0.5.1
+- flowrep =0.5.2
 - graphviz =12.2.1
 - hatchling =1.29.0
 - hatch-vcs =0.5.0

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -16,6 +16,6 @@ dependencies:
 - python >=3.11,<3.14
 - python-graphviz =0.21
 - rdflib =7.6.0
-- semantikon =1.3.1
+- semantikon =1.3.2
 - toposort =1.10
 - typeguard =4.5.2

--- a/.ci_support/lower_bound.yml
+++ b/.ci_support/lower_bound.yml
@@ -18,6 +18,6 @@ dependencies:
 - pyiron_snippets =1.3.0
 - python-graphviz =0.20.3
 - rdflib =7.1.4
-- semantikon =1.3.1
+- semantikon =1.3.2
 - toposort =1.10
 - typeguard =4.2.0

--- a/.ci_support/lower_bound.yml
+++ b/.ci_support/lower_bound.yml
@@ -7,7 +7,7 @@ dependencies:
 - bidict =0.23.1
 - cloudpickle =3.0.0
 - executorlib =1.5.3
-- flowrep =0.5.1
+- flowrep =0.5.2
 - graphviz =12.2.1
 - hatchling =1.27.0
 - hatch-vcs =0.5.0

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -22,7 +22,7 @@ dependencies:
 - python >=3.11,<3.14
 - python-graphviz =0.21
 - rdflib =7.6.0
-- semantikon =1.3.1
+- semantikon =1.3.2
 - toposort =1.10
 - typeguard =4.5.2
 - python-workflow-definition =0.1.5

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,7 +11,7 @@ dependencies:
 - bidict =0.23.1
 - cloudpickle =3.1.2
 - executorlib =1.9.3
-- flowrep =0.5.1
+- flowrep =0.5.2
 - graphviz =12.2.1
 - hatchling =1.29.0
 - hatch-vcs =0.5.0

--- a/notebooks/_wfms.ipynb
+++ b/notebooks/_wfms.ipynb
@@ -44,8 +44,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:29.209212Z",
-     "start_time": "2026-06-19T19:56:28.885628Z"
+     "end_time": "2026-06-23T05:06:11.580234Z",
+     "start_time": "2026-06-23T05:06:11.309603Z"
     }
    },
    "source": [
@@ -80,8 +80,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:29.290823Z",
-     "start_time": "2026-06-19T19:56:29.226121Z"
+     "end_time": "2026-06-23T05:06:11.607746Z",
+     "start_time": "2026-06-23T05:06:11.581960Z"
     }
    },
    "source": "mul.flowrep_recipe.model_dump(mode=\"json\")",
@@ -125,8 +125,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:30.836049Z",
-     "start_time": "2026-06-19T19:56:29.306393Z"
+     "end_time": "2026-06-23T05:06:13.139074Z",
+     "start_time": "2026-06-23T05:06:11.620084Z"
     }
    },
    "cell_type": "code",
@@ -141,8 +141,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:30.880218Z",
-     "start_time": "2026-06-19T19:56:30.850768Z"
+     "end_time": "2026-06-23T05:06:13.179827Z",
+     "start_time": "2026-06-23T05:06:13.154021Z"
     }
    },
    "source": [
@@ -196,8 +196,8 @@
    "id": "b8a1c76c",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:30.904754Z",
-     "start_time": "2026-06-19T19:56:30.890483Z"
+     "end_time": "2026-06-23T05:06:13.202868Z",
+     "start_time": "2026-06-23T05:06:13.189399Z"
     }
    },
    "source": [
@@ -213,8 +213,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:30.914193Z",
-     "start_time": "2026-06-19T19:56:30.906302Z"
+     "end_time": "2026-06-23T05:06:13.211559Z",
+     "start_time": "2026-06-23T05:06:13.204278Z"
     }
    },
    "source": [
@@ -230,7 +230,7 @@
      "text": [
       "status:   finished\n",
       "outputs:  {'shifted': 11}\n",
-      "duration: 0:00:00.000604\n",
+      "duration: 0:00:00.000669\n",
       "steps:    ['mul_0', 'add_0']\n"
      ]
     }
@@ -246,8 +246,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:30.939440Z",
-     "start_time": "2026-06-19T19:56:30.924394Z"
+     "end_time": "2026-06-23T05:06:13.234752Z",
+     "start_time": "2026-06-23T05:06:13.220998Z"
     }
    },
    "cell_type": "code",
@@ -271,8 +271,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:30.988015Z",
-     "start_time": "2026-06-19T19:56:30.952633Z"
+     "end_time": "2026-06-23T05:06:13.258051Z",
+     "start_time": "2026-06-23T05:06:13.244924Z"
     }
    },
    "cell_type": "code",
@@ -310,8 +310,8 @@
    "id": "564944f4",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:31.040699Z",
-     "start_time": "2026-06-19T19:56:30.989868Z"
+     "end_time": "2026-06-23T05:06:13.319901Z",
+     "start_time": "2026-06-23T05:06:13.268677Z"
     }
    },
    "source": [
@@ -327,8 +327,8 @@
    "id": "2d89bee2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:31.069121Z",
-     "start_time": "2026-06-19T19:56:31.041508Z"
+     "end_time": "2026-06-23T05:06:13.331829Z",
+     "start_time": "2026-06-23T05:06:13.321329Z"
     }
    },
    "source": [
@@ -346,8 +346,8 @@
    "id": "cd94d762",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:31.077608Z",
-     "start_time": "2026-06-19T19:56:31.069725Z"
+     "end_time": "2026-06-23T05:06:13.353642Z",
+     "start_time": "2026-06-23T05:06:13.340413Z"
     }
    },
    "source": "print(\"one-shot run:\", increment.pwf.run(x=4).outputs[\"output_0\"])",
@@ -368,8 +368,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:31.104652Z",
-     "start_time": "2026-06-19T19:56:31.089263Z"
+     "end_time": "2026-06-23T05:06:13.389164Z",
+     "start_time": "2026-06-23T05:06:13.363394Z"
     }
    },
    "source": [
@@ -429,8 +429,8 @@
    "id": "5a595873",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:31.148894Z",
-     "start_time": "2026-06-19T19:56:31.118224Z"
+     "end_time": "2026-06-23T05:06:13.427384Z",
+     "start_time": "2026-06-23T05:06:13.400272Z"
     }
    },
    "source": [
@@ -477,8 +477,8 @@
    "id": "1ad7570e",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:31.178722Z",
-     "start_time": "2026-06-19T19:56:31.150424Z"
+     "end_time": "2026-06-23T05:06:13.445739Z",
+     "start_time": "2026-06-23T05:06:13.429008Z"
     }
    },
    "source": [
@@ -531,8 +531,8 @@
    "id": "4910bdc7",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:31.201074Z",
-     "start_time": "2026-06-19T19:56:31.189769Z"
+     "end_time": "2026-06-23T05:06:13.477124Z",
+     "start_time": "2026-06-23T05:06:13.456707Z"
     }
    },
    "source": [
@@ -567,8 +567,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:31.228966Z",
-     "start_time": "2026-06-19T19:56:31.212391Z"
+     "end_time": "2026-06-23T05:06:13.521353Z",
+     "start_time": "2026-06-23T05:06:13.488611Z"
     }
    },
    "source": [
@@ -598,8 +598,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:31.260796Z",
-     "start_time": "2026-06-19T19:56:31.243488Z"
+     "end_time": "2026-06-23T05:06:13.588208Z",
+     "start_time": "2026-06-23T05:06:13.559264Z"
     }
    },
    "cell_type": "code",
@@ -631,8 +631,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:31.288810Z",
-     "start_time": "2026-06-19T19:56:31.271976Z"
+     "end_time": "2026-06-23T05:06:13.620656Z",
+     "start_time": "2026-06-23T05:06:13.600633Z"
     }
    },
    "cell_type": "code",
@@ -666,8 +666,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:31.331360Z",
-     "start_time": "2026-06-19T19:56:31.302533Z"
+     "end_time": "2026-06-23T05:06:13.652124Z",
+     "start_time": "2026-06-23T05:06:13.622359Z"
     }
    },
    "cell_type": "code",
@@ -714,8 +714,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:31.748840Z",
-     "start_time": "2026-06-19T19:56:31.333040Z"
+     "end_time": "2026-06-23T05:06:14.071347Z",
+     "start_time": "2026-06-23T05:06:13.653717Z"
     }
    },
    "cell_type": "code",
@@ -748,7 +748,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.405816\n"
+      "0.408\n"
      ]
     }
    ],
@@ -768,8 +768,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:32.825730Z",
-     "start_time": "2026-06-19T19:56:31.753747Z"
+     "end_time": "2026-06-23T05:06:15.125222Z",
+     "start_time": "2026-06-23T05:06:14.075961Z"
     }
    },
    "cell_type": "code",
@@ -793,7 +793,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.013153\n"
+      "1.022951\n"
      ]
     }
    ],
@@ -818,8 +818,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:32.861801Z",
-     "start_time": "2026-06-19T19:56:32.842915Z"
+     "end_time": "2026-06-23T05:06:15.191090Z",
+     "start_time": "2026-06-23T05:06:15.161915Z"
     }
    },
    "cell_type": "code",
@@ -850,8 +850,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:34.563819Z",
-     "start_time": "2026-06-19T19:56:32.863707Z"
+     "end_time": "2026-06-23T05:06:16.792109Z",
+     "start_time": "2026-06-23T05:06:15.192998Z"
     }
    },
    "cell_type": "code",
@@ -882,9 +882,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Local PID 83608\n",
-      "pid0 PID: 83608\n",
-      "pid1 PID: 83616\n"
+      "Local PID 6942\n",
+      "pid0 PID: 6942\n",
+      "pid1 PID: 6951\n"
      ]
     }
    ],
@@ -929,8 +929,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:34.609135Z",
-     "start_time": "2026-06-19T19:56:34.578880Z"
+     "end_time": "2026-06-23T05:06:16.834018Z",
+     "start_time": "2026-06-23T05:06:16.808542Z"
     }
    },
    "source": [
@@ -961,8 +961,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:34.785854Z",
-     "start_time": "2026-06-19T19:56:34.610732Z"
+     "end_time": "2026-06-23T05:06:17.012124Z",
+     "start_time": "2026-06-23T05:06:16.835590Z"
     }
    },
    "cell_type": "code",
@@ -1005,8 +1005,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:34.878893Z",
-     "start_time": "2026-06-19T19:56:34.789828Z"
+     "end_time": "2026-06-23T05:06:17.119734Z",
+     "start_time": "2026-06-23T05:06:17.025838Z"
     }
    },
    "cell_type": "code",
@@ -1071,8 +1071,8 @@
    "id": "b26ce438",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:34.918130Z",
-     "start_time": "2026-06-19T19:56:34.889709Z"
+     "end_time": "2026-06-23T05:06:17.143342Z",
+     "start_time": "2026-06-23T05:06:17.129699Z"
     }
    },
    "source": [
@@ -1084,7 +1084,7 @@
     {
      "data": {
       "text/plain": [
-       "[AddOutput(port=OutputPort(label='y', owner=<pyiron_workflow._wfms.workflow.Workflow object at 0x17fc18aa0>, type_hint=None, type_metadata=None))]"
+       "[AddOutput(port=OutputPort(label='y', owner=<pyiron_workflow._wfms.workflow.Workflow object at 0x13eaafdd0>, type_hint=None, type_metadata=None))]"
       ]
      },
      "execution_count": 27,
@@ -1103,8 +1103,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:34.937932Z",
-     "start_time": "2026-06-19T19:56:34.919749Z"
+     "end_time": "2026-06-23T05:06:17.180356Z",
+     "start_time": "2026-06-23T05:06:17.153351Z"
     }
    },
    "cell_type": "code",
@@ -1117,7 +1117,7 @@
     {
      "data": {
       "text/plain": [
-       "[RemoveOutput(port=OutputPort(label='y', owner=<pyiron_workflow._wfms.workflow.Workflow object at 0x17fc18aa0>, type_hint=None, type_metadata=None))]"
+       "[RemoveOutput(port=OutputPort(label='y', owner=<pyiron_workflow._wfms.workflow.Workflow object at 0x13eaafdd0>, type_hint=None, type_metadata=None))]"
       ]
      },
      "execution_count": 28,
@@ -1138,8 +1138,8 @@
    "id": "165cd650",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:34.965844Z",
-     "start_time": "2026-06-19T19:56:34.948866Z"
+     "end_time": "2026-06-23T05:06:17.209719Z",
+     "start_time": "2026-06-23T05:06:17.190677Z"
     }
    },
    "source": [
@@ -1150,7 +1150,7 @@
     {
      "data": {
       "text/plain": [
-       "[AddNode(node=<pyiron_workflow._wfms.atomic.Atomic object at 0x17fc1aed0>)]"
+       "[AddNode(node=<pyiron_workflow._wfms.atomic.Atomic object at 0x13e91a420>)]"
       ]
      },
      "execution_count": 29,
@@ -1169,8 +1169,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.006245Z",
-     "start_time": "2026-06-19T19:56:34.978102Z"
+     "end_time": "2026-06-23T05:06:17.235819Z",
+     "start_time": "2026-06-23T05:06:17.211429Z"
     }
    },
    "cell_type": "code",
@@ -1180,7 +1180,7 @@
     {
      "data": {
       "text/plain": [
-       "[RemoveNode(node=<pyiron_workflow._wfms.atomic.Atomic object at 0x17fc1aed0>)]"
+       "[RemoveNode(node=<pyiron_workflow._wfms.atomic.Atomic object at 0x13e91a420>)]"
       ]
      },
      "execution_count": 30,
@@ -1199,8 +1199,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.073381Z",
-     "start_time": "2026-06-19T19:56:35.020107Z"
+     "end_time": "2026-06-23T05:06:17.251324Z",
+     "start_time": "2026-06-23T05:06:17.237444Z"
     }
    },
    "cell_type": "code",
@@ -1240,8 +1240,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.104038Z",
-     "start_time": "2026-06-19T19:56:35.075553Z"
+     "end_time": "2026-06-23T05:06:17.279872Z",
+     "start_time": "2026-06-23T05:06:17.261667Z"
     }
    },
    "cell_type": "code",
@@ -1276,8 +1276,8 @@
    "id": "f2fb0893",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.165808Z",
-     "start_time": "2026-06-19T19:56:35.115925Z"
+     "end_time": "2026-06-23T05:06:17.316717Z",
+     "start_time": "2026-06-23T05:06:17.289647Z"
     }
    },
    "source": [
@@ -1292,7 +1292,7 @@
     {
      "data": {
       "text/plain": [
-       "[AddOutput(port=OutputPort(label='y', owner=<pyiron_workflow._wfms.workflow.Workflow object at 0x17fc18aa0>, type_hint=None, type_metadata=None)),\n",
+       "[AddOutput(port=OutputPort(label='y', owner=<pyiron_workflow._wfms.workflow.Workflow object at 0x13eaafdd0>, type_hint=None, type_metadata=None)),\n",
        " AddEdge(edge=EdgeTuple(source=SourceHandle(node='shift', port='output_0'), target=OutputTarget(node=None, port='y')))]"
       ]
      },
@@ -1309,8 +1309,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.196011Z",
-     "start_time": "2026-06-19T19:56:35.179475Z"
+     "end_time": "2026-06-23T05:06:17.329916Z",
+     "start_time": "2026-06-23T05:06:17.317376Z"
     }
    },
    "source": [
@@ -1349,8 +1349,8 @@
    "id": "6d681b0f",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.220926Z",
-     "start_time": "2026-06-19T19:56:35.208216Z"
+     "end_time": "2026-06-23T05:06:17.353943Z",
+     "start_time": "2026-06-23T05:06:17.342070Z"
     }
    },
    "source": [
@@ -1370,8 +1370,8 @@
    "id": "02438cec",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.248158Z",
-     "start_time": "2026-06-19T19:56:35.232809Z"
+     "end_time": "2026-06-23T05:06:17.384189Z",
+     "start_time": "2026-06-23T05:06:17.368050Z"
     }
    },
    "source": [
@@ -1389,8 +1389,8 @@
    "id": "b4280246",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.271420Z",
-     "start_time": "2026-06-19T19:56:35.259999Z"
+     "end_time": "2026-06-23T05:06:17.405140Z",
+     "start_time": "2026-06-23T05:06:17.394676Z"
     }
    },
    "source": [
@@ -1412,8 +1412,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.299537Z",
-     "start_time": "2026-06-19T19:56:35.282939Z"
+     "end_time": "2026-06-23T05:06:17.445615Z",
+     "start_time": "2026-06-23T05:06:17.415015Z"
     }
    },
    "source": [
@@ -1449,8 +1449,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.342919Z",
-     "start_time": "2026-06-19T19:56:35.312699Z"
+     "end_time": "2026-06-23T05:06:17.487981Z",
+     "start_time": "2026-06-23T05:06:17.456313Z"
     }
    },
    "cell_type": "code",
@@ -1504,10 +1504,13 @@
    "id": "2b8937f3e7932778"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-23T05:06:17.545801Z",
+     "start_time": "2026-06-23T05:06:17.497945Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "from pyiron_workflow._wfms import api as pwf\n",
     "\n",
@@ -1529,7 +1532,20 @@
     "autoencoder_result = wf.run(dataclass=MyData(no_default=1.1))\n",
     "autoencoder_result.outputs[\"dataclass\"]"
    ],
-   "id": "ca621c4512e5c069"
+   "id": "ca621c4512e5c069",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "OutputDataPort(value=MyData(no_default=1.1, foo=42, bar='towel'), annotation=<class '__main__.MyData'>)"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 40
   },
   {
    "metadata": {},
@@ -1538,12 +1554,28 @@
    "id": "1a9e0cdfcf79e452"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-23T05:06:17.579531Z",
+     "start_time": "2026-06-23T05:06:17.548993Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": "run.steps[0].outputs",
-   "id": "4aaf500a2c7433ab"
+   "id": "4aaf500a2c7433ab",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'output_0': OutputDataPort(value=10, annotation=None)}"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 41
   },
   {
    "metadata": {},
@@ -1562,11 +1594,16 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.372476Z",
-     "start_time": "2026-06-19T19:56:35.344872Z"
+     "end_time": "2026-06-23T05:06:17.605030Z",
+     "start_time": "2026-06-23T05:06:17.580527Z"
     }
    },
    "cell_type": "code",
+   "source": [
+    "rendered = fr.tools.flowrep2python(wf.recipe)\n",
+    "print(rendered.source)"
+   ],
+   "id": "8f7df728ab4712d3",
    "outputs": [
     {
      "name": "stdout",
@@ -1578,22 +1615,17 @@
       "import flowrep\n",
       "import typing\n",
       "\n",
-      "@flowrep.workflow(\"y\")\n",
-      "def compiled_from_workflow_recipe(x, b, m):\n",
-      "    scale = __main__.mul(x=m, y=x)\n",
-      "    shift = __main__.add(x=scale, y=b)\n",
-      "    return shift\n",
+      "@flowrep.workflow(\"dataclass\")\n",
+      "def compiled_from_workflow_recipe(dataclass):\n",
+      "    to_values_no_default, to_values_foo, to_values_bar = __main__.MyData.pwf_dc2outputs._function(dataclass=dataclass)\n",
+      "    to_dc = __main__.MyData.pwf_inputs2dc._function(no_default=to_values_no_default, foo=to_values_foo, bar=to_values_bar)\n",
+      "    return to_dc\n",
       "\n",
       "\n"
      ]
     }
    ],
-   "execution_count": 40,
-   "source": [
-    "rendered = fr.tools.flowrep2python(wf.recipe)\n",
-    "print(rendered.source)"
-   ],
-   "id": "8f7df728ab4712d3"
+   "execution_count": 42
   },
   {
    "cell_type": "markdown",
@@ -1611,8 +1643,8 @@
    "id": "fb47c792",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.401599Z",
-     "start_time": "2026-06-19T19:56:35.374276Z"
+     "end_time": "2026-06-23T05:06:17.662877Z",
+     "start_time": "2026-06-23T05:06:17.631059Z"
     }
    },
    "source": [
@@ -1634,7 +1666,7 @@
      ]
     }
    ],
-   "execution_count": 41
+   "execution_count": 43
   },
   {
    "metadata": {},
@@ -1645,8 +1677,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.418135Z",
-     "start_time": "2026-06-19T19:56:35.403395Z"
+     "end_time": "2026-06-23T05:06:17.691659Z",
+     "start_time": "2026-06-23T05:06:17.664675Z"
     }
    },
    "cell_type": "code",
@@ -1667,7 +1699,7 @@
      ]
     }
    ],
-   "execution_count": 42
+   "execution_count": 44
   },
   {
    "metadata": {
@@ -1683,8 +1715,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.462347Z",
-     "start_time": "2026-06-19T19:56:35.430385Z"
+     "end_time": "2026-06-23T05:06:17.714847Z",
+     "start_time": "2026-06-23T05:06:17.693852Z"
     }
    },
    "cell_type": "code",
@@ -1704,13 +1736,13 @@
      ]
     }
    ],
-   "execution_count": 43
+   "execution_count": 45
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.495412Z",
-     "start_time": "2026-06-19T19:56:35.464170Z"
+     "end_time": "2026-06-23T05:06:17.738153Z",
+     "start_time": "2026-06-23T05:06:17.716511Z"
     }
    },
    "cell_type": "code",
@@ -1727,12 +1759,12 @@
        "{'y': OutputDataPort(value=6.5, annotation=None)}"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 44
+   "execution_count": 46
   },
   {
    "metadata": {},
@@ -1743,8 +1775,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.527296Z",
-     "start_time": "2026-06-19T19:56:35.497206Z"
+     "end_time": "2026-06-23T05:06:17.767932Z",
+     "start_time": "2026-06-23T05:06:17.739939Z"
     }
    },
    "cell_type": "code",
@@ -1770,12 +1802,12 @@
        " 'x3': OutputDataPort(value=27, annotation=None)}"
       ]
      },
-     "execution_count": 45,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 45
+   "execution_count": 47
   },
   {
    "cell_type": "markdown",
@@ -1796,8 +1828,8 @@
    "id": "8c750917",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.555990Z",
-     "start_time": "2026-06-19T19:56:35.543721Z"
+     "end_time": "2026-06-23T05:06:17.799584Z",
+     "start_time": "2026-06-23T05:06:17.776859Z"
     }
    },
    "source": [
@@ -1832,20 +1864,20 @@
        "\t'shift': Atomic"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 46
+   "execution_count": 48
   },
   {
    "cell_type": "code",
    "id": "b834c4b5",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.650456Z",
-     "start_time": "2026-06-19T19:56:35.600489Z"
+     "end_time": "2026-06-23T05:06:17.820605Z",
+     "start_time": "2026-06-23T05:06:17.802013Z"
     }
    },
    "source": [
@@ -1870,12 +1902,12 @@
        "\t'grp': Macro"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 47
+   "execution_count": 49
   },
   {
    "metadata": {},
@@ -1886,8 +1918,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.673341Z",
-     "start_time": "2026-06-19T19:56:35.664865Z"
+     "end_time": "2026-06-23T05:06:17.844013Z",
+     "start_time": "2026-06-23T05:06:17.822312Z"
     }
    },
    "cell_type": "code",
@@ -1902,12 +1934,12 @@
        "\t'shift': Atomic"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 48
+   "execution_count": 50
   },
   {
    "metadata": {},
@@ -1921,8 +1953,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.701428Z",
-     "start_time": "2026-06-19T19:56:35.687392Z"
+     "end_time": "2026-06-23T05:06:17.870479Z",
+     "start_time": "2026-06-23T05:06:17.845636Z"
     }
    },
    "source": [
@@ -1941,7 +1973,7 @@
      ]
     }
    ],
-   "execution_count": 49
+   "execution_count": 51
   },
   {
    "metadata": {},
@@ -1952,8 +1984,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.745516Z",
-     "start_time": "2026-06-19T19:56:35.713276Z"
+     "end_time": "2026-06-23T05:06:17.900055Z",
+     "start_time": "2026-06-23T05:06:17.872534Z"
     }
    },
    "cell_type": "code",
@@ -1966,12 +1998,12 @@
        "{'y': OutputDataPort(value=6.4, annotation=None)}"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 50
+   "execution_count": 52
   },
   {
    "cell_type": "markdown",
@@ -1988,8 +2020,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.766926Z",
-     "start_time": "2026-06-19T19:56:35.755595Z"
+     "end_time": "2026-06-23T05:06:17.930165Z",
+     "start_time": "2026-06-23T05:06:17.902576Z"
     }
    },
    "source": [
@@ -2015,12 +2047,12 @@
        "\t'grp_shift': Atomic"
       ]
      },
-     "execution_count": 51,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 51
+   "execution_count": 53
   },
   {
    "metadata": {},
@@ -2031,8 +2063,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.794491Z",
-     "start_time": "2026-06-19T19:56:35.778203Z"
+     "end_time": "2026-06-23T05:06:17.966079Z",
+     "start_time": "2026-06-23T05:06:17.942667Z"
     }
    },
    "cell_type": "code",
@@ -2045,12 +2077,12 @@
        "{'y': OutputDataPort(value=6.3, annotation=None)}"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 52
+   "execution_count": 54
   },
   {
    "cell_type": "markdown",
@@ -2073,8 +2105,8 @@
    "id": "ed39eebd",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.822654Z",
-     "start_time": "2026-06-19T19:56:35.805796Z"
+     "end_time": "2026-06-23T05:06:18.049737Z",
+     "start_time": "2026-06-23T05:06:17.968528Z"
     }
    },
    "source": [
@@ -2131,7 +2163,7 @@
     "    return money"
    ],
    "outputs": [],
-   "execution_count": 53
+   "execution_count": 55
   },
   {
    "metadata": {},
@@ -2142,8 +2174,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.866187Z",
-     "start_time": "2026-06-19T19:56:35.836527Z"
+     "end_time": "2026-06-23T05:06:18.097472Z",
+     "start_time": "2026-06-23T05:06:18.061560Z"
     }
    },
    "cell_type": "code",
@@ -2160,12 +2192,12 @@
        "{'money': OutputDataPort(value=10, annotation=None)}"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 54
+   "execution_count": 56
   },
   {
    "metadata": {},
@@ -2176,8 +2208,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:35.911305Z",
-     "start_time": "2026-06-19T19:56:35.877709Z"
+     "end_time": "2026-06-23T05:06:18.151583Z",
+     "start_time": "2026-06-23T05:06:18.118565Z"
     }
    },
    "cell_type": "code",
@@ -2187,15 +2219,15 @@
     {
      "data": {
       "text/plain": [
-       "<Graph identifier=N3e4eca15430e421e9151f742ef49ef4e (<class 'rdflib.graph.Graph'>)>"
+       "<Graph identifier=N87563b4306cc4e48aa4db7e756f97c12 (<class 'rdflib.graph.Graph'>)>"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 55
+   "execution_count": 57
   },
   {
    "metadata": {},
@@ -2206,8 +2238,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:36.117837Z",
-     "start_time": "2026-06-19T19:56:35.922141Z"
+     "end_time": "2026-06-23T05:06:18.287182Z",
+     "start_time": "2026-06-23T05:06:18.160882Z"
     }
    },
    "cell_type": "code",
@@ -2218,16 +2250,16 @@
      "data": {
       "text/plain": [
        "(True,\n",
-       " <Graph identifier=N92363f3b567f47538b2a38cfad9b9693 (<class 'rdflib.graph.Graph'>)>,\n",
+       " <Graph identifier=Nadf891ed87d946d385f1d481462dbc05 (<class 'rdflib.graph.Graph'>)>,\n",
        " 'Validation Report\\nConforms: True\\n')"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 56
+   "execution_count": 58
   },
   {
    "metadata": {},
@@ -2245,8 +2277,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:36.344012Z",
-     "start_time": "2026-06-19T19:56:36.170850Z"
+     "end_time": "2026-06-23T05:06:18.415439Z",
+     "start_time": "2026-06-23T05:06:18.298191Z"
     }
    },
    "source": [
@@ -2277,12 +2309,12 @@
        "\tMessage: Focus node does not conform to shape MinCount 1: [ sh:class <http://example.org/cleaned> ]"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 57
+   "execution_count": 59
   },
   {
    "cell_type": "markdown",
@@ -2306,8 +2338,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:36.397871Z",
-     "start_time": "2026-06-19T19:56:36.357446Z"
+     "end_time": "2026-06-23T05:06:18.443581Z",
+     "start_time": "2026-06-23T05:06:18.418518Z"
     }
    },
    "cell_type": "code",
@@ -2352,12 +2384,12 @@
        "  {'target': 3, 'targetPort': None, 'source': 4, 'sourcePort': 'added'}]}"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 58
+   "execution_count": 60
   },
   {
    "metadata": {},
@@ -2368,8 +2400,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:36.424406Z",
-     "start_time": "2026-06-19T19:56:36.404329Z"
+     "end_time": "2026-06-23T05:06:18.466473Z",
+     "start_time": "2026-06-23T05:06:18.445334Z"
     }
    },
    "cell_type": "code",
@@ -2394,12 +2426,12 @@
        "{'y': OutputDataPort(value=6.5, annotation=None)}"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 59
+   "execution_count": 61
   },
   {
    "cell_type": "markdown",
@@ -2430,8 +2462,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:36.455961Z",
-     "start_time": "2026-06-19T19:56:36.426145Z"
+     "end_time": "2026-06-23T05:06:18.478214Z",
+     "start_time": "2026-06-23T05:06:18.468839Z"
     }
    },
    "cell_type": "code",
@@ -2446,7 +2478,7 @@
    ],
    "id": "82da92ef2d5247f7",
    "outputs": [],
-   "execution_count": 60
+   "execution_count": 62
   },
   {
    "cell_type": "markdown",
@@ -2459,8 +2491,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:36.468487Z",
-     "start_time": "2026-06-19T19:56:36.457254Z"
+     "end_time": "2026-06-23T05:06:18.496026Z",
+     "start_time": "2026-06-23T05:06:18.486711Z"
     }
    },
    "cell_type": "code",
@@ -2473,7 +2505,7 @@
    ],
    "id": "98276df1c822ed21",
    "outputs": [],
-   "execution_count": 61
+   "execution_count": 63
   },
   {
    "cell_type": "markdown",
@@ -2486,8 +2518,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:36.502943Z",
-     "start_time": "2026-06-19T19:56:36.480329Z"
+     "end_time": "2026-06-23T05:06:18.530707Z",
+     "start_time": "2026-06-23T05:06:18.505101Z"
     }
    },
    "cell_type": "code",
@@ -2505,13 +2537,13 @@
      ]
     }
    ],
-   "execution_count": 62
+   "execution_count": 64
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:36.530513Z",
-     "start_time": "2026-06-19T19:56:36.504576Z"
+     "end_time": "2026-06-23T05:06:18.553923Z",
+     "start_time": "2026-06-23T05:06:18.532255Z"
     }
    },
    "cell_type": "code",
@@ -2524,12 +2556,12 @@
        "{'shifted': OutputDataPort(value=20.3, annotation=None)}"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 63
+   "execution_count": 65
   },
   {
    "cell_type": "markdown",
@@ -2544,8 +2576,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-19T19:56:36.607191Z",
-     "start_time": "2026-06-19T19:56:36.539083Z"
+     "end_time": "2026-06-23T05:06:18.576342Z",
+     "start_time": "2026-06-23T05:06:18.555362Z"
     }
    },
    "cell_type": "code",
@@ -2575,7 +2607,7 @@
      ]
     }
    ],
-   "execution_count": 64
+   "execution_count": 66
   },
   {
    "metadata": {},

--- a/notebooks/_wfms.ipynb
+++ b/notebooks/_wfms.ipynb
@@ -390,16 +390,6 @@
    "execution_count": 12
   },
   {
-   "metadata": {},
-   "cell_type": "markdown",
-   "source": [
-    "### Dataclass QoL\n",
-    "\n",
-    "_(TO IMPLEMENT)_ -- `flowrep` already allows you to take a python function returning a dataclass, and break the dataclass fields into output ports in the recipe. More quality of life (QoL) improvements are coming soon in `pyiron_workflow`, including direct decoration of dataclasses themselves."
-   ],
-   "id": "45dbb90a47afef5"
-  },
-  {
    "cell_type": "markdown",
    "id": "23b6a1e8",
    "metadata": {},
@@ -1502,9 +1492,62 @@
    "execution_count": 39
   },
   {
-   "cell_type": "markdown",
-   "id": "f61a3ddd",
    "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "### Dataclass Quality-of-Life\n",
+    "\n",
+    "`flowrep` already allows you to take a python function returning a dataclass, and break the dataclass fields into output ports in the recipe. `pyiron_workflow` lets you go a step further and decorate dataclasses directly. Just like function decorations, these _stay as dataclasses_. Also like decorated functions, we extend the attributes available on them to include two new tool sets: one for making a node that transforms inputs into the dataclass instance, and another for the reverse direction: turning a dataclass instance into a set of separate output ports for each field.\n",
+    "\n",
+    "Here is an \"autoencoder\" from dataclass to IO and back:"
+   ],
+   "id": "2b8937f3e7932778"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "from pyiron_workflow._wfms import api as pwf\n",
+    "\n",
+    "@pwf.dataclass(frozen=True)\n",
+    "class MyData:\n",
+    "    no_default: float\n",
+    "    foo: int = 42\n",
+    "    bar: str = \"towel\"\n",
+    "    not_a_field = 13\n",
+    "\n",
+    "wf = pwf.Workflow(\"autoencoder\")\n",
+    "wf.to_values = MyData.pwf_dc2outputs.node()\n",
+    "wf.to_dc = MyData.pwf_inputs2dc.node()\n",
+    "wf.create_input_for(wf.to_values.inputs.dataclass)\n",
+    "wf.create_output_from(wf.to_dc)\n",
+    "for k in wf.to_values.outputs:\n",
+    "    wf.connect(wf.to_values.outputs[k], wf.to_dc.inputs[k])\n",
+    "\n",
+    "autoencoder_result = wf.run(dataclass=MyData(no_default=1.1))\n",
+    "autoencoder_result.outputs[\"dataclass\"]"
+   ],
+   "id": "ca621c4512e5c069"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "In the middle of the workflow, the dataclass has been broken apart into its fields:",
+   "id": "1a9e0cdfcf79e452"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "run.steps[0].outputs",
+   "id": "4aaf500a2c7433ab"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "## From workflow back to `flowrep` (and to python source)\n",
     "\n",
@@ -1512,11 +1555,10 @@
     "declarative view of what you have built. `flowrep`'s compiler can render that recipe\n",
     "straight back into runnable python source, closing the loop between visual/programmatic\n",
     "editing and code:"
-   ]
+   ],
+   "id": "a3db3f97f3e4a22e"
   },
   {
-   "cell_type": "code",
-   "id": "390c0f36",
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
@@ -1524,10 +1566,7 @@
      "start_time": "2026-06-19T19:56:35.344872Z"
     }
    },
-   "source": [
-    "rendered = fr.tools.flowrep2python(wf.recipe)\n",
-    "print(rendered.source)"
-   ],
+   "cell_type": "code",
    "outputs": [
     {
      "name": "stdout",
@@ -1549,7 +1588,12 @@
      ]
     }
    ],
-   "execution_count": 40
+   "execution_count": 40,
+   "source": [
+    "rendered = fr.tools.flowrep2python(wf.recipe)\n",
+    "print(rendered.source)"
+   ],
+   "id": "8f7df728ab4712d3"
   },
   {
    "cell_type": "markdown",

--- a/pyiron_workflow/_wfms/api/__init__.py
+++ b/pyiron_workflow/_wfms/api/__init__.py
@@ -7,5 +7,6 @@ from pyiron_workflow._wfms.api.schemas import (
 from pyiron_workflow._wfms.api.schemas import RunConfig as RunConfig
 from pyiron_workflow._wfms.api.schemas import Workflow as Workflow
 from pyiron_workflow._wfms.api.tools import atomic as atomic
+from pyiron_workflow._wfms.api.tools import dataclass as dataclass
 from pyiron_workflow._wfms.api.tools import node as node
 from pyiron_workflow._wfms.api.tools import workflow as workflow

--- a/pyiron_workflow/_wfms/api/tools.py
+++ b/pyiron_workflow/_wfms/api/tools.py
@@ -2,6 +2,7 @@ from pyiron_workflow._wfms.constructors import function2node as function2node
 from pyiron_workflow._wfms.constructors import node as node
 from pyiron_workflow._wfms.constructors import recipe2node as recipe2node
 from pyiron_workflow._wfms.decorators import atomic as atomic
+from pyiron_workflow._wfms.decorators import dataclass as dataclass
 from pyiron_workflow._wfms.decorators import workflow as workflow
 from pyiron_workflow._wfms.execution import run as run
 from pyiron_workflow._wfms.validation import validate_plan as validate_plan

--- a/pyiron_workflow/_wfms/compatibility.py
+++ b/pyiron_workflow/_wfms/compatibility.py
@@ -80,7 +80,7 @@ class _CompatibilityFactory(abc.ABC):
     """
 
     def __init__(self, func: types.FunctionType, *output_labels: str):
-        decorators._disallow_locals(func)
+        decorators._DecoratedFunction._disallow_locals(func)
         self._received_function = func
         self._output_labels = output_labels
         self._decorated = None

--- a/pyiron_workflow/_wfms/compatibility.py
+++ b/pyiron_workflow/_wfms/compatibility.py
@@ -142,7 +142,7 @@ class _AtomicFactory(_CompatibilityFactory):
         *output_labels: str,
     ) -> types.FunctionType:
         decorated = fr.tools.atomic(*output_labels)(func)
-        decorated.pwf = decorators.AtomicTools(decorated)
+        decorated.pwf = decorators.DecoratedAtomic(decorated)
         return decorated
 
 

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -21,8 +21,9 @@ _RecipeType = TypeVar("_RecipeType", fr.schemas.AtomicRecipe, fr.schemas.Workflo
 _NodeType = TypeVar("_NodeType", atomic_mod.Atomic, dag.Macro)
 
 
-class _PwfTools(Generic[_DecoratedType, _RecipeType], abc.ABC):
+class _PwfTools(Generic[_DecoratedType, _RecipeType, _NodeType], abc.ABC):
     assign_to: ClassVar[str]
+    _node_type: type[_NodeType]
 
     def __init__(self, wrapped: _DecoratedType):
         self._disallow_locals(wrapped)
@@ -33,12 +34,12 @@ class _PwfTools(Generic[_DecoratedType, _RecipeType], abc.ABC):
     def recipe(self) -> _RecipeType: ...
 
     @abc.abstractmethod
+    def _label(self, label: fr.schemas.Label | None = None) -> fr.schemas.Label: ...
+
     def node(
         self, label: fr.schemas.Label | None = None, /, *positional, **keyword
-    ) -> atomic_mod.Atomic | dag.Macro: ...
-
-    @abc.abstractmethod
-    def _label(self, label: fr.schemas.Label | None = None) -> fr.schemas.Label: ...
+    ) -> _NodeType:
+        return self._node_type(self._label(label), self.recipe, *positional, **keyword)
 
     def run(self, config: execution.RunConfig | None = None, **input_data):
         return self.node().run(config, **input_data)
@@ -54,9 +55,11 @@ class _PwfTools(Generic[_DecoratedType, _RecipeType], abc.ABC):
 
 
 class _DecoratedFunction(
-    _PwfTools[types.FunctionType, _RecipeType], Generic[_RecipeType, _NodeType], abc.ABC
+    _PwfTools[types.FunctionType, _RecipeType, _NodeType],
+    Generic[_RecipeType, _NodeType],
+    abc.ABC,
 ):
-    _node_type: type[_NodeType]
+    assign_to: ClassVar[str] = "pwf"
 
     @property
     def recipe(self) -> _RecipeType:
@@ -64,11 +67,6 @@ class _DecoratedFunction(
 
     def _label(self, label: fr.schemas.Label | None = None) -> fr.schemas.Label:
         return self._decorated_object.__name__ if label is None else label
-
-    def node(
-        self, label: fr.schemas.Label | None = None, /, *positional, **keyword
-    ) -> _NodeType:
-        return self._node_type(self._label(label), self.recipe, *positional, **keyword)
 
 
 class DecoratedAtomic(_DecoratedFunction[fr.schemas.AtomicRecipe, atomic_mod.Atomic]):

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -24,13 +24,14 @@ class _DecoratedFunction(Generic[_RecipeType]):
     def __init__(self, wrapped: types.FunctionType):
         self._disallow_locals(wrapped)
         self._decorated_function = wrapped
+        self._default_name = wrapped.__name__
 
     @property
     def recipe(self) -> _RecipeType:
         return self._decorated_function.flowrep_recipe  # type: ignore[attr-defined]
 
     def node(self, label: fr.schemas.Label | None = None, /, *positional, **keyword):
-        used_label = self._decorated_function.__name__ if label is None else label
+        used_label = self._default_name if label is None else label
         return self.node_type(used_label, self.recipe, *positional, **keyword)
 
     def run(self, config: execution.RunConfig | None = None, **input_data):

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 _RecipeType = TypeVar("_RecipeType", fr.schemas.AtomicRecipe, fr.schemas.WorkflowRecipe)
 
 
-class _PwfTools(Generic[_RecipeType]):
+class _DecoratedFunction(Generic[_RecipeType]):
     node_type: ClassVar[type[atomic_mod.Atomic] | type[dag.Macro]]
 
     def __init__(self, wrapped: types.FunctionType):
@@ -46,11 +46,11 @@ def _disallow_locals(func: types.FunctionType):
         )
 
 
-class AtomicTools(_PwfTools[fr.schemas.AtomicRecipe]):
+class DecoratedAtomic(_DecoratedFunction[fr.schemas.AtomicRecipe]):
     node_type = atomic_mod.Atomic
 
 
-class MacroTools(_PwfTools[fr.schemas.WorkflowRecipe]):
+class DecoratedMacro(_DecoratedFunction[fr.schemas.WorkflowRecipe]):
     node_type = dag.Macro
 
     def validate(
@@ -76,7 +76,9 @@ _assigned = tuple(
 @functools.wraps(fr.tools.atomic, assigned=_assigned)
 def atomic(*args, **kwargs):
     wrapped = fr.tools.atomic(*args, **kwargs)
-    return _double_wrap_if_decorator_got_args(args[0], wrapped, AtomicTools, "@atomic")
+    return _double_wrap_if_decorator_got_args(
+        args[0], wrapped, DecoratedAtomic, "@atomic"
+    )
 
 
 atomic.__doc__ = """
@@ -94,7 +96,7 @@ Base `flowrep` documentation:
 def _double_wrap_if_decorator_got_args(
     arg0: str | types.FunctionType,
     wrapped: types.FunctionType,
-    tool: type[AtomicTools] | type[MacroTools],
+    tool: type[DecoratedAtomic] | type[DecoratedMacro],
     decorator_name: str,
 ):
     if isinstance(arg0, types.FunctionType):
@@ -124,7 +126,9 @@ def _double_wrap_if_decorator_got_args(
 @functools.wraps(fr.tools.workflow, assigned=_assigned)
 def workflow(*args, **kwargs):
     wrapped = fr.tools.workflow(*args, **kwargs)
-    return _double_wrap_if_decorator_got_args(args[0], wrapped, MacroTools, "@workflow")
+    return _double_wrap_if_decorator_got_args(
+        args[0], wrapped, DecoratedMacro, "@workflow"
+    )
 
 
 workflow.__doc__ = """

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -351,6 +351,20 @@ class Dataclass2Outputs(_DecoratedDataclass):
         )
 
 
+_RESERVED_DATACLASS_PORT = "dataclass"
+
+
+def _check_reserved_fields(dcls: type) -> None:
+    for field in dataclasses.fields(dcls):
+        if field.name == _RESERVED_DATACLASS_PORT:
+            raise ValueError(
+                f"@dataclass attaches node tools that reserve the port name "
+                f"{_RESERVED_DATACLASS_PORT!r}, but dataclass "
+                f"{dcls.__qualname__!r} declares a field named "
+                f"{_RESERVED_DATACLASS_PORT!r}. Rename that field."
+            )
+
+
 @functools.wraps(dataclasses.dataclass, assigned=_assigned)
 def dataclass(
     cls=None,
@@ -363,6 +377,7 @@ def dataclass(
 ):
     def wrap(cls):
         dcls = dataclasses.dataclass(**dataclasses_dataclass_kwargs)(cls)
+        _check_reserved_fields(dcls)
         setattr(
             dcls,
             Inputs2Dataclass.assign_to,

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import abc
 import functools
 import types
-from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
+from typing import TYPE_CHECKING
 
 import flowrep as fr
 
@@ -15,24 +16,20 @@ if TYPE_CHECKING:
     import rdflib
 
 
-_RecipeType = TypeVar("_RecipeType", fr.schemas.AtomicRecipe, fr.schemas.WorkflowRecipe)
-
-
-class _DecoratedFunction(Generic[_RecipeType]):
-    node_type: ClassVar[type[atomic_mod.Atomic] | type[dag.Macro]]
-
+class _DecoratedFunction(abc.ABC):
     def __init__(self, wrapped: types.FunctionType):
         self._disallow_locals(wrapped)
         self._decorated_function = wrapped
         self._default_name = wrapped.__name__
 
     @property
-    def recipe(self) -> _RecipeType:
+    def recipe(self) -> fr.schemas.AtomicRecipe | fr.schemas.WorkflowRecipe:
         return self._decorated_function.flowrep_recipe  # type: ignore[attr-defined]
 
-    def node(self, label: fr.schemas.Label | None = None, /, *positional, **keyword):
-        used_label = self._default_name if label is None else label
-        return self.node_type(used_label, self.recipe, *positional, **keyword)
+    @abc.abstractmethod
+    def node(
+        self, label: fr.schemas.Label | None = None, /, *positional, **keyword
+    ) -> atomic_mod.Atomic | dag.Macro: ...
 
     def run(self, config: execution.RunConfig | None = None, **input_data):
         return self.node().run(config, **input_data)
@@ -47,12 +44,20 @@ class _DecoratedFunction(Generic[_RecipeType]):
             )
 
 
-class DecoratedAtomic(_DecoratedFunction[fr.schemas.AtomicRecipe]):
-    node_type = atomic_mod.Atomic
+class DecoratedAtomic(_DecoratedFunction):
+    def node(
+        self, label: fr.schemas.Label | None = None, /, *positional, **keyword
+    ) -> atomic_mod.Atomic:
+        used_label = self._default_name if label is None else label
+        return atomic_mod.Atomic(used_label, self.recipe, *positional, **keyword)
 
 
-class DecoratedMacro(_DecoratedFunction[fr.schemas.WorkflowRecipe]):
-    node_type = dag.Macro
+class DecoratedMacro(_DecoratedFunction):
+    def node(
+        self, label: fr.schemas.Label | None = None, /, *positional, **keyword
+    ) -> dag.Macro:
+        used_label = self._default_name if label is None else label
+        return dag.Macro(used_label, self.recipe, *positional, **keyword)
 
     def validate(
         self,

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -20,7 +20,6 @@ class _DecoratedFunction(abc.ABC):
     def __init__(self, wrapped: types.FunctionType):
         self._disallow_locals(wrapped)
         self._decorated_function = wrapped
-        self._default_name = wrapped.__name__
 
     @property
     def recipe(self) -> fr.schemas.AtomicRecipe | fr.schemas.WorkflowRecipe:
@@ -30,6 +29,9 @@ class _DecoratedFunction(abc.ABC):
     def node(
         self, label: fr.schemas.Label | None = None, /, *positional, **keyword
     ) -> atomic_mod.Atomic | dag.Macro: ...
+
+    def _label(self, label: fr.schemas.Label | None = None) -> fr.schemas.Label:
+        return self._decorated_function.__name__ if label is None else label
 
     def run(self, config: execution.RunConfig | None = None, **input_data):
         return self.node().run(config, **input_data)
@@ -48,16 +50,16 @@ class DecoratedAtomic(_DecoratedFunction):
     def node(
         self, label: fr.schemas.Label | None = None, /, *positional, **keyword
     ) -> atomic_mod.Atomic:
-        used_label = self._default_name if label is None else label
-        return atomic_mod.Atomic(used_label, self.recipe, *positional, **keyword)
+        return atomic_mod.Atomic(
+            self._label(label), self.recipe, *positional, **keyword
+        )
 
 
 class DecoratedMacro(_DecoratedFunction):
     def node(
         self, label: fr.schemas.Label | None = None, /, *positional, **keyword
     ) -> dag.Macro:
-        used_label = self._default_name if label is None else label
-        return dag.Macro(used_label, self.recipe, *positional, **keyword)
+        return dag.Macro(self._label(label), self.recipe, *positional, **keyword)
 
     def validate(
         self,

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -191,7 +191,7 @@ class _DecoratedDataclass(
         version_scraping: versions.VersionScrapingMap | None = None,
         forbid_main: bool = False,
         forbid_locals: bool = False,
-        forbid_lambda: bool = False,
+        forbid_lambda: bool = True,
         require_version: bool = False,
     ):
         super().__init__(wrapped)
@@ -372,6 +372,7 @@ def dataclass(
     version_scraping: versions.VersionScrapingMap | None = None,
     forbid_main: bool = False,
     forbid_locals: bool = False,
+    forbid_lambda: bool = False,  # Meaningless, but harmless
     require_version: bool = False,
     **dataclasses_dataclass_kwargs,
 ):
@@ -386,6 +387,7 @@ def dataclass(
                 version_scraping=version_scraping,
                 forbid_main=forbid_main,
                 forbid_locals=forbid_locals,
+                forbid_lambda=forbid_lambda,
                 require_version=require_version,
             ),
         )
@@ -397,6 +399,7 @@ def dataclass(
                 version_scraping=version_scraping,
                 forbid_main=forbid_main,
                 forbid_locals=forbid_locals,
+                forbid_lambda=forbid_lambda,
                 require_version=require_version,
             ),
         )

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -22,7 +22,7 @@ class _DecoratedFunction(Generic[_RecipeType]):
     node_type: ClassVar[type[atomic_mod.Atomic] | type[dag.Macro]]
 
     def __init__(self, wrapped: types.FunctionType):
-        _disallow_locals(wrapped)
+        self._disallow_locals(wrapped)
         self.function = wrapped
 
     @property
@@ -36,14 +36,14 @@ class _DecoratedFunction(Generic[_RecipeType]):
     def run(self, config: execution.RunConfig | None = None, **input_data):
         return self.node().run(config, **input_data)
 
-
-def _disallow_locals(func: types.FunctionType):
-    if "<locals>" in func.__qualname__:
-        raise ImportError(
-            "To turn decorated functions into nodes, pyiron_workflow needs to be "
-            "able to import the underlying decorated function; "
-            f"but {func.__qualname__!r} contains '<locals>'."
-        )
+    @staticmethod
+    def _disallow_locals(func: types.FunctionType):
+        if "<locals>" in func.__qualname__:
+            raise ImportError(
+                "To turn decorated functions into nodes, pyiron_workflow needs to be "
+                "able to import the underlying decorated function; "
+                f"but {func.__qualname__!r} contains '<locals>'."
+            )
 
 
 class DecoratedAtomic(_DecoratedFunction[fr.schemas.AtomicRecipe]):

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import functools
 import types
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 
 import flowrep as fr
 
@@ -22,6 +22,7 @@ _NodeType = TypeVar("_NodeType", atomic_mod.Atomic, dag.Macro)
 
 
 class _PwfTools(Generic[_DecoratedType, _RecipeType], abc.ABC):
+    assign_to: ClassVar[str]
 
     def __init__(self, wrapped: _DecoratedType):
         self._disallow_locals(wrapped)
@@ -131,13 +132,21 @@ def _double_wrap_if_decorator_got_args(
                 f"`flowrep_recipe` attribute. This is an internal error and likely flags "
                 f"a development bug. dir({wrapped!r}) = {dir(wrapped)}."
             )
-        wrapped.pwf = tool(wrapped)  # type: ignore[attr-defined]
+        setattr(
+            wrapped,
+            tool.assign_to,
+            tool(wrapped),
+        )
         return wrapped
     elif isinstance(arg0, str):
 
         def wrapped_decorator(func):
             double_wrapped = wrapped(func)
-            double_wrapped.pwf = tool(double_wrapped)
+            setattr(
+                double_wrapped,
+                tool.assign_to,
+                tool(double_wrapped),
+            )
             return double_wrapped
 
         return wrapped_decorator

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -117,6 +117,23 @@ Base `flowrep` documentation:
 """ + (fr.tools.atomic.__doc__ or "")
 
 
+@functools.wraps(fr.tools.workflow, assigned=_assigned)
+def workflow(*args, **kwargs):
+    return _attach_pwf_tool(fr.tools.workflow(*args, **kwargs), DecoratedMacro)
+
+
+workflow.__doc__ = """
+A powered-up version of the `flowrep` decorator of the same name.
+
+Additionally adds a `.pwf` attribute holding methods to instantiate the function as a 
+`pyiron_workflow._wfms.api.schemas.Macro` node instance, validate the underlying graph, 
+or create a dynamic node instance and run it.
+
+Base `flowrep` documentation:
+
+""" + (fr.tools.workflow.__doc__ or "")
+
+
 def _attach_pwf_tool(
     flowrep_result: (
         types.FunctionType | Callable[[types.FunctionType], types.FunctionType]
@@ -140,23 +157,6 @@ def _attach_pwf_tool(
         return decorated
 
     return decorator
-
-
-@functools.wraps(fr.tools.workflow, assigned=_assigned)
-def workflow(*args, **kwargs):
-    return _attach_pwf_tool(fr.tools.workflow(*args, **kwargs), DecoratedMacro)
-
-
-workflow.__doc__ = """
-A powered-up version of the `flowrep` decorator of the same name.
-
-Additionally adds a `.pwf` attribute holding methods to instantiate the function as a 
-`pyiron_workflow._wfms.api.schemas.Macro` node instance, validate the underlying graph, 
-or create a dynamic node instance and run it.
-
-Base `flowrep` documentation:
-
-""" + (fr.tools.workflow.__doc__ or "")
 
 
 class _DecoratedDataclass(

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -23,14 +23,14 @@ class _DecoratedFunction(Generic[_RecipeType]):
 
     def __init__(self, wrapped: types.FunctionType):
         self._disallow_locals(wrapped)
-        self.function = wrapped
+        self._decorated_function = wrapped
 
     @property
     def recipe(self) -> _RecipeType:
-        return self.function.flowrep_recipe  # type: ignore[attr-defined]
+        return self._decorated_function.flowrep_recipe  # type: ignore[attr-defined]
 
     def node(self, label: fr.schemas.Label | None = None, /, *positional, **keyword):
-        used_label = self.function.__name__ if label is None else label
+        used_label = self._decorated_function.__name__ if label is None else label
         return self.node_type(used_label, self.recipe, *positional, **keyword)
 
     def run(self, config: execution.RunConfig | None = None, **input_data):

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import functools
 import types
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 import flowrep as fr
 
@@ -16,28 +16,34 @@ if TYPE_CHECKING:
     import rdflib
 
 
-class _DecoratedFunction(abc.ABC):
-    def __init__(self, wrapped: types.FunctionType):
+_DecoratedType = TypeVar("_DecoratedType", types.FunctionType, type)
+_RecipeType = TypeVar("_RecipeType", fr.schemas.AtomicRecipe, fr.schemas.WorkflowRecipe)
+_NodeType = TypeVar("_NodeType", atomic_mod.Atomic, dag.Macro)
+
+
+class _PwfTools(Generic[_DecoratedType, _RecipeType], abc.ABC):
+
+    def __init__(self, wrapped: _DecoratedType):
         self._disallow_locals(wrapped)
-        self._decorated_object = wrapped
+        self._decorated_object: _DecoratedType = wrapped
 
     @property
-    def recipe(self) -> fr.schemas.AtomicRecipe | fr.schemas.WorkflowRecipe:
-        return self._decorated_object.flowrep_recipe  # type: ignore[attr-defined]
+    @abc.abstractmethod
+    def recipe(self) -> _RecipeType: ...
 
     @abc.abstractmethod
     def node(
         self, label: fr.schemas.Label | None = None, /, *positional, **keyword
     ) -> atomic_mod.Atomic | dag.Macro: ...
 
-    def _label(self, label: fr.schemas.Label | None = None) -> fr.schemas.Label:
-        return self._decorated_object.__name__ if label is None else label
+    @abc.abstractmethod
+    def _label(self, label: fr.schemas.Label | None = None) -> fr.schemas.Label: ...
 
     def run(self, config: execution.RunConfig | None = None, **input_data):
         return self.node().run(config, **input_data)
 
     @staticmethod
-    def _disallow_locals(func: types.FunctionType):
+    def _disallow_locals(func: types.FunctionType | type):
         if "<locals>" in func.__qualname__:
             raise ImportError(
                 "To turn decorated functions into nodes, pyiron_workflow needs to be "
@@ -46,20 +52,30 @@ class _DecoratedFunction(abc.ABC):
             )
 
 
-class DecoratedAtomic(_DecoratedFunction):
+class _DecoratedFunction(
+    _PwfTools[types.FunctionType, _RecipeType], Generic[_RecipeType, _NodeType], abc.ABC
+):
+    _node_type: type[_NodeType]
+
+    @property
+    def recipe(self) -> _RecipeType:
+        return self._decorated_object.flowrep_recipe  # type: ignore[attr-defined]
+
+    def _label(self, label: fr.schemas.Label | None = None) -> fr.schemas.Label:
+        return self._decorated_object.__name__ if label is None else label
+
     def node(
         self, label: fr.schemas.Label | None = None, /, *positional, **keyword
-    ) -> atomic_mod.Atomic:
-        return atomic_mod.Atomic(
-            self._label(label), self.recipe, *positional, **keyword
-        )
+    ) -> _NodeType:
+        return self._node_type(self._label(label), self.recipe, *positional, **keyword)
 
 
-class DecoratedMacro(_DecoratedFunction):
-    def node(
-        self, label: fr.schemas.Label | None = None, /, *positional, **keyword
-    ) -> dag.Macro:
-        return dag.Macro(self._label(label), self.recipe, *positional, **keyword)
+class DecoratedAtomic(_DecoratedFunction[fr.schemas.AtomicRecipe, atomic_mod.Atomic]):
+    _node_type = atomic_mod.Atomic
+
+
+class DecoratedMacro(_DecoratedFunction[fr.schemas.WorkflowRecipe, dag.Macro]):
+    _node_type = dag.Macro
 
     def validate(
         self,

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -181,7 +181,7 @@ class _DecoratedDataclass(
     _PwfTools[type, fr.schemas.AtomicRecipe, atomic_mod.Atomic], abc.ABC
 ):
     _root_function: ClassVar[staticmethod[..., Any]]
-    _unpack_mode = type[fr.schemas.UnpackMode]
+    _unpack_mode: ClassVar[fr.schemas.UnpackMode]
 
     _node_type = atomic_mod.Atomic
 
@@ -209,6 +209,10 @@ class _DecoratedDataclass(
             if p.annotation is not inspect.Parameter.empty
         }
         self._function.__annotations__["return"] = wrapped
+        # Point __wrapped__ at the dataclass __init__ so that get_type_hints()
+        # can resolve forward-reference annotations (e.g. dataclasses.InitVar[int])
+        # using the dataclass module's globals rather than _root_function's globals.
+        self._function.__wrapped__ = wrapped.__init__  # type: ignore[attr-defined]
 
         dc_version = versions.VersionInfo.of(
             wrapped,
@@ -316,10 +320,7 @@ class Dataclass2Outputs(_DecoratedDataclass):
         list[str],
         inspect.Signature,
     ]:
-        dc_sig = inspect.signature(cls)
-        params = dc_sig.parameters
-
-        outputs = list(params)
+        outputs = [f.name for f in dataclasses.fields(cls)]
 
         input_name = "dataclass"
         func_sig = inspect.Signature(

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -26,12 +26,12 @@ class _DecoratedFunction(Generic[_RecipeType]):
         self.function = wrapped
 
     @property
-    def _recipe(self) -> _RecipeType:
+    def recipe(self) -> _RecipeType:
         return self.function.flowrep_recipe  # type: ignore[attr-defined]
 
     def node(self, label: fr.schemas.Label | None = None, /, *positional, **keyword):
         used_label = self.function.__name__ if label is None else label
-        return self.node_type(used_label, self._recipe, *positional, **keyword)
+        return self.node_type(used_label, self.recipe, *positional, **keyword)
 
     def run(self, config: execution.RunConfig | None = None, **input_data):
         return self.node().run(config, **input_data)

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 _RecipeType = TypeVar("_RecipeType", fr.schemas.AtomicRecipe, fr.schemas.WorkflowRecipe)
 
 
-class PwfTools(Generic[_RecipeType]):
+class _PwfTools(Generic[_RecipeType]):
     node_type: ClassVar[type[atomic_mod.Atomic] | type[dag.Macro]]
 
     def __init__(self, wrapped: types.FunctionType):
@@ -46,11 +46,11 @@ def _disallow_locals(func: types.FunctionType):
         )
 
 
-class AtomicTools(PwfTools[fr.schemas.AtomicRecipe]):
+class AtomicTools(_PwfTools[fr.schemas.AtomicRecipe]):
     node_type = atomic_mod.Atomic
 
 
-class MacroTools(PwfTools[fr.schemas.WorkflowRecipe]):
+class MacroTools(_PwfTools[fr.schemas.WorkflowRecipe]):
     node_type = dag.Macro
 
     def validate(

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -19,11 +19,11 @@ if TYPE_CHECKING:
 class _DecoratedFunction(abc.ABC):
     def __init__(self, wrapped: types.FunctionType):
         self._disallow_locals(wrapped)
-        self._decorated_function = wrapped
+        self._decorated_object = wrapped
 
     @property
     def recipe(self) -> fr.schemas.AtomicRecipe | fr.schemas.WorkflowRecipe:
-        return self._decorated_function.flowrep_recipe  # type: ignore[attr-defined]
+        return self._decorated_object.flowrep_recipe  # type: ignore[attr-defined]
 
     @abc.abstractmethod
     def node(
@@ -31,7 +31,7 @@ class _DecoratedFunction(abc.ABC):
     ) -> atomic_mod.Atomic | dag.Macro: ...
 
     def _label(self, label: fr.schemas.Label | None = None) -> fr.schemas.Label:
-        return self._decorated_function.__name__ if label is None else label
+        return self._decorated_object.__name__ if label is None else label
 
     def run(self, config: execution.RunConfig | None = None, **input_data):
         return self.node().run(config, **input_data)

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -5,7 +5,8 @@ import dataclasses
 import functools
 import inspect
 import types
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, cast
 
 import flowrep as fr
 from pyiron_snippets import versions
@@ -101,10 +102,7 @@ _assigned = tuple(
 
 @functools.wraps(fr.tools.atomic, assigned=_assigned)
 def atomic(*args, **kwargs):
-    wrapped = fr.tools.atomic(*args, **kwargs)
-    return _double_wrap_if_decorator_got_args(
-        args[0], wrapped, DecoratedAtomic, "@atomic"
-    )
+    return _attach_pwf_tool(fr.tools.atomic(*args, **kwargs), DecoratedAtomic)
 
 
 atomic.__doc__ = """
@@ -119,50 +117,34 @@ Base `flowrep` documentation:
 """ + (fr.tools.atomic.__doc__ or "")
 
 
-def _double_wrap_if_decorator_got_args(
-    arg0: str | types.FunctionType,
-    wrapped: types.FunctionType,
+def _attach_pwf_tool(
+    flowrep_result: (
+        types.FunctionType | Callable[[types.FunctionType], types.FunctionType]
+    ),
     tool: type[DecoratedAtomic] | type[DecoratedMacro],
-    decorator_name: str,
-):
-    if isinstance(arg0, types.FunctionType):
-        if not hasattr(wrapped, "flowrep_recipe"):  # pragma: no cover
-            raise ValueError(
-                f"The {decorator_name} decorator must be applied to a function "
-                f"decorated with flowrep, as evidenced by the presence of a "
-                f"`flowrep_recipe` attribute. This is an internal error and likely flags "
-                f"a development bug. dir({wrapped!r}) = {dir(wrapped)}."
-            )
-        setattr(
-            wrapped,
-            tool.assign_to,
-            tool(wrapped),
-        )
-        return wrapped
-    elif isinstance(arg0, str):
+) -> types.FunctionType | Callable[[types.FunctionType], types.FunctionType]:
+    if hasattr(flowrep_result, "flowrep_recipe"):
+        # Bare form: flowrep already decorated the function.
+        decorated = cast(types.FunctionType, flowrep_result)
+        setattr(decorated, tool.assign_to, tool(decorated))
+        return decorated
 
-        def wrapped_decorator(func):
-            double_wrapped = wrapped(func)
-            setattr(
-                double_wrapped,
-                tool.assign_to,
-                tool(double_wrapped),
-            )
-            return double_wrapped
+    # Parametrized form: flowrep returned a decorator awaiting the function.
+    flowrep_decorator = cast(
+        Callable[[types.FunctionType], types.FunctionType], flowrep_result
+    )
 
-        return wrapped_decorator
-    else:
-        raise TypeError(
-            f"{decorator_name} can only decorate functions, got {type(arg0).__name__}"
-        )
+    def decorator(func: types.FunctionType) -> types.FunctionType:
+        decorated = flowrep_decorator(func)
+        setattr(decorated, tool.assign_to, tool(decorated))
+        return decorated
+
+    return decorator
 
 
 @functools.wraps(fr.tools.workflow, assigned=_assigned)
 def workflow(*args, **kwargs):
-    wrapped = fr.tools.workflow(*args, **kwargs)
-    return _double_wrap_if_decorator_got_args(
-        args[0], wrapped, DecoratedMacro, "@workflow"
-    )
+    return _attach_pwf_tool(fr.tools.workflow(*args, **kwargs), DecoratedMacro)
 
 
 workflow.__doc__ = """

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import abc
+import dataclasses
 import functools
+import inspect
 import types
-from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar
 
 import flowrep as fr
+from pyiron_snippets import versions
 
 from pyiron_workflow._wfms import (
     atomic as atomic_mod,
@@ -172,3 +175,234 @@ or create a dynamic node instance and run it.
 Base `flowrep` documentation:
 
 """ + (fr.tools.workflow.__doc__ or "")
+
+
+class _DecoratedDataclass(
+    _PwfTools[type, fr.schemas.AtomicRecipe, atomic_mod.Atomic], abc.ABC
+):
+    _root_function: ClassVar[staticmethod[..., Any]]
+    _unpack_mode = type[fr.schemas.UnpackMode]
+
+    _node_type = atomic_mod.Atomic
+
+    def __init__(
+        self,
+        wrapped,
+        version_scraping: versions.VersionScrapingMap | None = None,
+        forbid_main: bool = False,
+        forbid_locals: bool = False,
+        forbid_lambda: bool = False,
+        require_version: bool = False,
+    ):
+        super().__init__(wrapped)
+
+        inputs, inputs_with_defaults, restricted_input_kinds, outputs, func_sig = (
+            self._parse_dataclass(wrapped)
+        )
+
+        self._function = functools.partial(self._root_function, *self._partials())
+        self._function.__name__ = wrapped.__name__  # type: ignore[attr-defined]
+        self._function.__signature__ = func_sig  # type: ignore[attr-defined]
+        self._function.__annotations__ = {  # type: ignore[attr-defined]
+            name: p.annotation
+            for name, p in func_sig.parameters.items()
+            if p.annotation is not inspect.Parameter.empty
+        }
+        self._function.__annotations__["return"] = wrapped
+
+        dc_version = versions.VersionInfo.of(
+            wrapped,
+            version_scraping=version_scraping,
+            forbid_main=forbid_main,
+            forbid_locals=forbid_locals,
+            forbid_lambda=forbid_lambda,
+            require_version=require_version,
+        )
+        self._recipe = fr.schemas.AtomicRecipe(
+            inputs=inputs,
+            outputs=outputs,
+            reference=fr.schemas.PythonReference(
+                info=versions.VersionInfo(
+                    module=dc_version.module,
+                    qualname=dc_version.qualname + f".{self.assign_to}._function",
+                    version=dc_version.version,
+                ),
+                inputs_with_defaults=inputs_with_defaults,
+                restricted_input_kinds=restricted_input_kinds,
+            ),
+            unpack_mode=self._unpack_mode,
+        )
+
+    @abc.abstractmethod
+    def _parse_dataclass(self, cls) -> tuple[
+        list[str],
+        list[str],
+        dict[str, fr.schemas.RestrictedParamKind],
+        list[str],
+        inspect.Signature,
+    ]: ...
+
+    @abc.abstractmethod
+    def _partials(self) -> tuple: ...
+
+    @property
+    def recipe(self) -> fr.schemas.AtomicRecipe:
+        return self._recipe
+
+
+def _inputs_to_dataclass(cls, *args, **kwargs):
+    return cls(*args, **kwargs)
+
+
+class Inputs2Dataclass(_DecoratedDataclass):
+    assign_to: ClassVar[str] = "pwf_inputs2dc"
+    _root_function = staticmethod(_inputs_to_dataclass)
+    _unpack_mode = fr.schemas.UnpackMode.NONE
+
+    def _parse_dataclass(self, cls) -> tuple[
+        list[str],
+        list[str],
+        dict[str, fr.schemas.RestrictedParamKind],
+        list[str],
+        inspect.Signature,
+    ]:
+        dc_sig = inspect.signature(cls)
+        params = dc_sig.parameters
+
+        inputs = list(params)
+        inputs_with_defaults = [
+            name
+            for name, p in params.items()
+            if p.default is not inspect.Parameter.empty
+        ]
+        restricted_input_kinds = {
+            name: fr.schemas.RestrictedParamKind.KEYWORD_ONLY
+            for name, p in params.items()
+            if p.kind == inspect.Parameter.KEYWORD_ONLY
+        }
+
+        output_name = "dataclass"
+
+        func_sig = dc_sig.replace(return_annotation=cls)
+
+        return (
+            inputs,
+            inputs_with_defaults,
+            restricted_input_kinds,
+            [output_name],
+            func_sig,
+        )
+
+    def _partials(self) -> tuple:
+        return (self._decorated_object,)
+
+    def _label(self, label: fr.schemas.Label | None = None) -> fr.schemas.Label:
+        return f"Inputs2{self._decorated_object.__name__}" if label is None else label
+
+
+def _dataclass_to_outputs(dataclass):
+    return dataclass
+
+
+class Dataclass2Outputs(_DecoratedDataclass):
+    assign_to: ClassVar[str] = "pwf_dc2outputs"
+    _root_function = staticmethod(_dataclass_to_outputs)
+    _unpack_mode = fr.schemas.UnpackMode.DATACLASS
+
+    def _parse_dataclass(self, cls) -> tuple[
+        list[str],
+        list[str],
+        dict[str, fr.schemas.RestrictedParamKind],
+        list[str],
+        inspect.Signature,
+    ]:
+        dc_sig = inspect.signature(cls)
+        params = dc_sig.parameters
+
+        outputs = list(params)
+
+        input_name = "dataclass"
+        func_sig = inspect.Signature(
+            parameters=[
+                inspect.Parameter(
+                    input_name,
+                    inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                    annotation=cls,
+                )
+            ],
+            return_annotation=cls,
+        )
+
+        return (
+            [input_name],
+            [],
+            {},
+            outputs,
+            func_sig,
+        )
+
+    def _partials(self) -> tuple:
+        return ()
+
+    def _label(self, label: fr.schemas.Label | None = None) -> fr.schemas.Label:
+        return (
+            f"Dataclass2{self._decorated_object.__name__}" if label is None else label
+        )
+
+
+@functools.wraps(dataclasses.dataclass, assigned=_assigned)
+def dataclass(
+    cls=None,
+    /,
+    version_scraping: versions.VersionScrapingMap | None = None,
+    forbid_main: bool = False,
+    forbid_locals: bool = False,
+    require_version: bool = False,
+    **dataclasses_dataclass_kwargs,
+):
+    def wrap(cls):
+        dcls = dataclasses.dataclass(**dataclasses_dataclass_kwargs)(cls)
+        setattr(
+            dcls,
+            Inputs2Dataclass.assign_to,
+            Inputs2Dataclass(
+                dcls,
+                version_scraping=version_scraping,
+                forbid_main=forbid_main,
+                forbid_locals=forbid_locals,
+                require_version=require_version,
+            ),
+        )
+        setattr(
+            dcls,
+            Dataclass2Outputs.assign_to,
+            Dataclass2Outputs(
+                dcls,
+                version_scraping=version_scraping,
+                forbid_main=forbid_main,
+                forbid_locals=forbid_locals,
+                require_version=require_version,
+            ),
+        )
+        return dcls
+
+    # See if we're being called as @dataclass or @dataclass().
+    if cls is None:
+        # We're called with parens.
+        return wrap
+
+    # We're called as @dataclass without parens.
+    return wrap(cls)
+
+
+dataclass.__doc__ = """
+A powered-up version of the standard `dataclasses` decorator of the same name.
+
+Additionally adds a `.pwf_dc2outputs` and `.pwf_inputs2dc` attributes which host methods 
+to instantiate atomic nodes converting between multiple graph IO and a single dataclass 
+instance. The decorated dataclass is still usable as a regular dataclass, but don't 
+use fields which conflict with these two new attribute names.
+
+Base `dataclass` documentation:
+
+""" + (dataclasses.dataclass.__doc__ or "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "pint==0.25.3",
     "pyiron_snippets==1.3.0",
     "rdflib==7.6.0",
-    "semantikon==1.3.1",
+    "semantikon==1.3.2",
     "toposort==1.10",
     "typeguard==4.5.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "bidict==0.23.1",
     "cloudpickle==3.1.2",
     "executorlib==1.9.3",
-    "flowrep==0.5.1",
+    "flowrep==0.5.2",
     "graphviz==0.21",
     "networkx==3.6.1",
     "pandas==3.0.2",

--- a/tests/unit/_wfms/_fixtures.py
+++ b/tests/unit/_wfms/_fixtures.py
@@ -739,6 +739,6 @@ class WithInitFalse:
 
 @wfms.dataclass
 class WithInitVar:
-    a: int
+    a: "int"  # noqa: UP037
     d: dataclasses.InitVar[int] = 3
     b: int = 5

--- a/tests/unit/_wfms/_fixtures.py
+++ b/tests/unit/_wfms/_fixtures.py
@@ -14,6 +14,7 @@ Usage:
 
 from __future__ import annotations
 
+import dataclasses
 from typing import Annotated
 
 import flowrep as fr
@@ -681,3 +682,63 @@ def clothes_correct_macro_node(label: str = "my_correct_macro"):
 def clothes_incorrect_macro_node(label: str = "my_incorrect_macro"):
     """Return a fresh `Macro` for the invalid clothes pipeline (dye -> sell)."""
     return my_incorrect_macro.pwf.node(label)
+
+
+# --------------------------------------------------------------------------- #
+# Decorator-tool fixtures (wfms.atomic / wfms.workflow)                        #
+# --------------------------------------------------------------------------- #
+
+
+@wfms.atomic
+def wfms_add(x, y):
+    return x + y
+
+
+@wfms.atomic("relabelled_sum")
+def wfms_add_relabelled(x, y):
+    return x + y
+
+
+@wfms.workflow
+def wfms_macro(x, y, z):
+    a = add(x, y)
+    s = sub(a, z)
+    return a, s
+
+
+# --------------------------------------------------------------------------- #
+# Dataclass fixtures (wfms.dataclass)                                          #
+# --------------------------------------------------------------------------- #
+
+
+@wfms.dataclass
+class PlainPoint:
+    x: float
+    y: float
+
+
+@wfms.dataclass
+class WithDefaults:
+    a: int
+    b: int = 5
+    c: list = dataclasses.field(default_factory=list)
+
+
+@wfms.dataclass(frozen=True, kw_only=True)
+class FrozenKw:
+    nova: float
+    foo: int = 42
+    not_a_field = 13  # unannotated -> NOT a dataclass field
+
+
+@wfms.dataclass
+class WithInitFalse:
+    a: int
+    c: int = dataclasses.field(init=False, default=7)
+
+
+@wfms.dataclass
+class WithInitVar:
+    a: int
+    d: dataclasses.InitVar[int] = 3
+    b: int = 5

--- a/tests/unit/_wfms/_fixtures.py
+++ b/tests/unit/_wfms/_fixtures.py
@@ -694,6 +694,11 @@ def wfms_add(x, y):
     return x + y
 
 
+@wfms.atomic
+def wfms_sub(x, y):
+    return x - y
+
+
 @wfms.atomic("relabelled_sum")
 def wfms_add_relabelled(x, y):
     return x + y
@@ -701,8 +706,8 @@ def wfms_add_relabelled(x, y):
 
 @wfms.workflow
 def wfms_macro(x, y, z):
-    a = add(x, y)
-    s = sub(a, z)
+    a = wfms_add(x, y)
+    s = wfms_sub(a, z)
     return a, s
 
 

--- a/tests/unit/_wfms/test_dag.py
+++ b/tests/unit/_wfms/test_dag.py
@@ -66,9 +66,9 @@ class TestMacro(unittest.TestCase):
     def test_edges_constructed_from_recipe(self) -> None:
         n = _fixtures.macro_node()
         recipe_edges = (
-            [(source, target) for target, source in n._recipe.input_edges.items()]
-            + [(source, target) for target, source in n._recipe.edges.items()]
-            + [(source, target) for target, source in n._recipe.output_edges.items()]
+            [(source, target) for target, source in n.recipe.input_edges.items()]
+            + [(source, target) for target, source in n.recipe.edges.items()]
+            + [(source, target) for target, source in n.recipe.output_edges.items()]
         )
         self.assertSetEqual(set(recipe_edges), set(n.edges))
 

--- a/tests/unit/_wfms/test_decorators.py
+++ b/tests/unit/_wfms/test_decorators.py
@@ -6,7 +6,7 @@ import unittest
 import flowrep as fr
 
 from pyiron_workflow._wfms import api as wfms
-from pyiron_workflow._wfms import decorators
+from pyiron_workflow._wfms import decorators, validation
 from tests.unit._wfms import _fixtures
 
 
@@ -22,6 +22,14 @@ def _make_local_dataclass():
         a: int
 
     return Local
+
+
+def _make_local_atomic():
+    @wfms.atomic
+    def inner(x):
+        return x
+
+    return inner
 
 
 class _NoVersionCarrier:
@@ -168,6 +176,46 @@ class TestDataclassGuards(unittest.TestCase):
     def test_require_version_raises_without_version(self) -> None:
         with self.assertRaises(ValueError):
             wfms.dataclass(require_version=True)(_NoVersionCarrier)
+
+
+class TestAtomicWorkflowDecorators(unittest.TestCase):
+    def test_bare_atomic_attaches_tool(self) -> None:
+        self.assertIsInstance(_fixtures.wfms_add.pwf, decorators.DecoratedAtomic)
+
+    def test_atomic_default_and_explicit_label(self) -> None:
+        self.assertEqual(_fixtures.wfms_add.pwf.node().label, "wfms_add")
+        self.assertEqual(_fixtures.wfms_add.pwf.node("custom").label, "custom")
+
+    def test_atomic_run(self) -> None:
+        run = _fixtures.wfms_add.pwf.run(x=1, y=2)
+        (only,) = run.outputs.keys()
+        self.assertEqual(run.outputs[only].value, 3)
+
+    def test_string_dispatch_relabels_output(self) -> None:
+        self.assertIsInstance(
+            _fixtures.wfms_add_relabelled.pwf, decorators.DecoratedAtomic
+        )
+        self.assertEqual(
+            list(_fixtures.wfms_add_relabelled.pwf.node().outputs), ["relabelled_sum"]
+        )
+
+    def test_workflow_attaches_macro_tool(self) -> None:
+        self.assertIsInstance(_fixtures.wfms_macro.pwf, decorators.DecoratedMacro)
+        self.assertEqual(_fixtures.wfms_macro.pwf.node().label, "wfms_macro")
+
+    def test_macro_validate_returns_report(self) -> None:
+        report = _fixtures.wfms_macro.pwf.validate()
+        self.assertIsInstance(report, validation.CombinedValidationReport)
+
+    def test_invalid_dispatch_raises_type_error(self) -> None:
+        with self.assertRaises(TypeError):
+            decorators._double_wrap_if_decorator_got_args(
+                123, lambda: None, decorators.DecoratedAtomic, "@atomic"
+            )
+
+    def test_local_function_rejected(self) -> None:
+        with self.assertRaises(ImportError):
+            _make_local_atomic()
 
 
 if __name__ == "__main__":

--- a/tests/unit/_wfms/test_decorators.py
+++ b/tests/unit/_wfms/test_decorators.py
@@ -40,6 +40,10 @@ class _ForbidLambdaCarrier:
     a: int = 0
 
 
+def _nounpack_target(x):
+    return x, x  # with UnpackMode.NONE this stays a single output port
+
+
 class TestDataclassDecorator(unittest.TestCase):
     def test_attaches_both_tools(self) -> None:
         self.assertIsInstance(
@@ -220,9 +224,14 @@ class TestAtomicWorkflowDecorators(unittest.TestCase):
 
     def test_invalid_dispatch_raises_type_error(self) -> None:
         with self.assertRaises(TypeError):
-            decorators._double_wrap_if_decorator_got_args(
-                123, lambda: None, decorators.DecoratedAtomic, "@atomic"
-            )
+            wfms.atomic(123)
+
+    def test_keyword_param_form_attaches_tool(self) -> None:
+        decorated = wfms.atomic(unpack_mode=fr.schemas.UnpackMode.NONE)(
+            _nounpack_target
+        )
+        self.assertIsInstance(decorated.pwf, decorators.DecoratedAtomic)
+        self.assertEqual(len(list(decorated.pwf.node().outputs)), 1)
 
     def test_local_function_rejected(self) -> None:
         with self.assertRaises(ImportError):

--- a/tests/unit/_wfms/test_decorators.py
+++ b/tests/unit/_wfms/test_decorators.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import dataclasses
+import unittest
+
+from pyiron_workflow._wfms import decorators
+from tests.unit._wfms import _fixtures
+
+
+class TestDataclassDecorator(unittest.TestCase):
+    def test_attaches_both_tools(self) -> None:
+        self.assertIsInstance(
+            _fixtures.PlainPoint.pwf_inputs2dc, decorators.Inputs2Dataclass
+        )
+        self.assertIsInstance(
+            _fixtures.PlainPoint.pwf_dc2outputs, decorators.Dataclass2Outputs
+        )
+
+    def test_still_a_dataclass(self) -> None:
+        self.assertTrue(dataclasses.is_dataclass(_fixtures.PlainPoint))
+        self.assertEqual(_fixtures.PlainPoint(1.0, 2.0).x, 1.0)
+
+    def test_parameterized_call_form(self) -> None:
+        # @wfms.dataclass(frozen=True, kw_only=True) returns a usable dataclass
+        self.assertTrue(dataclasses.is_dataclass(_fixtures.FrozenKw))
+        inst = _fixtures.FrozenKw(nova=1.1)
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            inst.nova = 2.2  # type: ignore[misc]
+
+    def test_unannotated_attribute_is_not_a_field(self) -> None:
+        field_names = {f.name for f in dataclasses.fields(_fixtures.FrozenKw)}
+        self.assertNotIn("not_a_field", field_names)
+        self.assertNotIn(
+            "not_a_field", list(_fixtures.FrozenKw.pwf_inputs2dc.node().inputs)
+        )
+
+    def test_node_labels_default_and_explicit(self) -> None:
+        self.assertEqual(
+            _fixtures.PlainPoint.pwf_inputs2dc.node().label, "Inputs2PlainPoint"
+        )
+        self.assertEqual(
+            _fixtures.PlainPoint.pwf_dc2outputs.node().label, "Dataclass2PlainPoint"
+        )
+        self.assertEqual(
+            _fixtures.PlainPoint.pwf_inputs2dc.node("custom").label, "custom"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/_wfms/test_decorators.py
+++ b/tests/unit/_wfms/test_decorators.py
@@ -79,6 +79,10 @@ class TestInputs2Dataclass(unittest.TestCase):
 
 
 class TestDataclass2Outputs(unittest.TestCase):
+    def test_string_annotation_resolves(self):
+        node = _fixtures.WithInitVar.pwf_dc2outputs.node()
+        self.assertEqual(node.outputs["a"].type_hint, int)
+
     def test_plain_ports(self) -> None:
         node = _fixtures.PlainPoint.pwf_dc2outputs.node()
         self.assertEqual(list(node.inputs), ["dataclass"])

--- a/tests/unit/_wfms/test_decorators.py
+++ b/tests/unit/_wfms/test_decorators.py
@@ -10,6 +10,24 @@ from pyiron_workflow._wfms import decorators
 from tests.unit._wfms import _fixtures
 
 
+class _ReservedFieldCarrier:
+    """Plain class whose field name collides with the reserved 'dataclass' port."""
+
+    dataclass: int = 0
+
+
+def _make_local_dataclass():
+    @wfms.dataclass
+    class Local:
+        a: int
+
+    return Local
+
+
+class _NoVersionCarrier:
+    a: int = 0
+
+
 class TestDataclassDecorator(unittest.TestCase):
     def test_attaches_both_tools(self) -> None:
         self.assertIsInstance(
@@ -136,6 +154,20 @@ class TestDataclass2Outputs(unittest.TestCase):
             wf.run(dataclass=_fixtures.PlainPoint(1.0, 2.0)).outputs["dataclass"].value
         )
         self.assertEqual(result, _fixtures.PlainPoint(1.0, 2.0))
+
+
+class TestDataclassGuards(unittest.TestCase):
+    def test_reserved_field_name_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            wfms.dataclass(_ReservedFieldCarrier)
+
+    def test_local_dataclass_rejected(self) -> None:
+        with self.assertRaises(ImportError):
+            _make_local_dataclass()
+
+    def test_require_version_raises_without_version(self) -> None:
+        with self.assertRaises(ValueError):
+            wfms.dataclass(require_version=True)(_NoVersionCarrier)
 
 
 if __name__ == "__main__":

--- a/tests/unit/_wfms/test_decorators.py
+++ b/tests/unit/_wfms/test_decorators.py
@@ -5,6 +5,7 @@ import unittest
 
 import flowrep as fr
 
+from pyiron_workflow._wfms import api as wfms
 from pyiron_workflow._wfms import decorators
 from tests.unit._wfms import _fixtures
 
@@ -75,6 +76,62 @@ class TestInputs2Dataclass(unittest.TestCase):
                 for kind in ref.restricted_input_kinds.values()
             )
         )
+
+
+class TestDataclass2Outputs(unittest.TestCase):
+    def test_plain_ports(self) -> None:
+        node = _fixtures.PlainPoint.pwf_dc2outputs.node()
+        self.assertEqual(list(node.inputs), ["dataclass"])
+        self.assertEqual(list(node.outputs), ["x", "y"])
+
+    def test_plain_run_unpacks_fields(self) -> None:
+        run = _fixtures.PlainPoint.pwf_dc2outputs.run(
+            dataclass=_fixtures.PlainPoint(1.0, 2.0)
+        )
+        self.assertEqual(run.outputs["x"].value, 1.0)
+        self.assertEqual(run.outputs["y"].value, 2.0)
+
+    def test_frozen_read_back(self) -> None:
+        run = _fixtures.FrozenKw.pwf_dc2outputs.run(
+            dataclass=_fixtures.FrozenKw(nova=1.1)
+        )
+        self.assertEqual(run.outputs["nova"].value, 1.1)
+        self.assertEqual(run.outputs["foo"].value, 42)
+
+    def test_init_false_field_is_output_not_input(self) -> None:
+        # init=False -> real field (output) but not a constructor param (no input)
+        self.assertEqual(
+            list(_fixtures.WithInitFalse.pwf_dc2outputs.node().outputs), ["a", "c"]
+        )
+        self.assertEqual(
+            list(_fixtures.WithInitFalse.pwf_inputs2dc.node().inputs), ["a"]
+        )
+        run = _fixtures.WithInitFalse.pwf_dc2outputs.run(
+            dataclass=_fixtures.WithInitFalse(a=1)
+        )
+        self.assertEqual(run.outputs["c"].value, 7)
+
+    def test_init_var_is_input_not_output(self) -> None:
+        # InitVar -> constructor param (input) but not a real field (no output)
+        self.assertEqual(
+            list(_fixtures.WithInitVar.pwf_dc2outputs.node().outputs), ["a", "b"]
+        )
+        self.assertEqual(
+            list(_fixtures.WithInitVar.pwf_inputs2dc.node().inputs), ["a", "d", "b"]
+        )
+
+    def test_round_trip(self) -> None:
+        wf = wfms.Workflow("roundtrip")
+        wf.to_values = _fixtures.PlainPoint.pwf_dc2outputs.node()
+        wf.to_dc = _fixtures.PlainPoint.pwf_inputs2dc.node()
+        wf.create_input_for(wf.to_values.inputs.dataclass)
+        wf.create_output_from(wf.to_dc)
+        for k in wf.to_values.outputs:
+            wf.connect(wf.to_values.outputs[k], wf.to_dc.inputs[k])
+        result = (
+            wf.run(dataclass=_fixtures.PlainPoint(1.0, 2.0)).outputs["dataclass"].value
+        )
+        self.assertEqual(result, _fixtures.PlainPoint(1.0, 2.0))
 
 
 if __name__ == "__main__":

--- a/tests/unit/_wfms/test_decorators.py
+++ b/tests/unit/_wfms/test_decorators.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import dataclasses
 import unittest
 
+import flowrep as fr
+
 from pyiron_workflow._wfms import decorators
 from tests.unit._wfms import _fixtures
 
@@ -43,6 +45,35 @@ class TestDataclassDecorator(unittest.TestCase):
         )
         self.assertEqual(
             _fixtures.PlainPoint.pwf_inputs2dc.node("custom").label, "custom"
+        )
+
+
+class TestInputs2Dataclass(unittest.TestCase):
+    def test_ports(self) -> None:
+        node = _fixtures.PlainPoint.pwf_inputs2dc.node()
+        self.assertEqual(list(node.inputs), ["x", "y"])
+        self.assertEqual(list(node.outputs), ["dataclass"])
+
+    def test_run_constructs_instance(self) -> None:
+        run = _fixtures.PlainPoint.pwf_inputs2dc.run(x=1.0, y=2.0)
+        self.assertEqual(run.outputs["dataclass"].value, _fixtures.PlainPoint(1.0, 2.0))
+
+    def test_inputs_with_defaults(self) -> None:
+        ref = _fixtures.WithDefaults.pwf_inputs2dc.recipe.reference
+        self.assertEqual(ref.inputs_with_defaults, ["b", "c"])
+
+    def test_default_factory_resolves_on_run(self) -> None:
+        run = _fixtures.WithDefaults.pwf_inputs2dc.run(a=1)
+        self.assertEqual(run.outputs["dataclass"].value, _fixtures.WithDefaults(a=1))
+
+    def test_kw_only_recorded_as_restricted(self) -> None:
+        ref = _fixtures.FrozenKw.pwf_inputs2dc.recipe.reference
+        self.assertEqual(set(ref.restricted_input_kinds), {"nova", "foo"})
+        self.assertTrue(
+            all(
+                kind is fr.schemas.RestrictedParamKind.KEYWORD_ONLY
+                for kind in ref.restricted_input_kinds.values()
+            )
         )
 
 

--- a/tests/unit/_wfms/test_decorators.py
+++ b/tests/unit/_wfms/test_decorators.py
@@ -36,6 +36,10 @@ class _NoVersionCarrier:
     a: int = 0
 
 
+class _ForbidLambdaCarrier:
+    a: int = 0
+
+
 class TestDataclassDecorator(unittest.TestCase):
     def test_attaches_both_tools(self) -> None:
         self.assertIsInstance(
@@ -176,6 +180,13 @@ class TestDataclassGuards(unittest.TestCase):
     def test_require_version_raises_without_version(self) -> None:
         with self.assertRaises(ValueError):
             wfms.dataclass(require_version=True)(_NoVersionCarrier)
+
+    def test_forbid_lambda_forwarded(self) -> None:
+        # forbid_lambda is irrelevant for a class but must be accepted and
+        # forwarded to both tools without error.
+        dcls = wfms.dataclass(forbid_lambda=True)(_ForbidLambdaCarrier)
+        self.assertIsInstance(dcls.pwf_inputs2dc, decorators.Inputs2Dataclass)
+        self.assertIsInstance(dcls.pwf_dc2outputs, decorators.Dataclass2Outputs)
 
 
 class TestAtomicWorkflowDecorators(unittest.TestCase):

--- a/tests/unit/_wfms/test_validation.py
+++ b/tests/unit/_wfms/test_validation.py
@@ -467,7 +467,7 @@ class TestValidationSignatureCoherence(unittest.TestCase):
         for fn in (
             dag.Macro.validate,
             workflow.Workflow.validate,
-            decorators.MacroTools.validate,
+            decorators.DecoratedMacro.validate,
         ):
             self.assertEqual(
                 list(inspect.signature(fn).parameters)[1:], base


### PR DESCRIPTION
`@pyiron_workflow._wfms.api.dataclass` operates as a normal `@dataclasses.dataclass` decorator _and_ extends the dataclass with two new fields `.pwf_inputs2dc` and `.pwf._dc2outputs` analogous to the `.pwf` tools added to `@atomic` and `@workflow` decorated functions. These offer the same `.node` and `.run` methods, for transforming dataclass instances to/from IO ports.

Closes #864