### PR TITLE
Executorlib QoL

### DIFF
--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -38,3 +38,15 @@ jobs:
     uses: ./.github/workflows/slurm-test.yml
     with:
       mode: discover
+
+  slurm-interruption-wfms:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/slurm-test-wfms.yml
+    with:
+      mode: interrupt
+
+  slurm-discovery-wfms:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/slurm-test-wfms.yml
+    with:
+      mode: discover

--- a/.github/workflows/slurm-test-wfms.yml
+++ b/.github/workflows/slurm-test-wfms.yml
@@ -1,0 +1,33 @@
+name: Slurm Test WfMS
+on:
+  workflow_call:
+    inputs:
+      mode:
+        required: true
+        type: string
+
+jobs:
+  slurm_test:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - "8888:3306"
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+    steps:
+      - uses: actions/checkout@v6
+      - uses: koesterlab/setup-slurm-action@v1
+        timeout-minutes: 5
+      - uses: pyiron/actions/cached-miniforge@actions-4.2.1
+        with:
+          python-version: '3.12'
+          env-files: .ci_support/environment.yml .ci_support/environment-cluster.yml
+      - name: Test (${{ inputs.mode }})
+        shell: bash -l {0}
+        timeout-minutes: 8
+        run: |
+          python -u tests/cluster/_wfms/slurm_test.py --submit
+          python -u tests/cluster/_wfms/slurm_test.py --${{ inputs.mode }}

--- a/notebooks/_wfms.ipynb
+++ b/notebooks/_wfms.ipynb
@@ -891,12 +891,120 @@
    "metadata": {},
    "cell_type": "markdown",
    "source": [
-    "### Executorlib and trans-shutdown persistence\n",
+    "### Executorlib -- scaling and trans-shutdown persistence\n",
     "\n",
-    "_(TO IMPLEMENT)_ -- HPC-aware executors and resuming runs across interpreter\n",
-    "shutdowns. Coming soon."
+    "[`executorlib`](https://github.com/pyiron/executorlib) is the pyiron solution for scaling workflows to HPC; it uses the `concurrent.futures.Executor` API, but executes pyiron functions on more powerful compute using SLURM and flux.\n",
+    "\n",
+    "Because they follow the python standard library interface, `executorlib` executors are drop-in compatible in the `.executor` attribute on nodes (in both their instance and `ExecutorInstructions` format. To see that, let's revisit our process ID example using `executorlib.SingleNodeExecutor`. This time, we'll leverage `executorlib`'s use of `cloudpickle` to show how the `SingleNodeExecutor` will let us ship functions _defined locally in the notebook_ off to alternate processes."
    ],
    "id": "199261e134563fe5"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import executorlib\n",
+    "\n",
+    "def local_getpid():\n",
+    "    pid = os.getpid()\n",
+    "    return pid\n",
+    "\n",
+    "@pwf.workflow\n",
+    "def local_pids():\n",
+    "    pid0 = local_getpid()\n",
+    "    pid1 = local_getpid()\n",
+    "    return pid0, pid1\n",
+    "\n",
+    "wf = local_pids.pwf.node()\n",
+    "with executorlib.SingleNodeExecutor() as exe:\n",
+    "    wf.local_getpid_1.executor = exe\n",
+    "    out = wf.run()\n",
+    "\n",
+    "print(\"Notebook process PID:\", os.getpid())\n",
+    "out.outputs"
+   ],
+   "id": "3a4b898a90a3e6ac"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "To handle cross-process executions (e.g. you submit a job, shutdown your jupyter notebook, then come back tomorrow and want to recover the same job), `executorlib` uses local caches. In order to get cache hits in the graph-node-execution context, we provide thinly-wrapped executors which _only_ work with submitting node runs, and which override the caching directory to use the run configuration directory, and override the cache filenames to use the lexical path.\n",
+    "\n",
+    "Since we don't have access to SLURM from inside this notebook, we'll demonstrate the behaviour with a test executor. The `pyiron_workflow` wrapping aspect is identical for both this toy executor and its full SLURM counterpart, only the actual SLURM management itself differs. So here we learn cache management, and to learn how to configure the SLURM executor, see the `executorlib` docs themselves, or the GitHub continuous integration (CI) workflows for this package."
+   ],
+   "id": "96abd76c63477813"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import pathlib\n",
+    "import shutil\n",
+    "\n",
+    "def slow_node(t):\n",
+    "    time.sleep(t)\n",
+    "    return t\n",
+    "\n",
+    "@pwf.workflow\n",
+    "def slow_wf(t_sleep):\n",
+    "    slept_for = slow_node(t_sleep)\n",
+    "    return slept_for\n",
+    "\n",
+    "wf = slow_wf.pwf.node()\n",
+    "run_dir = pathlib.Path(\"./testing_exec_cache\")\n",
+    "cfg = pwf.RunConfig(run_dir=run_dir)\n",
+    "wf.slow_node_0.executor = pwf.ExecutorInstructions(\n",
+    "    pwf.tools._CacheTestExecutor,\n",
+    ")\n",
+    "\n",
+    "t_sleep = 1\n",
+    "t0 = time.perf_counter()\n",
+    "out1 = wf.run(cfg, t_sleep=t_sleep)\n",
+    "t1 = time.perf_counter()\n",
+    "out2 = wf.run(cfg, t_sleep=t_sleep)\n",
+    "t2 = time.perf_counter()\n",
+    "\n",
+    "print(f\"First run took {t1-t0:.3f}s\")\n",
+    "print(f\"Second run took {t2-t1:.3f}s\")\n",
+    "cache_dir = run_dir / pwf.tools._CacheTestExecutor.cache_directory\n",
+    "print(\"Second run exploited executorlib cache:\", list(cache_dir.iterdir()))"
+   ],
+   "id": "47832673e3675d96"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Since the cache filename derives from the node's lexical path, _all_ invocations of this executor for the same node in the same run config directory will find the hash -- even if we don't want them to. E.g., below we change our input, but still hit our cached result:",
+   "id": "a21152bdc3ca6496"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "with pwf.tools._CacheTestExecutor() as exe:\n",
+    "    wf.slow_node_0.executor = exe\n",
+    "    out_shorter = wf.run(cfg, t_sleep=t_sleep * 42)\n",
+    "out_shorter.outputs"
+   ],
+   "id": "12e4c01b88ed659a"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "# Clean up\n",
+    "shutil.rmtree(run_dir)"
+   ],
+   "id": "b896291d36ff7a41"
   },
   {
    "metadata": {},

--- a/notebooks/_wfms.ipynb
+++ b/notebooks/_wfms.ipynb
@@ -44,8 +44,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:11.580234Z",
-     "start_time": "2026-06-23T05:06:11.309603Z"
+     "end_time": "2026-06-24T23:53:33.245192Z",
+     "start_time": "2026-06-24T23:53:32.857015Z"
     }
    },
    "source": [
@@ -80,8 +80,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:11.607746Z",
-     "start_time": "2026-06-23T05:06:11.581960Z"
+     "end_time": "2026-06-24T23:53:33.379506Z",
+     "start_time": "2026-06-24T23:53:33.275352Z"
     }
    },
    "source": "mul.flowrep_recipe.model_dump(mode=\"json\")",
@@ -125,8 +125,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.139074Z",
-     "start_time": "2026-06-23T05:06:11.620084Z"
+     "end_time": "2026-06-24T23:53:34.896387Z",
+     "start_time": "2026-06-24T23:53:33.412821Z"
     }
    },
    "cell_type": "code",
@@ -141,8 +141,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.179827Z",
-     "start_time": "2026-06-23T05:06:13.154021Z"
+     "end_time": "2026-06-24T23:53:34.958736Z",
+     "start_time": "2026-06-24T23:53:34.911214Z"
     }
    },
    "source": [
@@ -196,8 +196,8 @@
    "id": "b8a1c76c",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.202868Z",
-     "start_time": "2026-06-23T05:06:13.189399Z"
+     "end_time": "2026-06-24T23:53:35.046738Z",
+     "start_time": "2026-06-24T23:53:34.988327Z"
     }
    },
    "source": [
@@ -213,8 +213,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.211559Z",
-     "start_time": "2026-06-23T05:06:13.204278Z"
+     "end_time": "2026-06-24T23:53:35.064917Z",
+     "start_time": "2026-06-24T23:53:35.056485Z"
     }
    },
    "source": [
@@ -230,7 +230,7 @@
      "text": [
       "status:   finished\n",
       "outputs:  {'shifted': 11}\n",
-      "duration: 0:00:00.000669\n",
+      "duration: 0:00:00.000759\n",
       "steps:    ['mul_0', 'add_0']\n"
      ]
     }
@@ -246,8 +246,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.234752Z",
-     "start_time": "2026-06-23T05:06:13.220998Z"
+     "end_time": "2026-06-24T23:53:35.101544Z",
+     "start_time": "2026-06-24T23:53:35.074458Z"
     }
    },
    "cell_type": "code",
@@ -271,8 +271,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.258051Z",
-     "start_time": "2026-06-23T05:06:13.244924Z"
+     "end_time": "2026-06-24T23:53:35.115890Z",
+     "start_time": "2026-06-24T23:53:35.103035Z"
     }
    },
    "cell_type": "code",
@@ -310,8 +310,8 @@
    "id": "564944f4",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.319901Z",
-     "start_time": "2026-06-23T05:06:13.268677Z"
+     "end_time": "2026-06-24T23:53:35.138196Z",
+     "start_time": "2026-06-24T23:53:35.125832Z"
     }
    },
    "source": [
@@ -327,8 +327,8 @@
    "id": "2d89bee2",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.331829Z",
-     "start_time": "2026-06-23T05:06:13.321329Z"
+     "end_time": "2026-06-24T23:53:35.158120Z",
+     "start_time": "2026-06-24T23:53:35.148997Z"
     }
    },
    "source": [
@@ -346,8 +346,8 @@
    "id": "cd94d762",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.353642Z",
-     "start_time": "2026-06-23T05:06:13.340413Z"
+     "end_time": "2026-06-24T23:53:35.182587Z",
+     "start_time": "2026-06-24T23:53:35.169046Z"
     }
    },
    "source": "print(\"one-shot run:\", increment.pwf.run(x=4).outputs[\"output_0\"])",
