### PR TITLE
Make progress hooks non-blocking

### DIFF
--- a/notebooks/_wfms.ipynb
+++ b/notebooks/_wfms.ipynb
@@ -421,7 +421,10 @@
     "\n",
     "`progress_hooks` fire on every status transition of every node in the tree,\n",
     "receiving the progress directory, a timestamp, the node's lexical path, and the new\n",
-    "status. This is the seam a GUI or logger taps to follow execution live."
+    "status. This is the seam a GUI or logger taps to follow execution live.\n",
+    "Each hook is wrapped in a `ProgressHook(fn, blocking=False)`.\n",
+    "By default hooks are **non-blocking** — they run on a background thread pool (sized by `RunConfig.hooks_max_threads`) so a slow hook can't stall execution, and a hook that raises is logged (to `RunConfig.logger_name`) rather than failing the run.\n",
+    "Pass `blocking=True` for a hook that must run inline and whose failure should abort the run."
    ]
   },
   {
@@ -440,7 +443,7 @@
     "    events.append((lexical_path, str(status)))\n",
     "\n",
     "wf = pwf.node(line)\n",
-    "cfg = pwf.RunConfig(progress_hooks=[progress_hook])\n",
+    "cfg = pwf.RunConfig(progress_hooks=[pwf.ProgressHook(progress_hook, blocking=True)])\n",
     "wf.run(cfg, x=1, m=2, b=3)\n",
     "\n",
     "for lexical_path, status in events:\n",

--- a/pyiron_workflow/_wfms/api/__init__.py
+++ b/pyiron_workflow/_wfms/api/__init__.py
@@ -4,6 +4,7 @@ from pyiron_workflow._wfms.api import tools as tools
 from pyiron_workflow._wfms.api.schemas import (
     ExecutorInstructions as ExecutorInstructions,
 )
+from pyiron_workflow._wfms.api.schemas import ProgressHook as ProgressHook
 from pyiron_workflow._wfms.api.schemas import RunConfig as RunConfig
 from pyiron_workflow._wfms.api.schemas import Workflow as Workflow
 from pyiron_workflow._wfms.api.tools import atomic as atomic

--- a/pyiron_workflow/_wfms/api/schemas.py
+++ b/pyiron_workflow/_wfms/api/schemas.py
@@ -2,6 +2,7 @@ from pyiron_workflow._wfms.atomic import Atomic as Atomic
 from pyiron_workflow._wfms.dag import Macro as Macro
 from pyiron_workflow._wfms.datatypes import EdgeTuple as EdgeTuple
 from pyiron_workflow._wfms.execution import ExecutorInstructions as ExecutorInstructions
+from pyiron_workflow._wfms.execution import ProgressHook as ProgressHook
 from pyiron_workflow._wfms.execution import Run as Run
 from pyiron_workflow._wfms.execution import RunConfig as RunConfig
 from pyiron_workflow._wfms.execution import RunStatus as RunStatus

--- a/pyiron_workflow/_wfms/execution.py
+++ b/pyiron_workflow/_wfms/execution.py
@@ -9,7 +9,7 @@ import pathlib
 import threading
 from collections.abc import Callable, Iterable
 from concurrent import futures
-from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeAlias, TypeVar
 
 import flowrep as fr
 
@@ -82,8 +82,13 @@ def _guarded(
         )
 
 
+HookFunction: TypeAlias = Callable[
+    [pathlib.Path, datetime.datetime, str, RunStatus], None
+]
+
+
 class ProgressHook(NamedTuple):
-    fn: Callable[[pathlib.Path, datetime.datetime, str, RunStatus], None]
+    fn: HookFunction
     blocking: bool = False
 
 
@@ -134,7 +139,9 @@ class Steps(list[Run[Any]]):
 @dataclasses.dataclass(frozen=True)
 class RunConfig:
     run_dir: pathlib.Path = pathlib.Path.cwd()
-    progress_hooks: Iterable[ProgressHook] = dataclasses.field(default_factory=list)
+    progress_hooks: Iterable[ProgressHook | HookFunction] = dataclasses.field(
+        default_factory=list
+    )
     exception_hooks: Iterable[
         Callable[[pathlib.Path, Run[ResultType], BaseException], None]
     ] = dataclasses.field(default_factory=list)
@@ -162,12 +169,15 @@ class RunConfig:
         self, time: datetime.datetime, lexical_path: str, status: RunStatus
     ):
         for hook in self.progress_hooks:
-            if hook.blocking:
-                hook.fn(self.run_dir, time, lexical_path, status)
+            progress_hook = (
+                hook if isinstance(hook, ProgressHook) else ProgressHook(hook)
+            )
+            if progress_hook.blocking:
+                progress_hook.fn(self.run_dir, time, lexical_path, status)
             else:
                 _get_hook_pool(self.hooks_max_threads).submit(
                     _guarded,
-                    hook.fn,
+                    progress_hook.fn,
                     logging.getLogger(self.logger_name),
                     self.run_dir,
                     time,

--- a/pyiron_workflow/_wfms/execution.py
+++ b/pyiron_workflow/_wfms/execution.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import atexit
 import dataclasses
 import datetime
 import enum
+import logging
 import pathlib
+import threading
 from collections.abc import Callable, Iterable
 from concurrent import futures
 from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeVar
@@ -21,6 +24,67 @@ class RunStatus(enum.StrEnum):
     RUNNING = "running"
     FINISHED = "finished"
     FAILED = "failed"
+
+
+_hook_pool: futures.ThreadPoolExecutor | None = None
+_hook_pool_lock = threading.Lock()
+
+
+def _get_hook_pool(max_threads: int) -> futures.ThreadPoolExecutor:
+    """Lazily build the per-process, non-blocking-hook thread pool.
+
+    A ``ThreadPoolExecutor`` is process-local, so each process (parent and any
+    executor worker) gets its own singleton; ``atexit`` drains it on exit. The
+    pool is sized on first creation; later ``max_threads`` values are ignored
+    for the lifetime of that process.
+    """
+    global _hook_pool  # noqa: PLW0603 -- deliberate per-process pool singleton
+    with _hook_pool_lock:
+        if _hook_pool is None:
+            _hook_pool = futures.ThreadPoolExecutor(max_workers=max_threads)
+            atexit.register(_shutdown_hook_pool)
+        return _hook_pool
+
+
+def _shutdown_hook_pool() -> None:
+    """Drain and discard the hook pool. Registered with ``atexit``; also the
+    reset hook tests call in ``tearDown``."""
+    global _hook_pool  # noqa: PLW0603 -- deliberate per-process pool singleton
+    with _hook_pool_lock:
+        if _hook_pool is not None:
+            _hook_pool.shutdown(wait=True)
+            _hook_pool = None
+
+
+def _guarded(
+    fn: Callable[[pathlib.Path, datetime.datetime, str, RunStatus], None],
+    logger: logging.Logger,
+    run_dir: pathlib.Path,
+    time: datetime.datetime,
+    lexical_path: str,
+    status: RunStatus,
+) -> None:
+    """Run a non-blocking progress hook, logging (not raising) ordinary errors.
+
+    Catches ``Exception`` only, so ``KeyboardInterrupt``/``SystemExit`` are left
+    to propagate to the caller (here, the pool worker, which absorbs them into
+    its discarded future); a deliberate ``os._exit`` raises nothing so it is
+    unaffected.
+    """
+    try:
+        fn(run_dir, time, lexical_path, status)
+    except Exception:
+        logger.exception(
+            "Non-blocking progress hook %r failed for %s @ %s",
+            fn,
+            lexical_path,
+            status,
+        )
+
+
+class ProgressHook(NamedTuple):
+    fn: Callable[[pathlib.Path, datetime.datetime, str, RunStatus], None]
+    blocking: bool = False
 
 
 ResultType = TypeVar("ResultType", bound=fr.schemas.NodeData[Any])
@@ -70,15 +134,15 @@ class Steps(list[Run[Any]]):
 @dataclasses.dataclass(frozen=True)
 class RunConfig:
     run_dir: pathlib.Path = pathlib.Path.cwd()
-    progress_hooks: Iterable[
-        Callable[[pathlib.Path, datetime.datetime, str, RunStatus], None]
-    ] = dataclasses.field(default_factory=list)
+    progress_hooks: Iterable[ProgressHook] = dataclasses.field(default_factory=list)
     exception_hooks: Iterable[
         Callable[[pathlib.Path, Run[ResultType], BaseException], None]
     ] = dataclasses.field(default_factory=list)
     dag_layers_multithreaded: bool = True
     dag_layers_max_threads: int = 10
     dag_layers_fail_fast: bool = False
+    hooks_max_threads: int = 10
+    logger_name: str = __name__
     _prime_mover: lexical.LexicalPath | None = dataclasses.field(
         default=None, kw_only=True
     )
@@ -98,7 +162,18 @@ class RunConfig:
         self, time: datetime.datetime, lexical_path: str, status: RunStatus
     ):
         for hook in self.progress_hooks:
-            hook(self.run_dir, time, lexical_path, status)
+            if hook.blocking:
+                hook.fn(self.run_dir, time, lexical_path, status)
+            else:
+                _get_hook_pool(self.hooks_max_threads).submit(
+                    _guarded,
+                    hook.fn,
+                    logging.getLogger(self.logger_name),
+                    self.run_dir,
+                    time,
+                    lexical_path,
+                    status,
+                )
 
     def emit_exception(self, failed_run: Run[ResultType], exception: BaseException):
         for hook in self.exception_hooks:

--- a/tests/unit/_wfms/test_datatypes.py
+++ b/tests/unit/_wfms/test_datatypes.py
@@ -161,7 +161,9 @@ class TestNodeRun(unittest.TestCase):
         ) -> None:
             calls.append(status)
 
-        config = execution.RunConfig(progress_hooks=[hook])
+        config = execution.RunConfig(
+            progress_hooks=[execution.ProgressHook(hook, True)]
+        )
         run = n.run(config, x=1, y=2)
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
         # The default config carries no hooks, so a populated `calls` proves the
@@ -182,7 +184,9 @@ class TestNodeRun(unittest.TestCase):
         ) -> None:
             seen_paths.append(lexical_path)
 
-        config = execution.RunConfig(progress_hooks=[hook])
+        config = execution.RunConfig(
+            progress_hooks=[execution.ProgressHook(hook, True)]
+        )
         run = n.run(config, x=1, y=2)
         # The config is forwarded (hook fired) *and* the keyword inputs still
         # reach the node and compute correctly -- the config did not leak into

--- a/tests/unit/_wfms/test_execution.py
+++ b/tests/unit/_wfms/test_execution.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import datetime
+import logging
 import pathlib
 import tempfile
+import threading
 import unittest
 from concurrent import futures
 
@@ -122,7 +124,10 @@ class TestRunConfigEmitProgress(unittest.TestCase):
             run_dir = pathlib.Path(tmp)
             config = execution.RunConfig(
                 run_dir=run_dir,
-                progress_hooks=[hook_a, hook_b],
+                progress_hooks=[
+                    execution.ProgressHook(hook_a, True),
+                    execution.ProgressHook(hook_b, True),
+                ],
             )
             now = datetime.datetime(2026, 1, 1, 12, 0, 0)
             config.emit_progress(now, "pm", execution.RunStatus.PENDING)