@@ -368,8 +368,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.389164Z",
-     "start_time": "2026-06-23T05:06:13.363394Z"
+     "end_time": "2026-06-24T23:53:35.217651Z",
+     "start_time": "2026-06-24T23:53:35.192050Z"
     }
    },
    "source": [
@@ -429,8 +429,8 @@
    "id": "5a595873",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.427384Z",
-     "start_time": "2026-06-23T05:06:13.400272Z"
+     "end_time": "2026-06-24T23:53:35.247201Z",
+     "start_time": "2026-06-24T23:53:35.219253Z"
     }
    },
    "source": [
@@ -477,8 +477,8 @@
    "id": "1ad7570e",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.445739Z",
-     "start_time": "2026-06-23T05:06:13.429008Z"
+     "end_time": "2026-06-24T23:53:35.275138Z",
+     "start_time": "2026-06-24T23:53:35.249038Z"
     }
    },
    "source": [
@@ -531,8 +531,8 @@
    "id": "4910bdc7",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.477124Z",
-     "start_time": "2026-06-23T05:06:13.456707Z"
+     "end_time": "2026-06-24T23:53:35.298463Z",
+     "start_time": "2026-06-24T23:53:35.287253Z"
     }
    },
    "source": [
@@ -567,8 +567,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.521353Z",
-     "start_time": "2026-06-23T05:06:13.488611Z"
+     "end_time": "2026-06-24T23:53:35.330247Z",
+     "start_time": "2026-06-24T23:53:35.309055Z"
     }
    },
    "source": [
@@ -598,8 +598,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.588208Z",
-     "start_time": "2026-06-23T05:06:13.559264Z"
+     "end_time": "2026-06-24T23:53:35.350625Z",
+     "start_time": "2026-06-24T23:53:35.341610Z"
     }
    },
    "cell_type": "code",
@@ -631,8 +631,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.620656Z",
-     "start_time": "2026-06-23T05:06:13.600633Z"
+     "end_time": "2026-06-24T23:53:35.377602Z",
+     "start_time": "2026-06-24T23:53:35.360940Z"
     }
    },
    "cell_type": "code",
@@ -666,8 +666,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:13.652124Z",
-     "start_time": "2026-06-23T05:06:13.622359Z"
+     "end_time": "2026-06-24T23:53:35.406359Z",
+     "start_time": "2026-06-24T23:53:35.391343Z"
     }
    },
    "cell_type": "code",
@@ -714,8 +714,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:14.071347Z",
-     "start_time": "2026-06-23T05:06:13.653717Z"
+     "end_time": "2026-06-24T23:53:35.845421Z",
+     "start_time": "2026-06-24T23:53:35.417098Z"
     }
    },
    "cell_type": "code",
@@ -748,7 +748,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.408\n"
+      "0.409035\n"
      ]
     }
    ],
@@ -768,8 +768,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:15.125222Z",
-     "start_time": "2026-06-23T05:06:14.075961Z"
+     "end_time": "2026-06-24T23:53:36.910748Z",
+     "start_time": "2026-06-24T23:53:35.863562Z"
     }
    },
    "cell_type": "code",
@@ -790,7 +790,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.022951\n"
+      "1.022711\n"
      ]
     }
    ],
@@ -815,8 +815,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:15.191090Z",
-     "start_time": "2026-06-23T05:06:15.161915Z"
+     "end_time": "2026-06-24T23:53:36.952518Z",
+     "start_time": "2026-06-24T23:53:36.933556Z"
     }
    },
    "cell_type": "code",
@@ -847,8 +847,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:16.792109Z",
-     "start_time": "2026-06-23T05:06:15.192998Z"
+     "end_time": "2026-06-24T23:53:38.605170Z",
+     "start_time": "2026-06-24T23:53:36.965623Z"
     }
    },
    "cell_type": "code",
@@ -879,9 +879,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Local PID 6942\n",
-      "pid0 PID: 6942\n",
-      "pid1 PID: 6951\n"
+      "Local PID 34187\n",
+      "pid0 PID: 34187\n",
+      "pid1 PID: 34196\n"
      ]
     }
    ],
@@ -900,10 +900,13 @@
    "id": "199261e134563fe5"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-24T23:53:40.275304Z",
+     "start_time": "2026-06-24T23:53:38.617765Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "import executorlib\n",
     "\n",
@@ -925,7 +928,28 @@
     "print(\"Notebook process PID:\", os.getpid())\n",
     "out.outputs"
    ],
-   "id": "3a4b898a90a3e6ac"
+   "id": "3a4b898a90a3e6ac",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Notebook process PID: 34187\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'pid0': OutputDataPort(value=34187, annotation=None),\n",
+       " 'pid1': OutputDataPort(value=34198, annotation=None)}"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 24
   },
   {
    "metadata": {},
@@ -938,10 +962,13 @@
    "id": "96abd76c63477813"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-24T23:53:42.886836Z",
+     "start_time": "2026-06-24T23:53:40.288869Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "import pathlib\n",
     "import shutil\n",
@@ -974,7 +1001,19 @@
     "cache_dir = run_dir / pwf.tools._CacheTestExecutor.cache_directory\n",
     "print(\"Second run exploited executorlib cache:\", list(cache_dir.iterdir()))"
    ],
-   "id": "47832673e3675d96"
+   "id": "47832673e3675d96",
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "First run took 2.545s\n",
+      "Second run took 0.026s\n",
+      "Second run exploited executorlib cache: [PosixPath('testing_exec_cache/executorlib_cache/pyiron.log'), PosixPath('testing_exec_cache/executorlib_cache/slow_wf.slow_node_0_o.h5')]\n"
+     ]
+    }
+   ],
+   "execution_count": 25
   },
   {
    "metadata": {},
@@ -983,28 +1022,49 @@
    "id": "a21152bdc3ca6496"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-24T23:53:42.961117Z",
+     "start_time": "2026-06-24T23:53:42.900112Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "with pwf.tools._CacheTestExecutor() as exe:\n",
     "    wf.slow_node_0.executor = exe\n",
     "    out_shorter = wf.run(cfg, t_sleep=t_sleep * 42)\n",
     "out_shorter.outputs"
    ],
-   "id": "12e4c01b88ed659a"
+   "id": "12e4c01b88ed659a",
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'slept_for': OutputDataPort(value=1, annotation=None)}"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 26
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-06-24T23:53:42.980751Z",
+     "start_time": "2026-06-24T23:53:42.963054Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "# Clean up\n",
     "shutil.rmtree(run_dir)"
    ],
-   "id": "b896291d36ff7a41"
+   "id": "b896291d36ff7a41",
+   "outputs": [],
+   "execution_count": 27
   },
   {
    "metadata": {},
@@ -1034,8 +1094,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:16.834018Z",
-     "start_time": "2026-06-23T05:06:16.808542Z"
+     "end_time": "2026-06-24T23:53:43.005618Z",
+     "start_time": "2026-06-24T23:53:42.982729Z"
     }
    },
    "source": [
@@ -1055,7 +1115,7 @@
      ]
     }
    ],
-   "execution_count": 24
+   "execution_count": 28
   },
   {
    "metadata": {},
@@ -1066,8 +1126,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.012124Z",
-     "start_time": "2026-06-23T05:06:16.835590Z"
+     "end_time": "2026-06-24T23:53:43.209570Z",
+     "start_time": "2026-06-24T23:53:43.008594Z"
     }
    },
    "cell_type": "code",
@@ -1094,12 +1154,12 @@
        "Conforms: True"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 25
+   "execution_count": 29
   },
   {
    "metadata": {},
@@ -1110,8 +1170,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.119734Z",
-     "start_time": "2026-06-23T05:06:17.025838Z"
+     "end_time": "2026-06-24T23:53:43.316558Z",
+     "start_time": "2026-06-24T23:53:43.213274Z"
     }
    },
    "cell_type": "code",
@@ -1139,12 +1199,12 @@
        "Conforms: True"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 26
+   "execution_count": 30
   },
   {
    "cell_type": "markdown",
@@ -1176,8 +1236,8 @@
    "id": "b26ce438",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.143342Z",
-     "start_time": "2026-06-23T05:06:17.129699Z"
+     "end_time": "2026-06-24T23:53:43.339667Z",
+     "start_time": "2026-06-24T23:53:43.318540Z"
     }
    },
    "source": [
@@ -1189,15 +1249,15 @@
     {
      "data": {
       "text/plain": [
-       "[AddOutput(port=OutputPort(label='y', owner=<pyiron_workflow._wfms.workflow.Workflow object at 0x13eaafdd0>, type_hint=None, type_metadata=None))]"
+       "[AddOutput(port=OutputPort(label='y', owner=<pyiron_workflow._wfms.workflow.Workflow object at 0x17f6b27b0>, type_hint=None, type_metadata=None))]"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 27
+   "execution_count": 31
   },
   {
    "metadata": {},
@@ -1208,8 +1268,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.180356Z",
-     "start_time": "2026-06-23T05:06:17.153351Z"
+     "end_time": "2026-06-24T23:53:43.364474Z",
+     "start_time": "2026-06-24T23:53:43.342491Z"
     }
    },
    "cell_type": "code",
@@ -1222,15 +1282,15 @@
     {
      "data": {
       "text/plain": [
-       "[RemoveOutput(port=OutputPort(label='y', owner=<pyiron_workflow._wfms.workflow.Workflow object at 0x13eaafdd0>, type_hint=None, type_metadata=None))]"
+       "[RemoveOutput(port=OutputPort(label='y', owner=<pyiron_workflow._wfms.workflow.Workflow object at 0x17f6b27b0>, type_hint=None, type_metadata=None))]"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 28
+   "execution_count": 32
   },
   {
    "metadata": {},
@@ -1243,8 +1303,8 @@
    "id": "165cd650",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.209719Z",
-     "start_time": "2026-06-23T05:06:17.190677Z"
+     "end_time": "2026-06-24T23:53:43.387623Z",
+     "start_time": "2026-06-24T23:53:43.366277Z"
     }
    },
    "source": [
@@ -1255,15 +1315,15 @@
     {
      "data": {
       "text/plain": [
-       "[AddNode(node=<pyiron_workflow._wfms.atomic.Atomic object at 0x13e91a420>)]"
+       "[AddNode(node=<pyiron_workflow._wfms.atomic.Atomic object at 0x17f717320>)]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 29
+   "execution_count": 33
   },
   {
    "metadata": {},
@@ -1274,8 +1334,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.235819Z",
-     "start_time": "2026-06-23T05:06:17.211429Z"
+     "end_time": "2026-06-24T23:53:43.415722Z",
+     "start_time": "2026-06-24T23:53:43.389282Z"
     }
    },
    "cell_type": "code",
@@ -1285,15 +1345,15 @@
     {
      "data": {
       "text/plain": [
-       "[RemoveNode(node=<pyiron_workflow._wfms.atomic.Atomic object at 0x13e91a420>)]"
+       "[RemoveNode(node=<pyiron_workflow._wfms.atomic.Atomic object at 0x17f717320>)]"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 30
+   "execution_count": 34
   },
   {
    "metadata": {},
@@ -1304,8 +1364,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.251324Z",
-     "start_time": "2026-06-23T05:06:17.237444Z"
+     "end_time": "2026-06-24T23:53:43.447232Z",
+     "start_time": "2026-06-24T23:53:43.421468Z"
     }
    },
    "cell_type": "code",
@@ -1329,12 +1389,12 @@
        "[AddEdge(edge=EdgeTuple(source=InputSource(node=None, port='x'), target=TargetHandle(node='scale', port='y')))]"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 31
+   "execution_count": 35
   },
   {
    "metadata": {},
@@ -1345,8 +1405,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.279872Z",
-     "start_time": "2026-06-23T05:06:17.261667Z"
+     "end_time": "2026-06-24T23:53:43.466503Z",
+     "start_time": "2026-06-24T23:53:43.449146Z"
     }
    },
    "cell_type": "code",
@@ -1359,12 +1419,12 @@
        "[RemoveEdge(edge=EdgeTuple(source=InputSource(node=None, port='m'), target=TargetHandle(node='scale', port='x')))]"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 32
+   "execution_count": 36
   },
   {
    "metadata": {},
@@ -1381,8 +1441,8 @@
    "id": "f2fb0893",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.316717Z",
-     "start_time": "2026-06-23T05:06:17.289647Z"
+     "end_time": "2026-06-24T23:53:43.488906Z",
+     "start_time": "2026-06-24T23:53:43.468106Z"
     }
    },
    "source": [
@@ -1397,16 +1457,16 @@
     {
      "data": {
       "text/plain": [
-       "[AddOutput(port=OutputPort(label='y', owner=<pyiron_workflow._wfms.workflow.Workflow object at 0x13eaafdd0>, type_hint=None, type_metadata=None)),\n",
+       "[AddOutput(port=OutputPort(label='y', owner=<pyiron_workflow._wfms.workflow.Workflow object at 0x17f6b27b0>, type_hint=None, type_metadata=None)),\n",
        " AddEdge(edge=EdgeTuple(source=SourceHandle(node='shift', port='output_0'), target=OutputTarget(node=None, port='y')))]"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 33
+   "execution_count": 37
   },
   {
    "cell_type": "code",
@@ -1414,8 +1474,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.329916Z",
-     "start_time": "2026-06-23T05:06:17.317376Z"
+     "end_time": "2026-06-24T23:53:43.515621Z",
+     "start_time": "2026-06-24T23:53:43.491595Z"
     }
    },
    "source": [
@@ -1435,7 +1495,7 @@
      ]
     }
    ],
-   "execution_count": 34
+   "execution_count": 38
   },
   {
    "cell_type": "markdown",
@@ -1454,8 +1514,8 @@
    "id": "6d681b0f",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.353943Z",
-     "start_time": "2026-06-23T05:06:17.342070Z"
+     "end_time": "2026-06-24T23:53:43.542227Z",
+     "start_time": "2026-06-24T23:53:43.517264Z"
     }
    },
    "source": [
@@ -1468,15 +1528,15 @@
     "    return x"
    ],
    "outputs": [],
-   "execution_count": 35
+   "execution_count": 39
   },
   {
    "cell_type": "code",
    "id": "02438cec",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.384189Z",
-     "start_time": "2026-06-23T05:06:17.368050Z"
+     "end_time": "2026-06-24T23:53:43.557832Z",
+     "start_time": "2026-06-24T23:53:43.544773Z"
     }
    },
    "source": [
@@ -1487,15 +1547,15 @@
     "typed.create_output_from(typed.ni, \"x\");"
    ],
    "outputs": [],
-   "execution_count": 36
+   "execution_count": 40
   },
   {
    "cell_type": "code",
    "id": "b4280246",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.405140Z",
-     "start_time": "2026-06-23T05:06:17.394676Z"
+     "end_time": "2026-06-24T23:53:43.611055Z",
+     "start_time": "2026-06-24T23:53:43.558454Z"
     }
    },
    "source": [
@@ -1509,7 +1569,7 @@
     ")"
    ],
    "outputs": [],
-   "execution_count": 37
+   "execution_count": 41
   },
   {
    "cell_type": "code",
@@ -1517,8 +1577,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.445615Z",
-     "start_time": "2026-06-23T05:06:17.415015Z"
+     "end_time": "2026-06-24T23:53:43.666548Z",
+     "start_time": "2026-06-24T23:53:43.639283Z"
     }
    },
    "source": [
@@ -1539,7 +1599,7 @@
      ]
     }
    ],
-   "execution_count": 38
+   "execution_count": 42
   },
   {
    "cell_type": "markdown",
@@ -1554,8 +1614,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.487981Z",
-     "start_time": "2026-06-23T05:06:17.456313Z"
+     "end_time": "2026-06-24T23:53:43.687430Z",
+     "start_time": "2026-06-24T23:53:43.668262Z"
     }
    },
    "cell_type": "code",
@@ -1594,7 +1654,7 @@
      ]
     }
    ],
-   "execution_count": 39
+   "execution_count": 43
   },
   {
    "metadata": {},
@@ -1611,8 +1671,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.545801Z",
-     "start_time": "2026-06-23T05:06:17.497945Z"
+     "end_time": "2026-06-24T23:53:43.710853Z",
+     "start_time": "2026-06-24T23:53:43.689061Z"
     }
    },
    "cell_type": "code",
@@ -1645,12 +1705,12 @@
        "OutputDataPort(value=MyData(no_default=1.1, foo=42, bar='towel'), annotation=<class '__main__.MyData'>)"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 40
+   "execution_count": 44
   },
   {
    "metadata": {},
@@ -1661,8 +1721,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.579531Z",
-     "start_time": "2026-06-23T05:06:17.548993Z"
+     "end_time": "2026-06-24T23:53:43.734048Z",
+     "start_time": "2026-06-24T23:53:43.712588Z"
     }
    },
    "cell_type": "code",
@@ -1675,12 +1735,12 @@
        "{'output_0': OutputDataPort(value=10, annotation=None)}"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 41
+   "execution_count": 45
   },
   {
    "metadata": {},
@@ -1699,8 +1759,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.605030Z",
-     "start_time": "2026-06-23T05:06:17.580527Z"
+     "end_time": "2026-06-24T23:53:43.756505Z",
+     "start_time": "2026-06-24T23:53:43.735694Z"
     }
    },
    "cell_type": "code",
@@ -1730,7 +1790,7 @@
      ]
     }
    ],
-   "execution_count": 42
+   "execution_count": 46
   },
   {
    "cell_type": "markdown",
@@ -1748,8 +1808,8 @@
    "id": "fb47c792",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.662877Z",
-     "start_time": "2026-06-23T05:06:17.631059Z"
+     "end_time": "2026-06-24T23:53:43.782598Z",
+     "start_time": "2026-06-24T23:53:43.759004Z"
     }
    },
    "source": [
@@ -1771,7 +1831,7 @@
      ]
     }
    ],
-   "execution_count": 43
+   "execution_count": 47
   },
   {
    "metadata": {},
@@ -1782,8 +1842,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.691659Z",
-     "start_time": "2026-06-23T05:06:17.664675Z"
+     "end_time": "2026-06-24T23:53:43.804524Z",
+     "start_time": "2026-06-24T23:53:43.784295Z"
     }
    },
    "cell_type": "code",
@@ -1804,7 +1864,7 @@
      ]
     }
    ],
-   "execution_count": 44
+   "execution_count": 48
   },
   {
    "metadata": {
@@ -1820,8 +1880,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.714847Z",
-     "start_time": "2026-06-23T05:06:17.693852Z"
+     "end_time": "2026-06-24T23:53:43.826953Z",
+     "start_time": "2026-06-24T23:53:43.806177Z"
     }
    },
    "cell_type": "code",
@@ -1841,13 +1901,13 @@
      ]
     }
    ],
-   "execution_count": 45
+   "execution_count": 49
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.738153Z",
-     "start_time": "2026-06-23T05:06:17.716511Z"
+     "end_time": "2026-06-24T23:53:43.851173Z",
+     "start_time": "2026-06-24T23:53:43.828476Z"
     }
    },
    "cell_type": "code",
@@ -1864,12 +1924,12 @@
        "{'y': OutputDataPort(value=6.5, annotation=None)}"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 46
+   "execution_count": 50
   },
   {
    "metadata": {},
@@ -1880,8 +1940,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.767932Z",
-     "start_time": "2026-06-23T05:06:17.739939Z"
+     "end_time": "2026-06-24T23:53:43.874001Z",
+     "start_time": "2026-06-24T23:53:43.852671Z"
     }
    },
    "cell_type": "code",
@@ -1907,12 +1967,12 @@
        " 'x3': OutputDataPort(value=27, annotation=None)}"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 51,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 47
+   "execution_count": 51
   },
   {
    "cell_type": "markdown",
@@ -1933,8 +1993,8 @@
    "id": "8c750917",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.799584Z",
-     "start_time": "2026-06-23T05:06:17.776859Z"
+     "end_time": "2026-06-24T23:53:43.899305Z",
+     "start_time": "2026-06-24T23:53:43.875870Z"
     }
    },
    "source": [
@@ -1969,20 +2029,20 @@
        "\t'shift': Atomic"
       ]
      },