@@ -188,7 +193,7 @@ class TestRunHappyPath(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             config = execution.RunConfig(
                 run_dir=pathlib.Path(tmp),
-                progress_hooks=[hook],
+                progress_hooks=[execution.ProgressHook(hook, True)],
             )
             run = execution.run(node, config, x=1, y=2)
 
@@ -315,7 +320,7 @@ class TestRunProgressHooks(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             config = execution.RunConfig(
                 run_dir=pathlib.Path(tmp),
-                progress_hooks=[hook],
+                progress_hooks=[execution.ProgressHook(hook, True)],
             )
             execution.run(macro, config, x=1, y=2, z=3)
 
@@ -347,6 +352,171 @@ class TestPopulateInputPorts(unittest.TestCase):
         self.assertIn("nonsense", msg)
         # The error message includes the recipe's input list verbatim.
         self.assertIn(str(live.recipe.inputs), msg)
+
+
+# --------------------------------------------------------------------------- #
+# process-local hook pool                                                     #
+# --------------------------------------------------------------------------- #
+
+
+class TestHookPool(unittest.TestCase):
+    def tearDown(self) -> None:
+        execution._shutdown_hook_pool()
+
+    def test_get_hook_pool_is_lazy_singleton_with_max_workers(self) -> None:
+        self.assertIsNone(execution._hook_pool)
+        pool = execution._get_hook_pool(3)
+        self.assertIsInstance(pool, futures.ThreadPoolExecutor)
+        self.assertEqual(pool._max_workers, 3)
+        self.assertIs(execution._get_hook_pool(3), pool)  # same instance reused
+
+    def test_shutdown_resets_singleton_and_rebuilds(self) -> None:
+        first = execution._get_hook_pool(1)
+        execution._shutdown_hook_pool()
+        self.assertIsNone(execution._hook_pool)
+        second = execution._get_hook_pool(1)
+        self.assertIsNot(second, first)  # fresh pool after reset
+
+    def test_shutdown_is_noop_when_no_pool(self) -> None:
+        self.assertIsNone(execution._hook_pool)
+        execution._shutdown_hook_pool()  # must not raise
+        self.assertIsNone(execution._hook_pool)
+
+
+# --------------------------------------------------------------------------- #
+# _guarded                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestGuarded(unittest.TestCase):
+    def _args(self):
+        return (
+            pathlib.Path("/run/dir"),
+            datetime.datetime(2026, 1, 1, 12, 0, 0),
+            "node.path",
+            execution.RunStatus.RUNNING,
+        )
+
+    def test_calls_fn_with_four_hook_args(self) -> None:
+        seen: list[tuple] = []
+        logger = logging.getLogger("test._guarded.ok")
+        execution._guarded(lambda *a: seen.append(a), logger, *self._args())
+        self.assertEqual(seen, [self._args()])
+
+    def test_logs_and_swallows_exception(self) -> None:
+        logger = logging.getLogger("test._guarded.boom")
+
+        def raising(*_a) -> None:
+            raise ValueError("nope")
+
+        with self.assertLogs(logger, level="ERROR") as cm:
+            execution._guarded(raising, logger, *self._args())  # must not raise
+        self.assertTrue(any("nope" in line for line in cm.output))
+
+    def test_propagates_base_exception(self) -> None:
+        logger = logging.getLogger("test._guarded.kbd")
+
+        def interrupt(*_a) -> None:
+            raise KeyboardInterrupt
+
+        with self.assertRaises(KeyboardInterrupt):
+            execution._guarded(interrupt, logger, *self._args())
+
+
+# --------------------------------------------------------------------------- #
+# ProgressHook dispatch                                                       #
+# --------------------------------------------------------------------------- #
+
+
+class TestProgressHookDispatch(unittest.TestCase):
+    def tearDown(self) -> None:
+        execution._shutdown_hook_pool()
+
+    def _emit(self, config: execution.RunConfig) -> None:
+        config.emit_progress(
+            datetime.datetime(2026, 1, 1, 12, 0, 0),
+            "pm",
+            execution.RunStatus.RUNNING,
+        )
+
+    def test_default_is_non_blocking(self) -> None:
+        self.assertFalse(execution.ProgressHook(lambda *a: None).blocking)
+
+    def test_blocking_hook_runs_inline(self) -> None:
+        seen: list[str] = []
+        config = execution.RunConfig(
+            progress_hooks=[execution.ProgressHook(lambda *a: seen.append("x"), True)]
+        )
+        self._emit(config)
+        self.assertEqual(seen, ["x"])  # already ran, no flush needed
+
+    def test_non_blocking_hook_runs_after_flush(self) -> None:
+        seen: list[str] = []
+        config = execution.RunConfig(
+            progress_hooks=[execution.ProgressHook(lambda *a: seen.append("x"))]
+        )
+        self._emit(config)
+        execution._shutdown_hook_pool()  # flush the pool (wait=True)
+        self.assertEqual(seen, ["x"])
+
+    def test_non_blocking_hooks_all_run_with_single_thread(self) -> None:
+        seen: list[int] = []
+        config = execution.RunConfig(
+            hooks_max_threads=1,
+            progress_hooks=[
+                execution.ProgressHook(lambda *a: seen.append(1)),
+                execution.ProgressHook(lambda *a: seen.append(2)),
+            ],
+        )
+        self._emit(config)
+        execution._shutdown_hook_pool()
+        self.assertEqual(sorted(seen), [1, 2])
+
+    def test_non_blocking_exception_routes_to_configured_logger(self) -> None:
+        def raising(*_a) -> None:
+            raise ValueError("kaboom")
+
+        config = execution.RunConfig(
+            logger_name="my.custom.sink",
+            progress_hooks=[execution.ProgressHook(raising)],
+        )
+        with self.assertLogs("my.custom.sink", level="ERROR") as cm:
+            self._emit(config)
+            execution._shutdown_hook_pool()  # ensure the worker finished logging
+        self.assertTrue(any("kaboom" in line for line in cm.output))
+
+
+# --------------------------------------------------------------------------- #
+# run() — non-blocking hooks do not stall the run thread                      #
+# --------------------------------------------------------------------------- #
+
+
+class TestRunDoesNotBlockOnHooks(unittest.TestCase):
+    def tearDown(self) -> None:
+        execution._shutdown_hook_pool()
+
+    def test_run_completes_while_non_blocking_hook_is_still_blocked(self) -> None:
+        release = threading.Event()
+        entered = threading.Event()
+
+        def slow_hook(run_dir, t, lp, status) -> None:
+            entered.set()
+            if not release.wait(timeout=5):  # generous; released by the test
+                raise AssertionError("hook never released")
+
+        node = _fixtures.atomic_add_node()
+        with tempfile.TemporaryDirectory() as tmp:
+            config = execution.RunConfig(
+                run_dir=pathlib.Path(tmp),
+                progress_hooks=[execution.ProgressHook(slow_hook)],  # non-blocking
+            )
+            run = execution.run(node, config, x=1, y=2)
+            # run() returned even though the hook is parked in release.wait():
+            self.assertTrue(entered.wait(timeout=5))
+            self.assertFalse(release.is_set())
+            self.assertEqual(run.status, execution.RunStatus.FINISHED)
+            self.assertEqual(run.outputs["output_0"].value, 3)
+            release.set()  # let the hook finish before teardown flushes the pool
 
 
 if __name__ == "__main__":

--- a/tests/unit/_wfms/test_execution.py
+++ b/tests/unit/_wfms/test_execution.py
@@ -317,18 +317,25 @@ class TestRunProgressHooks(unittest.TestCase):
         ) -> None:
             captured.append((lp, status))
 
-        with tempfile.TemporaryDirectory() as tmp:
-            config = execution.RunConfig(
-                run_dir=pathlib.Path(tmp),
-                progress_hooks=[execution.ProgressHook(hook, True)],
-            )
-            execution.run(macro, config, x=1, y=2, z=3)
+        for progress in (
+            [execution.ProgressHook(hook, True)],
+            [hook],
+        ):
+            with self.subTest(progress=progress):
+                with tempfile.TemporaryDirectory() as tmp:
+                    config = execution.RunConfig(
+                        run_dir=pathlib.Path(tmp),
+                        progress_hooks=progress,
+                    )
+                    execution.run(macro, config, x=1, y=2, z=3)
 
-        prime_statuses = {status for lp, status in captured if lp == macro.lexical_path}
-        self.assertEqual(
-            prime_statuses,
-            {execution.RunStatus.RUNNING, execution.RunStatus.FINISHED},
-        )
+                prime_statuses = {
+                    status for lp, status in captured if lp == macro.lexical_path
+                }
+                self.assertEqual(
+                    prime_statuses,
+                    {execution.RunStatus.RUNNING, execution.RunStatus.FINISHED},
+                )
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
By default. A new named tuple adds blocking status to the callback registration. Run configuration offers new fields for the number of threads available for concurrent callback operations, and the name of the logger where their errors get shoved (so callback errors don't crash the main process).