-     "execution_count": 48,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 48
+   "execution_count": 52
   },
   {
    "cell_type": "code",
    "id": "b834c4b5",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.820605Z",
-     "start_time": "2026-06-23T05:06:17.802013Z"
+     "end_time": "2026-06-24T23:53:43.922359Z",
+     "start_time": "2026-06-24T23:53:43.900976Z"
     }
    },
    "source": [
@@ -2007,12 +2067,12 @@
        "\t'grp': Macro"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 49
+   "execution_count": 53
   },
   {
    "metadata": {},
@@ -2023,8 +2083,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.844013Z",
-     "start_time": "2026-06-23T05:06:17.822312Z"
+     "end_time": "2026-06-24T23:53:43.946174Z",
+     "start_time": "2026-06-24T23:53:43.925282Z"
     }
    },
    "cell_type": "code",
@@ -2039,12 +2099,12 @@
        "\t'shift': Atomic"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 50
+   "execution_count": 54
   },
   {
    "metadata": {},
@@ -2058,8 +2118,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.870479Z",
-     "start_time": "2026-06-23T05:06:17.845636Z"
+     "end_time": "2026-06-24T23:53:43.968696Z",
+     "start_time": "2026-06-24T23:53:43.947637Z"
     }
    },
    "source": [
@@ -2078,7 +2138,7 @@
      ]
     }
    ],
-   "execution_count": 51
+   "execution_count": 55
   },
   {
    "metadata": {},
@@ -2089,8 +2149,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.900055Z",
-     "start_time": "2026-06-23T05:06:17.872534Z"
+     "end_time": "2026-06-24T23:53:43.992232Z",
+     "start_time": "2026-06-24T23:53:43.970422Z"
     }
    },
    "cell_type": "code",
@@ -2103,12 +2163,12 @@
        "{'y': OutputDataPort(value=6.4, annotation=None)}"
       ]
      },
-     "execution_count": 52,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 52
+   "execution_count": 56
   },
   {
    "cell_type": "markdown",
@@ -2125,8 +2185,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.930165Z",
-     "start_time": "2026-06-23T05:06:17.902576Z"
+     "end_time": "2026-06-24T23:53:44.016361Z",
+     "start_time": "2026-06-24T23:53:43.993714Z"
     }
    },
    "source": [
@@ -2152,12 +2212,12 @@
        "\t'grp_shift': Atomic"
       ]
      },
-     "execution_count": 53,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 53
+   "execution_count": 57
   },
   {
    "metadata": {},
@@ -2168,8 +2228,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:17.966079Z",
-     "start_time": "2026-06-23T05:06:17.942667Z"
+     "end_time": "2026-06-24T23:53:44.038681Z",
+     "start_time": "2026-06-24T23:53:44.018031Z"
     }
    },
    "cell_type": "code",
@@ -2182,12 +2242,12 @@
        "{'y': OutputDataPort(value=6.3, annotation=None)}"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 54
+   "execution_count": 58
   },
   {
    "cell_type": "markdown",
@@ -2210,8 +2270,8 @@
    "id": "ed39eebd",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:18.049737Z",
-     "start_time": "2026-06-23T05:06:17.968528Z"
+     "end_time": "2026-06-24T23:53:44.051428Z",
+     "start_time": "2026-06-24T23:53:44.041607Z"
     }
    },
    "source": [
@@ -2268,7 +2328,7 @@
     "    return money"
    ],
    "outputs": [],
-   "execution_count": 55
+   "execution_count": 59
   },
   {
    "metadata": {},
@@ -2279,8 +2339,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:18.097472Z",
-     "start_time": "2026-06-23T05:06:18.061560Z"
+     "end_time": "2026-06-24T23:53:44.077367Z",
+     "start_time": "2026-06-24T23:53:44.062776Z"
     }
    },
    "cell_type": "code",
@@ -2297,12 +2357,12 @@
        "{'money': OutputDataPort(value=10, annotation=None)}"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 60,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 56
+   "execution_count": 60
   },
   {
    "metadata": {},
@@ -2313,8 +2373,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:18.151583Z",
-     "start_time": "2026-06-23T05:06:18.118565Z"
+     "end_time": "2026-06-24T23:53:44.184299Z",
+     "start_time": "2026-06-24T23:53:44.126687Z"
     }
    },
    "cell_type": "code",
@@ -2324,15 +2384,15 @@
     {
      "data": {
       "text/plain": [
-       "<Graph identifier=N87563b4306cc4e48aa4db7e756f97c12 (<class 'rdflib.graph.Graph'>)>"
+       "<Graph identifier=N741d2edd697d4c74bf83a38df12c3f85 (<class 'rdflib.graph.Graph'>)>"
       ]
      },
-     "execution_count": 57,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 57
+   "execution_count": 61
   },
   {
    "metadata": {},
@@ -2343,8 +2403,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:18.287182Z",
-     "start_time": "2026-06-23T05:06:18.160882Z"
+     "end_time": "2026-06-24T23:53:44.319608Z",
+     "start_time": "2026-06-24T23:53:44.185915Z"
     }
    },
    "cell_type": "code",
@@ -2355,16 +2415,16 @@
      "data": {
       "text/plain": [
        "(True,\n",
-       " <Graph identifier=Nadf891ed87d946d385f1d481462dbc05 (<class 'rdflib.graph.Graph'>)>,\n",
+       " <Graph identifier=Ndfef0f023e684ec5bce362e353a8c144 (<class 'rdflib.graph.Graph'>)>,\n",
        " 'Validation Report\\nConforms: True\\n')"
       ]
      },
-     "execution_count": 58,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 58
+   "execution_count": 62
   },
   {
    "metadata": {},
@@ -2382,8 +2442,8 @@
    "metadata": {
     "lines_to_next_cell": 2,
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:18.415439Z",
-     "start_time": "2026-06-23T05:06:18.298191Z"
+     "end_time": "2026-06-24T23:53:44.480296Z",
+     "start_time": "2026-06-24T23:53:44.321275Z"
     }
    },
    "source": [
@@ -2414,12 +2474,12 @@
        "\tMessage: Focus node does not conform to shape MinCount 1: [ sh:class <http://example.org/cleaned> ]"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 59
+   "execution_count": 63
   },
   {
    "cell_type": "markdown",
@@ -2443,8 +2503,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:18.443581Z",
-     "start_time": "2026-06-23T05:06:18.418518Z"
+     "end_time": "2026-06-24T23:53:44.506618Z",
+     "start_time": "2026-06-24T23:53:44.482381Z"
     }
    },
    "cell_type": "code",
@@ -2489,12 +2549,12 @@
        "  {'target': 3, 'targetPort': None, 'source': 4, 'sourcePort': 'added'}]}"
       ]
      },
-     "execution_count": 60,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 60
+   "execution_count": 64
   },
   {
    "metadata": {},
@@ -2505,8 +2565,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:18.466473Z",
-     "start_time": "2026-06-23T05:06:18.445334Z"
+     "end_time": "2026-06-24T23:53:44.530833Z",
+     "start_time": "2026-06-24T23:53:44.508446Z"
     }
    },
    "cell_type": "code",
@@ -2531,12 +2591,12 @@
        "{'y': OutputDataPort(value=6.5, annotation=None)}"
       ]
      },
-     "execution_count": 61,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 61
+   "execution_count": 65
   },
   {
    "cell_type": "markdown",
@@ -2567,8 +2627,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:18.478214Z",
-     "start_time": "2026-06-23T05:06:18.468839Z"
+     "end_time": "2026-06-24T23:53:44.541481Z",
+     "start_time": "2026-06-24T23:53:44.532790Z"
     }
    },
    "cell_type": "code",
@@ -2583,7 +2643,7 @@
    ],
    "id": "82da92ef2d5247f7",
    "outputs": [],
-   "execution_count": 62
+   "execution_count": 66
   },
   {
    "cell_type": "markdown",
@@ -2596,8 +2656,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:18.496026Z",
-     "start_time": "2026-06-23T05:06:18.486711Z"
+     "end_time": "2026-06-24T23:53:44.560182Z",
+     "start_time": "2026-06-24T23:53:44.550036Z"
     }
    },
    "cell_type": "code",
@@ -2610,7 +2670,7 @@
    ],
    "id": "98276df1c822ed21",
    "outputs": [],
-   "execution_count": 63
+   "execution_count": 67
   },
   {
    "cell_type": "markdown",
@@ -2623,8 +2683,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:18.530707Z",
-     "start_time": "2026-06-23T05:06:18.505101Z"
+     "end_time": "2026-06-24T23:53:44.585990Z",
+     "start_time": "2026-06-24T23:53:44.570546Z"
     }
    },
    "cell_type": "code",
@@ -2642,13 +2702,13 @@
      ]
     }
    ],
-   "execution_count": 64
+   "execution_count": 68
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:18.553923Z",
-     "start_time": "2026-06-23T05:06:18.532255Z"
+     "end_time": "2026-06-24T23:53:44.681102Z",
+     "start_time": "2026-06-24T23:53:44.633968Z"
     }
    },
    "cell_type": "code",
@@ -2661,12 +2721,12 @@
        "{'shifted': OutputDataPort(value=20.3, annotation=None)}"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "execution_count": 65
+   "execution_count": 69
   },
   {
    "cell_type": "markdown",
@@ -2681,8 +2741,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2026-06-23T05:06:18.576342Z",
-     "start_time": "2026-06-23T05:06:18.555362Z"
+     "end_time": "2026-06-24T23:53:44.702087Z",
+     "start_time": "2026-06-24T23:53:44.683170Z"
     }
    },
    "cell_type": "code",
@@ -2712,7 +2772,7 @@
      ]
     }
    ],
-   "execution_count": 66
+   "execution_count": 70
   },
   {
    "metadata": {},

--- a/notebooks/_wfms.ipynb
+++ b/notebooks/_wfms.ipynb
@@ -421,7 +421,10 @@
     "\n",
     "`progress_hooks` fire on every status transition of every node in the tree,\n",
     "receiving the progress directory, a timestamp, the node's lexical path, and the new\n",
-    "status. This is the seam a GUI or logger taps to follow execution live."
+    "status. This is the seam a GUI or logger taps to follow execution live.\n",
+    "Each hook is wrapped in a `ProgressHook(fn, blocking=False)`.\n",
+    "By default hooks are **non-blocking** — they run on a background thread pool (sized by `RunConfig.hooks_max_threads`) so a slow hook can't stall execution, and a hook that raises is logged (to `RunConfig.logger_name`) rather than failing the run.\n",
+    "Pass `blocking=True` for a hook that must run inline and whose failure should abort the run."
    ]
   },
   {
@@ -440,7 +443,7 @@
     "    events.append((lexical_path, str(status)))\n",
     "\n",
     "wf = pwf.node(line)\n",
-    "cfg = pwf.RunConfig(progress_hooks=[progress_hook])\n",
+    "cfg = pwf.RunConfig(progress_hooks=[pwf.ProgressHook(progress_hook, blocking=True)])\n",
     "wf.run(cfg, x=1, m=2, b=3)\n",
     "\n",
     "for lexical_path, status in events:\n",

--- a/pyiron_workflow/_wfms/api/__init__.py
+++ b/pyiron_workflow/_wfms/api/__init__.py
@@ -4,6 +4,7 @@ from pyiron_workflow._wfms.api import tools as tools
 from pyiron_workflow._wfms.api.schemas import (
     ExecutorInstructions as ExecutorInstructions,
 )
+from pyiron_workflow._wfms.api.schemas import ProgressHook as ProgressHook
 from pyiron_workflow._wfms.api.schemas import RunConfig as RunConfig
 from pyiron_workflow._wfms.api.schemas import Workflow as Workflow
 from pyiron_workflow._wfms.api.tools import atomic as atomic

--- a/pyiron_workflow/_wfms/api/schemas.py
+++ b/pyiron_workflow/_wfms/api/schemas.py
@@ -2,6 +2,7 @@ from pyiron_workflow._wfms.atomic import Atomic as Atomic
 from pyiron_workflow._wfms.dag import Macro as Macro
 from pyiron_workflow._wfms.datatypes import EdgeTuple as EdgeTuple
 from pyiron_workflow._wfms.execution import ExecutorInstructions as ExecutorInstructions
+from pyiron_workflow._wfms.execution import ProgressHook as ProgressHook
 from pyiron_workflow._wfms.execution import Run as Run
 from pyiron_workflow._wfms.execution import RunConfig as RunConfig
 from pyiron_workflow._wfms.execution import RunStatus as RunStatus

--- a/pyiron_workflow/_wfms/api/tools.py
+++ b/pyiron_workflow/_wfms/api/tools.py
@@ -5,4 +5,7 @@ from pyiron_workflow._wfms.decorators import atomic as atomic
 from pyiron_workflow._wfms.decorators import dataclass as dataclass
 from pyiron_workflow._wfms.decorators import workflow as workflow
 from pyiron_workflow._wfms.execution import run as run
+from pyiron_workflow._wfms.executorlib import NodeSingleExecutor as NodeSingleExecutor
+from pyiron_workflow._wfms.executorlib import NodeSlurmExecutor as NodeSlurmExecutor
+from pyiron_workflow._wfms.executorlib import _CacheTestExecutor as _CacheTestExecutor
 from pyiron_workflow._wfms.validation import validate_plan as validate_plan

--- a/pyiron_workflow/_wfms/execution.py
+++ b/pyiron_workflow/_wfms/execution.py
@@ -9,7 +9,7 @@ import pathlib
 import threading
 from collections.abc import Callable, Iterable
 from concurrent import futures
-from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeAlias, TypeVar
 
 import flowrep as fr
 
@@ -82,8 +82,13 @@ def _guarded(
         )
 
 
+HookFunction: TypeAlias = Callable[
+    [pathlib.Path, datetime.datetime, str, RunStatus], None
+]
+
+
 class ProgressHook(NamedTuple):
-    fn: Callable[[pathlib.Path, datetime.datetime, str, RunStatus], None]
+    fn: HookFunction
     blocking: bool = False
 
 
@@ -134,7 +139,9 @@ class Steps(list[Run[Any]]):
 @dataclasses.dataclass(frozen=True)
 class RunConfig:
     run_dir: pathlib.Path = pathlib.Path.cwd()
-    progress_hooks: Iterable[ProgressHook] = dataclasses.field(default_factory=list)
+    progress_hooks: Iterable[ProgressHook | HookFunction] = dataclasses.field(
+        default_factory=list
+    )
     exception_hooks: Iterable[
         Callable[[pathlib.Path, Run[ResultType], BaseException], None]
     ] = dataclasses.field(default_factory=list)
@@ -162,12 +169,15 @@ class RunConfig:
         self, time: datetime.datetime, lexical_path: str, status: RunStatus
     ):
         for hook in self.progress_hooks:
-            if hook.blocking:
-                hook.fn(self.run_dir, time, lexical_path, status)
+            progress_hook = (
+                hook if isinstance(hook, ProgressHook) else ProgressHook(hook)
+            )
+            if progress_hook.blocking:
+                progress_hook.fn(self.run_dir, time, lexical_path, status)
             else:
                 _get_hook_pool(self.hooks_max_threads).submit(
                     _guarded,
-                    hook.fn,
+                    progress_hook.fn,
                     logging.getLogger(self.logger_name),
                     self.run_dir,
                     time,

--- a/pyiron_workflow/_wfms/execution.py
+++ b/pyiron_workflow/_wfms/execution.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import atexit
 import dataclasses
 import datetime
 import enum
+import logging
 import pathlib
+import threading
 from collections.abc import Callable, Iterable
 from concurrent import futures
 from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeVar
@@ -21,6 +24,67 @@ class RunStatus(enum.StrEnum):
     RUNNING = "running"
     FINISHED = "finished"
     FAILED = "failed"
+
+
+_hook_pool: futures.ThreadPoolExecutor | None = None
+_hook_pool_lock = threading.Lock()
+
+
+def _get_hook_pool(max_threads: int) -> futures.ThreadPoolExecutor:
+    """Lazily build the per-process, non-blocking-hook thread pool.
+
+    A ``ThreadPoolExecutor`` is process-local, so each process (parent and any
+    executor worker) gets its own singleton; ``atexit`` drains it on exit. The
+    pool is sized on first creation; later ``max_threads`` values are ignored
+    for the lifetime of that process.
+    """
+    global _hook_pool  # noqa: PLW0603 -- deliberate per-process pool singleton
+    with _hook_pool_lock:
+        if _hook_pool is None:
+            _hook_pool = futures.ThreadPoolExecutor(max_workers=max_threads)
+            atexit.register(_shutdown_hook_pool)
+        return _hook_pool
+
+
+def _shutdown_hook_pool() -> None:
+    """Drain and discard the hook pool. Registered with ``atexit``; also the
+    reset hook tests call in ``tearDown``."""
+    global _hook_pool  # noqa: PLW0603 -- deliberate per-process pool singleton
+    with _hook_pool_lock:
+        if _hook_pool is not None:
+            _hook_pool.shutdown(wait=True)
+            _hook_pool = None
+
+
+def _guarded(
+    fn: Callable[[pathlib.Path, datetime.datetime, str, RunStatus], None],
+    logger: logging.Logger,
+    run_dir: pathlib.Path,
+    time: datetime.datetime,
+    lexical_path: str,
+    status: RunStatus,
+) -> None:
+    """Run a non-blocking progress hook, logging (not raising) ordinary errors.
+
+    Catches ``Exception`` only, so ``KeyboardInterrupt``/``SystemExit`` are left
+    to propagate to the caller (here, the pool worker, which absorbs them into
+    its discarded future); a deliberate ``os._exit`` raises nothing so it is
+    unaffected.
+    """
+    try:
+        fn(run_dir, time, lexical_path, status)
+    except Exception:
+        logger.exception(
+            "Non-blocking progress hook %r failed for %s @ %s",
+            fn,
+            lexical_path,
+            status,
+        )
+
+
+class ProgressHook(NamedTuple):
+    fn: Callable[[pathlib.Path, datetime.datetime, str, RunStatus], None]
+    blocking: bool = False
 
 
 ResultType = TypeVar("ResultType", bound=fr.schemas.NodeData[Any])
@@ -70,15 +134,15 @@ class Steps(list[Run[Any]]):
 @dataclasses.dataclass(frozen=True)
 class RunConfig:
     run_dir: pathlib.Path = pathlib.Path.cwd()
-    progress_hooks: Iterable[
-        Callable[[pathlib.Path, datetime.datetime, str, RunStatus], None]
-    ] = dataclasses.field(default_factory=list)
+    progress_hooks: Iterable[ProgressHook] = dataclasses.field(default_factory=list)
     exception_hooks: Iterable[
         Callable[[pathlib.Path, Run[ResultType], BaseException], None]
     ] = dataclasses.field(default_factory=list)
     dag_layers_multithreaded: bool = True
     dag_layers_max_threads: int = 10
     dag_layers_fail_fast: bool = False
+    hooks_max_threads: int = 10
+    logger_name: str = __name__
     _prime_mover: lexical.LexicalPath | None = dataclasses.field(
         default=None, kw_only=True
     )
@@ -98,7 +162,18 @@ class RunConfig:
         self, time: datetime.datetime, lexical_path: str, status: RunStatus
     ):
         for hook in self.progress_hooks:
-            hook(self.run_dir, time, lexical_path, status)
+            if hook.blocking:
+                hook.fn(self.run_dir, time, lexical_path, status)
+            else:
+                _get_hook_pool(self.hooks_max_threads).submit(
+                    _guarded,
+                    hook.fn,
+                    logging.getLogger(self.logger_name),
+                    self.run_dir,
+                    time,
+                    lexical_path,
+                    status,
+                )
 
     def emit_exception(self, failed_run: Run[ResultType], exception: BaseException):
         for hook in self.exception_hooks:

--- a/pyiron_workflow/_wfms/executorlib.py
+++ b/pyiron_workflow/_wfms/executorlib.py
@@ -1,0 +1,88 @@
+"""
+Simple wrappers around executorlib executors, which are exclusively intended to
+submit the core execution routine, and which override executorlib caching directory with
+the run configuration directory and cache file roots with the lexical path.
+
+This makes it possible to recover executorlib-cached data between python processes
+(e.g. shutting down your notebook and coming back), but the onus is on the _user_ to
+specify the right terminal input data to correspond with this run configuration
+directory -- we don't do any data hashing.
+I.e., make a fresh run config directory for each iteration of input data where the
+caching executors are being leveraged.
+"""
+
+from typing import Any, ClassVar
+
+import executorlib
+import executorlib.api as exlib_api
+
+from pyiron_workflow._wfms import execution
+
+
+class DedicatedExecutorError(TypeError):
+    """
+    To raise when you try to use one of these executors outside the context of a node.
+    """
+
+
+class ProtectedResourceError(ValueError):
+    """
+    Raise when a user provides executorlib resources that we need to override.
+    """
+
+
+class CacheOverride(executorlib.BaseExecutor):
+    cache_directory: ClassVar[str] = "executorlib_cache"
+
+    def submit(self, fn, /, *args, **kwargs):
+        """
+        Modify behaviour when submitting for a pyiron_workflow execution loop
+        """
+        if fn is execution._return_mutated_state_with_any_exception:
+            assert len(args) == 3, "enforce implementation expectations on _return..."
+            node, _, config = args
+            cache_key_info = {
+                "cache_key": node.lexical_path,
+                "cache_directory": str(config.run_dir / self.cache_directory),
+            }
+        else:
+            raise DedicatedExecutorError(
+                f"{self.__class__.__name__} is only intended to work with the "
+                f"run routine of pyiron_workflow, but got submitted {fn!r} with input"
+                f"{args!r}, and {kwargs!r}"
+            )
+
+        _validate_existing_resource_dict(kwargs)
+
+        if "resource_dict" in kwargs:
+            kwargs["resource_dict"].update(cache_key_info)
+        else:
+            kwargs["resource_dict"] = cache_key_info
+
+        return super().submit(fn, *args, **kwargs)
+
+
+def _validate_existing_resource_dict(kwargs: dict[str, Any]):
+    if "resource_dict" in kwargs:
+        if "cache_key" in kwargs["resource_dict"]:
+            raise ProtectedResourceError(
+                f"pyiron_workflow needs the freedom to specify the cache, so the "
+                f'requested "cache_key" '
+                f"({kwargs['resource_dict']['cache_key']}) would get overwritten."
+            )
+        if "cache_directory" in kwargs["resource_dict"]:
+            raise ProtectedResourceError(
+                f"pyiron_workflow needs the freedom to specify the cache, so the "
+                f'requested "cache_directory" '
+                f"({kwargs['resource_dict']['cache_directory']})would get "
+                f"overwritten."
+            )
+
+
+class NodeSingleExecutor(CacheOverride, executorlib.SingleNodeExecutor): ...
+
+
+class NodeSlurmExecutor(CacheOverride, executorlib.SlurmClusterExecutor): ...
+
+
+class _CacheTestExecutor(CacheOverride, exlib_api.TestClusterExecutor): ...

--- a/pyiron_workflow/_wfms/executorlib.py
+++ b/pyiron_workflow/_wfms/executorlib.py
@@ -38,28 +38,28 @@ class CacheOverride(executorlib.BaseExecutor):
         """
         Modify behaviour when submitting for a pyiron_workflow execution loop
         """
-        if fn is execution._return_mutated_state_with_any_exception:
-            assert len(args) == 3, "enforce implementation expectations on _return..."
-            node, _, config = args
-            cache_key_info = {
-                "cache_key": node.lexical_path,
-                "cache_directory": str(config.run_dir / self.cache_directory),
-            }
-        else:
+        if (
+            fn is not execution._return_mutated_state_with_any_exception
+            or len(args) != 3
+            or len(kwargs) != 0
+        ):
             raise DedicatedExecutorError(
                 f"{self.__class__.__name__} is only intended to work with the "
-                f"run routine of pyiron_workflow, but got submitted {fn!r} with input"
+                f"run routine of pyiron_workflow: "
+                f"{execution._return_mutated_state_with_any_exception.__module__}."
+                f"{execution._return_mutated_state_with_any_exception.__qualname__}, and "
+                f"its three expected arguments, but got submitted {fn!r} with input "
                 f"{args!r}, and {kwargs!r}"
             )
 
-        _validate_existing_resource_dict(kwargs)
+        node, _, config = args
+        cache_key_info = {
+            "cache_key": node.lexical_path,
+            "cache_directory": str(config.run_dir / self.cache_directory),
+        }
+        super_kwargs = {"resource_dict": cache_key_info}
 
-        if "resource_dict" in kwargs:
-            kwargs["resource_dict"].update(cache_key_info)
-        else:
-            kwargs["resource_dict"] = cache_key_info
-
-        return super().submit(fn, *args, **kwargs)
+        return super().submit(fn, *args, **super_kwargs)
 
 
 def _validate_existing_resource_dict(kwargs: dict[str, Any]):

--- a/pyiron_workflow/_wfms/executorlib.py
+++ b/pyiron_workflow/_wfms/executorlib.py
@@ -11,7 +11,7 @@ I.e., make a fresh run config directory for each iteration of input data where t
 caching executors are being leveraged.
 """
 
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import executorlib
 import executorlib.api as exlib_api
@@ -60,23 +60,6 @@ class CacheOverride(executorlib.BaseExecutor):
         super_kwargs = {"resource_dict": cache_key_info}
 
         return super().submit(fn, *args, **super_kwargs)
-
-
-def _validate_existing_resource_dict(kwargs: dict[str, Any]):
-    if "resource_dict" in kwargs:
-        if "cache_key" in kwargs["resource_dict"]:
-            raise ProtectedResourceError(
-                f"pyiron_workflow needs the freedom to specify the cache, so the "
-                f'requested "cache_key" '
-                f"({kwargs['resource_dict']['cache_key']}) would get overwritten."
-            )
-        if "cache_directory" in kwargs["resource_dict"]:
-            raise ProtectedResourceError(
-                f"pyiron_workflow needs the freedom to specify the cache, so the "
-                f'requested "cache_directory" '
-                f"({kwargs['resource_dict']['cache_directory']})would get "
-                f"overwritten."
-            )
 
 
 class NodeSingleExecutor(CacheOverride, executorlib.SingleNodeExecutor): ...

--- a/tests/cluster/_wfms/slurm_test.py
+++ b/tests/cluster/_wfms/slurm_test.py
@@ -1,0 +1,161 @@
+import argparse
+import os
+import pathlib
+import subprocess
+import time
+
+from pip._internal.utils import datetime
+
+import pyiron_workflow._wfms.api as pwf
+
+
+@pwf.atomic
+def identity(x):
+    return x
+
+
+@pwf.atomic
+def sleepy(t):
+    time.sleep(t)
+    return t
+
+
+@pwf.workflow
+def three_step(t):
+    n1 = identity(t)
+    n2 = sleepy(n1)
+    n3 = identity(n2)
+    return n3
+
+
+CACHE_DIR = pathlib.Path("/tmp/slurm_test")
+CACHE_DIR.mkdir(parents=True, exist_ok=True)
+T_SLEEP = 10
+
+
+def kill_sleeper(
+    run_dir: pathlib.Path,
+    timestamp: datetime.datetime,
+    lexical_path: str,
+    status: pwf.schemas.RunStatus,
+):
+    hard_coded_sleepy_path = "three_step.sleepy_0"
+    if (
+        lexical_path == hard_coded_sleepy_path
+        and status == pwf.schemas.RunStatus.RUNNING
+    ):
+        time.sleep(1)  # give the job a second to process
+        print_queue("Queue at kill time")
+        assert_queue_has_n_items(1)
+        os._exit(0)  # Then hard exit so that we don't even wait for the executor
+
+
+def get_queue() -> list[dict[str, str]]:
+    """Return current squeue entries as list of dicts."""
+    cmd = ["squeue", "--noheader", "--format=%i|%j|%T|%u"]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    jobs = []
+    for line in result.stdout.splitlines():
+        job_id, name, state, job_user = line.split("|")
+        jobs.append({"job_id": job_id, "name": name, "state": state, "user": job_user})
+    return jobs
+
+
+def print_queue(extra_message: str | None = None) -> None:
+    if extra_message:
+        print(extra_message)
+    cmd = ["squeue"]
+    subprocess.run(cmd, check=True)
+
+
+def assert_queue_has_n_items(n: int) -> None:
+    jobs = get_queue()
+    assert len(jobs) == n, f"Expected {n} job(s) in queue, found {len(jobs)}: {jobs}"
+
+
+def setup(callbacks=None):
+    submission_template = """\
+#!/bin/bash
+#SBATCH --output=time.out
+#SBATCH --job-name={{job_name}}
+#SBATCH --chdir={{working_directory}}
+#SBATCH --get-user-env=L
+#SBATCH --cpus-per-task={{cores}}
+
+{{command}}
+"""
+    resource_dict = {"submission_template": submission_template}
+
+    wf = three_step.pwf.node()
+
+    wf.sleepy_0.executor = pwf.ExecutorInstructions(
+        pwf.tools.NodeSlurmExecutor,
+        (),
+        {"resource_dict": resource_dict},
+    )
+
+    cfg = pwf.RunConfig(run_dir=CACHE_DIR, progress_hooks=callbacks or [])
+    return wf, cfg
+
+
+def submission():
+    wf, cfg = setup([pwf.ProgressHook(kill_sleeper)])
+    wf.run(cfg, t=T_SLEEP)
+
+
+def interruption():
+    print_queue("Queue at interruption time")
+    assert_queue_has_n_items(1)
+    wf, cfg = setup()
+    t0 = time.time()
+    out = wf.run(cfg, t=T_SLEEP)
+    dt = time.time() - t0
+    print("Result", out.outputs, "in", dt)
+    time.sleep(1)  # Let everything settle
+    assert_queue_has_n_items(0)
+    assert (
+        dt > 0.5 * T_SLEEP
+    ), f"Expected to need to wait for the job to finish, but got a small dt -- {dt}"
+    assert (
+        out.outputs["n3"].value == T_SLEEP
+    ), f"Sanity check that the workflow returned T_SLEEP, but got {out.outputs['n3'].value}"
+
+
+def discovery():
+    print_queue("Queue at discovery time")
+    assert_queue_has_n_items(1)
+    time.sleep(1.5 * T_SLEEP)  # Wait for it to finish
+    assert_queue_has_n_items(0)
+    wf, cfg = setup()
+    t0 = time.time()
+    out = wf.run(cfg, t=T_SLEEP)
+    dt = time.time() - t0
+    print("Result", out.outputs, "in", dt)
+    assert (
+        dt < 0.1 * T_SLEEP
+    ), f"Expected to get a quick cache hit, but got a large -- {dt}"
+    assert (
+        out.outputs["n3"].value == T_SLEEP
+    ), f"Sanity check that the workflow returned T_SLEEP, but got {out.outputs['n3'].value}"
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run workflow stages.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--submit", action="store_true", help="Run submission stage.")
+    group.add_argument(
+        "--interrupt", action="store_true", help="Run interruption stage."
+    )
+    group.add_argument("--discover", action="store_true", help="Run discovery stage.")
+    args = parser.parse_args()
+
+    if args.submit:
+        submission()
+    elif args.interrupt:
+        interruption()
+    elif args.discover:
+        discovery()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/_wfms/test_executors.py
+++ b/tests/integration/_wfms/test_executors.py
@@ -1,4 +1,7 @@
 import os
+import pathlib
+import shutil
+import tempfile
 import time
 import unittest
 from concurrent import futures
@@ -6,6 +9,7 @@ from concurrent import futures
 import flowrep as fr
 
 from pyiron_workflow._wfms import api as wfms
+from pyiron_workflow._wfms import executorlib
 
 
 def get_pid(trigger):
@@ -61,6 +65,23 @@ def sleepy_array(times: list[float]) -> list[float]:
         t_sleep = sleepy(t)
         slept_for.append(t_sleep)
     return slept_for
+
+
+@fr.workflow
+def slow_wf(t):
+    s = sleepy(t)
+    return s
+
+
+@fr.workflow
+def two_slow(a, b):
+    x = sleepy(a)
+    y = sleepy(b)
+    return x, y
+
+
+def plain_fn(x):
+    return x
 
 
 class TestExecutors(unittest.TestCase):
@@ -194,3 +215,123 @@ class TestDagParallelism(unittest.TestCase):
                 diff_to_max = abs(t_diff - self.max_time)
                 diff_to_tot = abs(t_diff - self.tot_time)
                 self.assertLess(diff_to_tot, diff_to_max)
+
+
+class TestCachingExecutors(unittest.TestCase):
+    T = 1.0
+
+    def setUp(self) -> None:
+        self.run_root = pathlib.Path(tempfile.mkdtemp())
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.run_root, ignore_errors=True)
+
+    def _fresh_node(self, executor_cls):
+        node = wfms.node(slow_wf.flowrep_recipe)
+        node.sleepy_0.executor = wfms.ExecutorInstructions(executor_cls)
+        return node
+
+    def _cache_dir(self, run_dir):
+        return run_dir / executorlib.CacheOverride.cache_directory
+
+    def _assert_cached(self, run_dir, lexical_path):
+        names = [p.name for p in self._cache_dir(run_dir).iterdir()]
+        self.assertTrue(
+            any(lexical_path in name for name in names),
+            msg=f"Expected a cache file named for {lexical_path} among {names}",
+        )
+
+    def test_cache_lifecycle(self):
+        for executor_cls in (
+            wfms.tools._CacheTestExecutor,
+            wfms.tools.NodeSingleExecutor,
+        ):
+            with self.subTest(executor=executor_cls.__name__):
+                run_dir = self.run_root / executor_cls.__name__
+                cfg = wfms.RunConfig(run_dir=run_dir)
+
+                node = self._fresh_node(executor_cls)
+                t0 = time.perf_counter()
+                out_cold = node.run(cfg, t=self.T)
+                dt_first = time.perf_counter() - t0
+                self.assertEqual(out_cold.outputs["s"].value, self.T)
+                self._assert_cached(run_dir, node.sleepy_0.lexical_path)
+
+                # Fresh node instance + same run_dir -> reconnect to the cache
+                warm = self._fresh_node(executor_cls)
+                t1 = time.perf_counter()
+                out_warm = warm.run(cfg, t=self.T)
+                dt_second = time.perf_counter() - t1
+                self.assertEqual(out_warm.outputs["s"].value, self.T)
+                self.assertLess(dt_second, dt_first / 2)
+                self.assertLess(dt_second, 1.0)
+
+                # Footgun: different input, same node/dir -> stale cached value
+                t2 = time.perf_counter()
+                out_stale = warm.run(cfg, t=self.T * 99)
+                dt_third = time.perf_counter() - t2
+                self.assertEqual(
+                    out_stale.outputs["s"].value,
+                    self.T,
+                    msg="Cache key is the lexical path only; stale value expected",
+                )
+                self.assertLess(dt_third, 1.0)
+
+    def test_fresh_run_dir_recomputes(self):
+        node_a = self._fresh_node(wfms.tools._CacheTestExecutor)
+        out_a = node_a.run(wfms.RunConfig(run_dir=self.run_root / "a"), t=self.T)
+        self.assertEqual(out_a.outputs["s"].value, self.T)
+
+        # A different run_dir must miss the cache and recompute the new value
+        node_b = self._fresh_node(wfms.tools._CacheTestExecutor)
+        out_b = node_b.run(wfms.RunConfig(run_dir=self.run_root / "b"), t=self.T * 2)
+        self.assertEqual(
+            out_b.outputs["s"].value,
+            self.T * 2,
+            msg="A fresh run_dir must not return a stale cache hit",
+        )
+
+    def test_instance_form_caches(self):
+        cfg = wfms.RunConfig(run_dir=self.run_root / "instance")
+
+        cold = wfms.node(slow_wf.flowrep_recipe)
+        with wfms.tools._CacheTestExecutor() as exe:
+            cold.sleepy_0.executor = exe
+            t0 = time.perf_counter()
+            out_cold = cold.run(cfg, t=self.T)
+            dt_first = time.perf_counter() - t0
+        self.assertEqual(out_cold.outputs["s"].value, self.T)
+
+        warm = wfms.node(slow_wf.flowrep_recipe)
+        with wfms.tools._CacheTestExecutor() as exe:
+            warm.sleepy_0.executor = exe
+            t1 = time.perf_counter()
+            out_warm = warm.run(cfg, t=self.T)
+            dt_second = time.perf_counter() - t1
+        self.assertEqual(out_warm.outputs["s"].value, self.T)
+        self.assertLess(dt_second, dt_first / 2)
+        self.assertLess(dt_second, 1.0)
+
+    def test_distinct_nodes_distinct_cache(self):
+        run_dir = self.run_root / "distinct"
+        cfg = wfms.RunConfig(run_dir=run_dir)
+
+        node = wfms.node(two_slow.flowrep_recipe)
+        node.sleepy_0.executor = wfms.ExecutorInstructions(
+            wfms.tools._CacheTestExecutor
+        )
+        node.sleepy_1.executor = wfms.ExecutorInstructions(
+            wfms.tools._CacheTestExecutor
+        )
+        node.run(cfg, a=0.01, b=0.01)
+
+        self.assertNotEqual(node.sleepy_0.lexical_path, node.sleepy_1.lexical_path)
+        self._assert_cached(run_dir, node.sleepy_0.lexical_path)
+        self._assert_cached(run_dir, node.sleepy_1.lexical_path)
+
+    def test_dedicated_executor_error(self):
+        with (
+            wfms.tools._CacheTestExecutor() as exe,
+            self.assertRaises(executorlib.DedicatedExecutorError),
+        ):
+            exe.submit(plain_fn, 1)

--- a/tests/unit/_wfms/test_datatypes.py
+++ b/tests/unit/_wfms/test_datatypes.py
@@ -161,7 +161,9 @@ class TestNodeRun(unittest.TestCase):
         ) -> None:
             calls.append(status)
 
-        config = execution.RunConfig(progress_hooks=[hook])
+        config = execution.RunConfig(
+            progress_hooks=[execution.ProgressHook(hook, True)]
+        )
         run = n.run(config, x=1, y=2)
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
         # The default config carries no hooks, so a populated `calls` proves the
@@ -182,7 +184,9 @@ class TestNodeRun(unittest.TestCase):
         ) -> None:
             seen_paths.append(lexical_path)
 
-        config = execution.RunConfig(progress_hooks=[hook])
+        config = execution.RunConfig(
+            progress_hooks=[execution.ProgressHook(hook, True)]
+        )
         run = n.run(config, x=1, y=2)
         # The config is forwarded (hook fired) *and* the keyword inputs still
         # reach the node and compute correctly -- the config did not leak into

--- a/tests/unit/_wfms/test_execution.py
+++ b/tests/unit/_wfms/test_execution.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import datetime
+import logging
 import pathlib
 import tempfile
+import threading
 import unittest
 from concurrent import futures
 
@@ -122,7 +124,10 @@ class TestRunConfigEmitProgress(unittest.TestCase):
             run_dir = pathlib.Path(tmp)
             config = execution.RunConfig(
                 run_dir=run_dir,
-                progress_hooks=[hook_a, hook_b],
+                progress_hooks=[
+                    execution.ProgressHook(hook_a, True),
+                    execution.ProgressHook(hook_b, True),
+                ],
             )
             now = datetime.datetime(2026, 1, 1, 12, 0, 0)
             config.emit_progress(now, "pm", execution.RunStatus.PENDING)
@@ -188,7 +193,7 @@ class TestRunHappyPath(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             config = execution.RunConfig(
                 run_dir=pathlib.Path(tmp),
-                progress_hooks=[hook],
+                progress_hooks=[execution.ProgressHook(hook, True)],
             )
             run = execution.run(node, config, x=1, y=2)
 
@@ -315,7 +320,7 @@ class TestRunProgressHooks(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             config = execution.RunConfig(
                 run_dir=pathlib.Path(tmp),
-                progress_hooks=[hook],
+                progress_hooks=[execution.ProgressHook(hook, True)],
             )
             execution.run(macro, config, x=1, y=2, z=3)
 
@@ -347,6 +352,171 @@ class TestPopulateInputPorts(unittest.TestCase):
         self.assertIn("nonsense", msg)
         # The error message includes the recipe's input list verbatim.
         self.assertIn(str(live.recipe.inputs), msg)
+
+
+# --------------------------------------------------------------------------- #
+# process-local hook pool                                                     #
+# --------------------------------------------------------------------------- #
+
+
+class TestHookPool(unittest.TestCase):
+    def tearDown(self) -> None:
+        execution._shutdown_hook_pool()
+
+    def test_get_hook_pool_is_lazy_singleton_with_max_workers(self) -> None:
+        self.assertIsNone(execution._hook_pool)
+        pool = execution._get_hook_pool(3)
+        self.assertIsInstance(pool, futures.ThreadPoolExecutor)
+        self.assertEqual(pool._max_workers, 3)
+        self.assertIs(execution._get_hook_pool(3), pool)  # same instance reused
+
+    def test_shutdown_resets_singleton_and_rebuilds(self) -> None:
+        first = execution._get_hook_pool(1)
+        execution._shutdown_hook_pool()
+        self.assertIsNone(execution._hook_pool)
+        second = execution._get_hook_pool(1)
+        self.assertIsNot(second, first)  # fresh pool after reset
+
+    def test_shutdown_is_noop_when_no_pool(self) -> None:
+        self.assertIsNone(execution._hook_pool)
+        execution._shutdown_hook_pool()  # must not raise
+        self.assertIsNone(execution._hook_pool)
+
+
+# --------------------------------------------------------------------------- #
+# _guarded                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestGuarded(unittest.TestCase):
+    def _args(self):
+        return (
+            pathlib.Path("/run/dir"),
+            datetime.datetime(2026, 1, 1, 12, 0, 0),
+            "node.path",
+            execution.RunStatus.RUNNING,
+        )
+
+    def test_calls_fn_with_four_hook_args(self) -> None:
+        seen: list[tuple] = []
+        logger = logging.getLogger("test._guarded.ok")
+        execution._guarded(lambda *a: seen.append(a), logger, *self._args())
+        self.assertEqual(seen, [self._args()])
+
+    def test_logs_and_swallows_exception(self) -> None:
+        logger = logging.getLogger("test._guarded.boom")
+
+        def raising(*_a) -> None:
+            raise ValueError("nope")
+
+        with self.assertLogs(logger, level="ERROR") as cm:
+            execution._guarded(raising, logger, *self._args())  # must not raise
+        self.assertTrue(any("nope" in line for line in cm.output))
+
+    def test_propagates_base_exception(self) -> None:
+        logger = logging.getLogger("test._guarded.kbd")
+
+        def interrupt(*_a) -> None:
+            raise KeyboardInterrupt
+
+        with self.assertRaises(KeyboardInterrupt):
+            execution._guarded(interrupt, logger, *self._args())
+
+
+# --------------------------------------------------------------------------- #
+# ProgressHook dispatch                                                       #
+# --------------------------------------------------------------------------- #
+
+
+class TestProgressHookDispatch(unittest.TestCase):
+    def tearDown(self) -> None:
+        execution._shutdown_hook_pool()
+
+    def _emit(self, config: execution.RunConfig) -> None:
+        config.emit_progress(
+            datetime.datetime(2026, 1, 1, 12, 0, 0),
+            "pm",
+            execution.RunStatus.RUNNING,
+        )
+
+    def test_default_is_non_blocking(self) -> None:
+        self.assertFalse(execution.ProgressHook(lambda *a: None).blocking)
+
+    def test_blocking_hook_runs_inline(self) -> None:
+        seen: list[str] = []
+        config = execution.RunConfig(
+            progress_hooks=[execution.ProgressHook(lambda *a: seen.append("x"), True)]
+        )
+        self._emit(config)
+        self.assertEqual(seen, ["x"])  # already ran, no flush needed
+
+    def test_non_blocking_hook_runs_after_flush(self) -> None:
+        seen: list[str] = []
+        config = execution.RunConfig(
+            progress_hooks=[execution.ProgressHook(lambda *a: seen.append("x"))]
+        )
+        self._emit(config)
+        execution._shutdown_hook_pool()  # flush the pool (wait=True)
+        self.assertEqual(seen, ["x"])
+
+    def test_non_blocking_hooks_all_run_with_single_thread(self) -> None:
+        seen: list[int] = []
+        config = execution.RunConfig(
+            hooks_max_threads=1,
+            progress_hooks=[
+                execution.ProgressHook(lambda *a: seen.append(1)),
+                execution.ProgressHook(lambda *a: seen.append(2)),
+            ],
+        )
+        self._emit(config)
+        execution._shutdown_hook_pool()
+        self.assertEqual(sorted(seen), [1, 2])
+
+    def test_non_blocking_exception_routes_to_configured_logger(self) -> None:
+        def raising(*_a) -> None:
+            raise ValueError("kaboom")
+
+        config = execution.RunConfig(
+            logger_name="my.custom.sink",
+            progress_hooks=[execution.ProgressHook(raising)],
+        )
+        with self.assertLogs("my.custom.sink", level="ERROR") as cm:
+            self._emit(config)
+            execution._shutdown_hook_pool()  # ensure the worker finished logging
+        self.assertTrue(any("kaboom" in line for line in cm.output))
+
+
+# --------------------------------------------------------------------------- #
+# run() — non-blocking hooks do not stall the run thread                      #
+# --------------------------------------------------------------------------- #
+
+
+class TestRunDoesNotBlockOnHooks(unittest.TestCase):
+    def tearDown(self) -> None:
+        execution._shutdown_hook_pool()
+
+    def test_run_completes_while_non_blocking_hook_is_still_blocked(self) -> None:
+        release = threading.Event()
+        entered = threading.Event()
+
+        def slow_hook(run_dir, t, lp, status) -> None:
+            entered.set()
+            if not release.wait(timeout=5):  # generous; released by the test
+                raise AssertionError("hook never released")
+
+        node = _fixtures.atomic_add_node()
+        with tempfile.TemporaryDirectory() as tmp:
+            config = execution.RunConfig(
+                run_dir=pathlib.Path(tmp),
+                progress_hooks=[execution.ProgressHook(slow_hook)],  # non-blocking
+            )
+            run = execution.run(node, config, x=1, y=2)
+            # run() returned even though the hook is parked in release.wait():
+            self.assertTrue(entered.wait(timeout=5))
+            self.assertFalse(release.is_set())
+            self.assertEqual(run.status, execution.RunStatus.FINISHED)
+            self.assertEqual(run.outputs["output_0"].value, 3)
+            release.set()  # let the hook finish before teardown flushes the pool
 
 
 if __name__ == "__main__":

--- a/tests/unit/_wfms/test_execution.py
+++ b/tests/unit/_wfms/test_execution.py
@@ -317,18 +317,25 @@ class TestRunProgressHooks(unittest.TestCase):
         ) -> None:
             captured.append((lp, status))
 
-        with tempfile.TemporaryDirectory() as tmp:
-            config = execution.RunConfig(
-                run_dir=pathlib.Path(tmp),
-                progress_hooks=[execution.ProgressHook(hook, True)],
-            )
-            execution.run(macro, config, x=1, y=2, z=3)
+        for progress in (
+            [execution.ProgressHook(hook, True)],
+            [hook],
+        ):
+            with self.subTest(progress=progress):
+                with tempfile.TemporaryDirectory() as tmp:
+                    config = execution.RunConfig(
+                        run_dir=pathlib.Path(tmp),
+                        progress_hooks=progress,
+                    )
+                    execution.run(macro, config, x=1, y=2, z=3)
 
-        prime_statuses = {status for lp, status in captured if lp == macro.lexical_path}
-        self.assertEqual(
-            prime_statuses,
-            {execution.RunStatus.RUNNING, execution.RunStatus.FINISHED},
-        )
+                prime_statuses = {
+                    status for lp, status in captured if lp == macro.lexical_path
+                }
+                self.assertEqual(
+                    prime_statuses,
+                    {execution.RunStatus.RUNNING, execution.RunStatus.FINISHED},
+                )
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/_wfms/test_executors.py
+++ b/tests/unit/_wfms/test_executors.py
@@ -1,0 +1,38 @@
+"""
+Most executor tests are in the integration suite due to their non-trivial run times.
+"""
+
+import unittest
+
+from pyiron_workflow._wfms import execution, executorlib
+
+
+class TestFailureHandling(unittest.TestCase):
+    def test_wrong_callable_raiess(self):
+        with (
+            executorlib._CacheTestExecutor() as exe,
+            self.assertRaises(executorlib.DedicatedExecutorError, msg="Wrong function"),
+        ):
+            exe.submit(int, 1)
+
+    def test_wrong_args_raises(self):
+        with (
+            executorlib._CacheTestExecutor() as exe,
+            self.assertRaises(
+                executorlib.DedicatedExecutorError, msg="Wrong number of args"
+            ),
+        ):
+            exe.submit(execution._return_mutated_state_with_any_exception, 1, 2, 3, 4)
+
+    def test_kwargs_raises(self):
+        with (
+            executorlib._CacheTestExecutor() as exe,
+            self.assertRaises(executorlib.DedicatedExecutorError, msg="Wrong kwargs"),
+        ):
+            exe.submit(
+                execution._return_mutated_state_with_any_exception,
+                1,
+                2,
+                3,
+                anything="else",
+            )


### PR DESCRIPTION
Extends the notebook with an executorlib section. As expected, naive usage works out-of-the-box thanks to stdlib `Executor`-interface compliance. 

For trans-shutdown re-discoverability of cached results, I followed a similar pattern as in the legacy code: a very thin wrapper around the `executorlib` executors which is expected to _only_ work with the `.run` paradigm here, and force-overloads the `cache_dir` and `cache_key` resource properties. In this case, `RunConfig.run_dir` is used to set the dir, determining uniqueness for rediscoverability, and the `node.lexical_path` is used for the individual result. That means re-running the same workflow with _different_ inputs at the same `run_dir` will get false cache hits. That's not my favourite, but at least this is simple and easy to understand: caches are made in the `run_dir` -- want a fresh cache location? Specify a new directory for your run. It avoids the complexity of trying to get hashes based on the input that are both totally unique _and_ which manage to get cache hits when you re-instantiate and re-run a workflow (e.g. with new instances of non-trivial input data, which wouldn't by default get hashed the same). I think this is a fair tradeoff, but we can always look to add more hand-holding later.

TODO: getting a version of the slurm test CI working for these. Should be a bit simpler and more robust because now we can add progress hooks to hard-crash at certain event points instead of having to rely on sleep times.