### PR TITLE
Pull mode

### DIFF
--- a/pyiron_workflow/_wfms/api/tools.py
+++ b/pyiron_workflow/_wfms/api/tools.py
@@ -8,4 +8,7 @@ from pyiron_workflow._wfms.execution import run as run
 from pyiron_workflow._wfms.executorlib import NodeSingleExecutor as NodeSingleExecutor
 from pyiron_workflow._wfms.executorlib import NodeSlurmExecutor as NodeSlurmExecutor
 from pyiron_workflow._wfms.executorlib import _CacheTestExecutor as _CacheTestExecutor
+from pyiron_workflow._wfms.pull import pull as pull
+from pyiron_workflow._wfms.pull import pulled_inputs as pulled_inputs
+from pyiron_workflow._wfms.pull import pulled_workflow as pulled_workflow
 from pyiron_workflow._wfms.validation import validate_plan as validate_plan

--- a/pyiron_workflow/_wfms/datatypes.py
+++ b/pyiron_workflow/_wfms/datatypes.py
@@ -250,6 +250,22 @@ class Node(
 
         return _pull.pulled_inputs(self, break_out_of_context, expose_defaults)
 
+    @abc.abstractmethod
+    def copy(
+        self, new_label: fr.schemas.Label | None = None, _copy_to: Self | None = None
+    ) -> Self:
+        """
+        Make a new copy of this node based on its recipe, and copy over node-state
+        (so far, just the executor.)
+
+        Intentionally loses scope information like the owner and any pending
+        connections, and history information like the ``last_run``.
+        """
+
+    @staticmethod
+    def _copy_data(from_: Node, to_: Node, /) -> None:
+        to_.executor = from_.executor
+
     def __call__(self, *args: Port | Node, **kwargs: Port | Node) -> Self:
         self.connect_input(*args, **kwargs)
         return self
@@ -393,6 +409,13 @@ class StaticNode(Node[RecipeType, execution.ResultType], abc.ABC):
     def recipe(self) -> RecipeType:
         return self._recipe
 
+    def copy(
+        self, new_label: fr.schemas.Label | None = None, _copy_to: Self | None = None
+    ) -> Self:
+        node_copy = _copy_to or self.__class__(new_label or self.label, self.recipe)
+        self._copy_data(self, node_copy)
+        return node_copy
+
     def generate_flowrep_live_node(self) -> execution.ResultType:
         return self._result_type().from_recipe(self.recipe)
 
@@ -529,6 +552,14 @@ class StaticGraph(StaticNode[RecipeType, execution.ResultType], Graph, abc.ABC):
         super().__init__(label, recipe, *positional_connections, **keyword_connections)
         self._nodes = self._build_nodes(recipe)
         self._edges = self._build_edges(recipe)
+
+    def copy(
+        self, new_label: fr.schemas.Label | None = None, _copy_to: Self | None = None
+    ) -> Self:
+        node_copy = super().copy(new_label=new_label, _copy_to=_copy_to)
+        for label, child in self.nodes.items():
+            child.copy(_copy_to=node_copy.nodes[label])
+        return node_copy
 
     @abc.abstractmethod
     def _build_nodes(self, recipe: RecipeType) -> NodeMap: ...

--- a/pyiron_workflow/_wfms/datatypes.py
+++ b/pyiron_workflow/_wfms/datatypes.py
@@ -224,16 +224,16 @@ class Node(
 
     def pull(
         self,
+        config: execution.RunConfig | None = None,
         break_out_of_context: bool = False,
         expose_defaults: bool = False,
-        config: execution.RunConfig | None = None,
         /,
         **input_kwargs,
     ) -> execution.Run[execution.ResultType]:
         from pyiron_workflow._wfms import pull as _pull  # noqa: PLC0415 -- cycle guard
 
         return _pull.pull(
-            self, break_out_of_context, expose_defaults, config, **input_kwargs
+            self, config, break_out_of_context, expose_defaults, **input_kwargs
         )
 
     def pulled_workflow(

--- a/pyiron_workflow/_wfms/datatypes.py
+++ b/pyiron_workflow/_wfms/datatypes.py
@@ -222,6 +222,34 @@ class Node(
         self.last_run = current_run
         return current_run
 
+    def pull(
+        self,
+        break_out_of_context: bool = False,
+        expose_defaults: bool = False,
+        config: execution.RunConfig | None = None,
+        /,
+        **input_kwargs,
+    ) -> execution.Run[execution.ResultType]:
+        from pyiron_workflow._wfms import pull as _pull  # noqa: PLC0415 -- cycle guard
+
+        return _pull.pull(
+            self, break_out_of_context, expose_defaults, config, **input_kwargs
+        )
+
+    def pulled_workflow(
+        self, break_out_of_context: bool = False, expose_defaults: bool = False, /
+    ):
+        from pyiron_workflow._wfms import pull as _pull  # noqa: PLC0415 -- cycle guard
+
+        return _pull.pulled_workflow(self, break_out_of_context, expose_defaults)
+
+    def pulled_inputs(
+        self, break_out_of_context: bool = False, expose_defaults: bool = False, /
+    ):
+        from pyiron_workflow._wfms import pull as _pull  # noqa: PLC0415 -- cycle guard
+
+        return _pull.pulled_inputs(self, break_out_of_context, expose_defaults)
+
     def __call__(self, *args: Port | Node, **kwargs: Port | Node) -> Self:
         self.connect_input(*args, **kwargs)
         return self

--- a/pyiron_workflow/_wfms/pull.py
+++ b/pyiron_workflow/_wfms/pull.py
@@ -140,9 +140,10 @@ def _resolve_boundary(
     seen: set[str],
     pulled: Node,
 ) -> None:
+    parent = graph.owner  # the subgraph `graph` is itself a child of `parent`
     if (
         graph is ceiling
-        or graph.owner is None
+        or parent is None
         # These are _equivalent conditions_ -- if the owner is None, this is the ceiling
     ):
         ceiling_port = graph.inputs[boundary_port]
@@ -155,7 +156,6 @@ def _resolve_boundary(
             ceiling_port.type_metadata,
         )
         return
-    parent = graph.owner  # the subgraph `graph` is itself a child of `parent`
     if parent is None or not _is_traceable(parent):
         if parent is not None:
             raise _flow_control_error(parent, pulled)

--- a/pyiron_workflow/_wfms/pull.py
+++ b/pyiron_workflow/_wfms/pull.py
@@ -4,6 +4,7 @@ import dataclasses
 from typing import TYPE_CHECKING
 
 import flowrep as fr
+import typing_extensions
 
 from pyiron_workflow._wfms import constructors, execution, workflow
 from pyiron_workflow._wfms.datatypes import (
@@ -56,7 +57,7 @@ def _member_label(node: Node, ceiling: Graph | None) -> str:
     return _relative(node, ceiling) or node.label
 
 
-def _is_traceable(graph: object) -> bool:
+def _is_traceable(graph: object) -> typing_extensions.TypeIs[ImmutableDag | MutableDag]:
     """Whether a graph exposes concrete (non-prospective) edges we may walk."""
     return isinstance(graph, ImmutableDag | MutableDag)
 
@@ -167,7 +168,6 @@ def _resolve_boundary(
         )
         return  # pragma: no cover
     # else _is_traceable(parent) and parent: ImmutableDag | MutableDag
-    assert isinstance(parent, ImmutableDag | MutableDag)
     # TODO: structure the function better so that the inspectors can just see this
     edge = _incoming_edge(parent, graph.label, boundary_port)
     if edge is None:
@@ -261,7 +261,6 @@ def _resolve_input(
         _require(member, port_label, port, ceiling, cone)
         return
     # else _is_traceable(graph) and graph: ImmutableDag | MutableDag
-    assert isinstance(graph, ImmutableDag | MutableDag)
     # TODO: structure the function better so that the inspectors can just see this
     edge = _incoming_edge(graph, member.label, port_label)
     if edge is None:

--- a/pyiron_workflow/_wfms/pull.py
+++ b/pyiron_workflow/_wfms/pull.py
@@ -135,7 +135,6 @@ def _resolve_boundary(
     consumer_port: str,
     consumer_port_obj: InputPort,
     ceiling: Graph | None,
-    break_out: bool,
     cone: _Cone,
     worklist: list[Node],
     seen: set[str],
@@ -154,7 +153,7 @@ def _resolve_boundary(
         return
     parent = graph.owner  # the subgraph `graph` is itself a child of `parent`
     if parent is None or not _is_traceable(parent):
-        if parent is not None and break_out:
+        if parent is not None:
             raise _flow_control_error(parent, pulled)
         # `graph`'s boundary port is unfed at the parent level: required input,
         # keyed by the deep consumer.
@@ -201,7 +200,6 @@ def _resolve_boundary(
             consumer_port,
             consumer_port_obj,
             ceiling,
-            break_out,
             cone,
             worklist,
             seen,
@@ -283,7 +281,6 @@ def _resolve_input(
             port_label,
             port,
             ceiling,
-            break_out,
             cone,
             worklist,
             seen,

--- a/pyiron_workflow/_wfms/pull.py
+++ b/pyiron_workflow/_wfms/pull.py
@@ -249,10 +249,12 @@ def _resolve_input(
 ) -> None:
     if port.has_default and not expose_defaults:
         return
+
     graph = member.owner
     if graph is None:
         _require(member, port_label, port, ceiling, cone)
         return
+
     if not _is_traceable(graph):
         # `graph` is a flow controller: its edges are prospective and may not be
         # walked. Punching out is impossible; stopping isolates the node.
@@ -260,8 +262,8 @@ def _resolve_input(
             raise _flow_control_error(graph, pulled)
         _require(member, port_label, port, ceiling, cone)
         return
+
     # else _is_traceable(graph) and graph: ImmutableDag | MutableDag
-    # TODO: structure the function better so that the inspectors can just see this
     edge = _incoming_edge(graph, member.label, port_label)
     if edge is None:
         _require(member, port_label, port, ceiling, cone)

--- a/pyiron_workflow/_wfms/pull.py
+++ b/pyiron_workflow/_wfms/pull.py
@@ -12,12 +12,13 @@ from pyiron_workflow._wfms.datatypes import (
     Graph,
     ImmutableDag,
     MutableDag,
+    Node,
 )
 
 if TYPE_CHECKING:
     import semantikon
 
-    from pyiron_workflow._wfms.datatypes import InputPort, Node
+    from pyiron_workflow._wfms.datatypes import InputPort
 
 
 @dataclasses.dataclass
@@ -33,28 +34,25 @@ class _Cone:
     input_edges: EdgeList = dataclasses.field(default_factory=list)
 
 
-def _root(node: Node) -> Node:
-    current = node
-    while current.owner is not None:
-        current = current.owner
-    return current
+def _ceiling(node: Node, break_out_of_context: bool) -> Graph | None:
+    if break_out_of_context:
+        root: Graph | None = node.owner
+        while isinstance(root, Node) and root.owner is not None:
+            root = root.owner
+        return root
+    else:
+        return node.owner
 
 
-def _ceiling(node: Node, break_out_of_context: bool) -> Node:
-    if node.owner is None:
-        return node
-    return _root(node) if break_out_of_context else node.owner
-
-
-def _relative(node: Node, ceiling: Node) -> str:
+def _relative(node: Node, ceiling: Graph | None) -> str:
     """Flat label relative to `ceiling`; '' iff `node is ceiling`."""
-    if node is ceiling:
+    if ceiling is None:
         return ""
     prefix = ceiling.lexical_path
     return node.lexical_path[len(prefix) + 1 :].replace(".", "__")
 
 
-def _member_label(node: Node, ceiling: Node) -> str:
+def _member_label(node: Node, ceiling: Graph | None) -> str:
     return _relative(node, ceiling) or node.label
 
 
@@ -71,7 +69,7 @@ def _incoming_edge(graph: Graph, node_label: str, port: str) -> EdgeTuple | None
     return None
 
 
-def _flow_control_error(controller: Node, pulled: Node) -> ValueError:
+def _flow_control_error(controller: Graph, pulled: Node) -> ValueError:
     return ValueError(
         f"Cannot pull {pulled.lexical_path!r} out of the flow controller "
         f"{controller.lexical_path!r} (a {type(controller).__name__}): a pull cannot "
@@ -98,7 +96,7 @@ def _add_input(
 
 
 def _require(
-    member: Node, port_label: str, port: InputPort, ceiling: Node, cone: _Cone
+    member: Node, port_label: str, port: InputPort, ceiling: Graph | None, cone: _Cone
 ) -> None:
     """Surface a genuinely-unfed input port as a required workflow input."""
     rel = _relative(member, ceiling)
@@ -112,7 +110,7 @@ def _add_dependency(
     dep_port: str,
     consumer_label: str,
     consumer_port: str,
-    ceiling: Node,
+    ceiling: Graph | None,
     cone: _Cone,
     worklist: list[Node],
     seen: set[str],
@@ -130,12 +128,12 @@ def _add_dependency(
 
 
 def _resolve_boundary(
-    graph: Graph,
+    graph: ImmutableDag | MutableDag,
     boundary_port: str,
     consumer_label: str,
     consumer_port: str,
     consumer_port_obj: InputPort,
-    ceiling: Node,
+    ceiling: Graph | None,
     break_out: bool,
     cone: _Cone,
     worklist: list[Node],
@@ -143,7 +141,7 @@ def _resolve_boundary(
     pulled: Node,
 ) -> None:
     if graph is ceiling:
-        ceiling_port = ceiling.inputs[boundary_port]
+        ceiling_port = graph.inputs[boundary_port]
         _add_input(
             cone,
             boundary_port,
@@ -168,6 +166,9 @@ def _resolve_boundary(
             consumer_port_obj.type_metadata,
         )
         return  # pragma: no cover
+    # else _is_traceable(parent) and parent: ImmutableDag | MutableDag
+    assert isinstance(parent, ImmutableDag | MutableDag)
+    # TODO: structure the function better so that the inspectors can just see this
     edge = _incoming_edge(parent, graph.label, boundary_port)
     if edge is None:
         _add_input(
@@ -210,7 +211,7 @@ def _resolve_boundary(
 
 def _build_cone(
     node: Node, break_out_of_context: bool, expose_defaults: bool
-) -> tuple[_Cone, Node]:
+) -> tuple[_Cone, Graph | None]:
     ceiling = _ceiling(node, break_out_of_context)
     cone = _Cone(pulled_label=_member_label(node, ceiling))
     seen = {cone.pulled_label}
@@ -238,7 +239,7 @@ def _resolve_input(
     member: Node,
     port_label: str,
     port: InputPort,
-    ceiling: Node,
+    ceiling: Graph | None,
     break_out: bool,
     expose_defaults: bool,
     cone: _Cone,
@@ -259,6 +260,9 @@ def _resolve_input(
             raise _flow_control_error(graph, pulled)
         _require(member, port_label, port, ceiling, cone)
         return
+    # else _is_traceable(graph) and graph: ImmutableDag | MutableDag
+    assert isinstance(graph, ImmutableDag | MutableDag)
+    # TODO: structure the function better so that the inspectors can just see this
     edge = _incoming_edge(graph, member.label, port_label)
     if edge is None:
         _require(member, port_label, port, ceiling, cone)

--- a/pyiron_workflow/_wfms/pull.py
+++ b/pyiron_workflow/_wfms/pull.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING
+
+import flowrep as fr
+
+from pyiron_workflow._wfms import constructors, execution, workflow
+from pyiron_workflow._wfms.datatypes import (
+    EdgeList,
+    EdgeTuple,
+    Graph,
+    ImmutableDag,
+    MutableDag,
+)
+
+if TYPE_CHECKING:
+    import semantikon
+
+    from pyiron_workflow._wfms.datatypes import InputPort, Node
+
+
+@dataclasses.dataclass
+class _Cone:
+    """Accumulates the flattened dependency cone of a pulled node."""
+
+    pulled_label: str
+    members: dict[str, Node] = dataclasses.field(default_factory=dict)
+    internal_edges: EdgeList = dataclasses.field(default_factory=list)
+    input_specs: dict[str, tuple[type | None, semantikon.TypeMetadata | None]] = (
+        dataclasses.field(default_factory=dict)
+    )
+    input_edges: EdgeList = dataclasses.field(default_factory=list)
+
+
+def _root(node: Node) -> Node:
+    current = node
+    while current.owner is not None:
+        current = current.owner
+    return current
+
+
+def _ceiling(node: Node, break_out_of_context: bool) -> Node:
+    if node.owner is None:
+        return node
+    return _root(node) if break_out_of_context else node.owner
+
+
+def _relative(node: Node, ceiling: Node) -> str:
+    """Flat label relative to `ceiling`; '' iff `node is ceiling`."""
+    if node is ceiling:
+        return ""
+    prefix = ceiling.lexical_path
+    return node.lexical_path[len(prefix) + 1 :].replace(".", "__")
+
+
+def _member_label(node: Node, ceiling: Node) -> str:
+    return _relative(node, ceiling) or node.label
+
+
+def _is_traceable(graph: object) -> bool:
+    """Whether a graph exposes concrete (non-prospective) edges we may walk."""
+    return isinstance(graph, ImmutableDag | MutableDag)
+
+
+def _incoming_edge(graph: Graph, node_label: str, port: str) -> EdgeTuple | None:
+    target = fr.schemas.TargetHandle(node=node_label, port=port)
+    for edge in graph.edges:
+        if edge.target == target:
+            return edge
+    return None
+
+
+def _flow_control_error(controller: Node, pulled: Node) -> ValueError:
+    return ValueError(
+        f"Cannot pull {pulled.lexical_path!r} out of the flow controller "
+        f"{controller.lexical_path!r} (a {type(controller).__name__}): a pull cannot "
+        f"break out of a flow controller's context. Use break_out_of_context=False "
+        f"to pull in isolation, supplying its inputs directly."
+    )
+
+
+def _add_input(
+    cone: _Cone,
+    key: str,
+    target_node_label: str,
+    target_port_label: str,
+    hint: type | None,
+    metadata: semantikon.TypeMetadata | None,
+) -> None:
+    cone.input_specs.setdefault(key, (hint, metadata))
+    cone.input_edges.append(
+        EdgeTuple(
+            fr.schemas.InputSource(port=key),
+            fr.schemas.TargetHandle(node=target_node_label, port=target_port_label),
+        )
+    )
+
+
+def _require(
+    member: Node, port_label: str, port: InputPort, ceiling: Node, cone: _Cone
+) -> None:
+    """Surface a genuinely-unfed input port as a required workflow input."""
+    rel = _relative(member, ceiling)
+    node_label = rel or member.label
+    key = f"{rel}__{port_label}" if rel else port_label
+    _add_input(cone, key, node_label, port_label, port.type_hint, port.type_metadata)
+
+
+def _add_dependency(
+    dep: Node,
+    dep_port: str,
+    consumer_label: str,
+    consumer_port: str,
+    ceiling: Node,
+    cone: _Cone,
+    worklist: list[Node],
+    seen: set[str],
+) -> None:
+    dep_label = _member_label(dep, ceiling)
+    cone.internal_edges.append(
+        EdgeTuple(
+            fr.schemas.SourceHandle(node=dep_label, port=dep_port),
+            fr.schemas.TargetHandle(node=consumer_label, port=consumer_port),
+        )
+    )
+    if dep_label not in seen:
+        seen.add(dep_label)
+        worklist.append(dep)
+
+
+def _resolve_boundary(
+    graph: Graph,
+    boundary_port: str,
+    consumer_label: str,
+    consumer_port: str,
+    consumer_port_obj: InputPort,
+    ceiling: Node,
+    break_out: bool,
+    cone: _Cone,
+    worklist: list[Node],
+    seen: set[str],
+    pulled: Node,
+) -> None:
+    if graph is ceiling:
+        ceiling_port = ceiling.inputs[boundary_port]
+        _add_input(
+            cone,
+            boundary_port,
+            consumer_label,
+            consumer_port,
+            ceiling_port.type_hint,
+            ceiling_port.type_metadata,
+        )
+        return
+    parent = graph.owner  # the subgraph `graph` is itself a child of `parent`
+    if parent is None or not _is_traceable(parent):
+        if parent is not None and break_out:
+            raise _flow_control_error(parent, pulled)
+        # `graph`'s boundary port is unfed at the parent level: required input,
+        # keyed by the deep consumer.
+        _add_input(  # pragma: no cover  -- only reachable if parent is None (unreachable)
+            cone,
+            f"{consumer_label}__{consumer_port}",
+            consumer_label,
+            consumer_port,
+            consumer_port_obj.type_hint,
+            consumer_port_obj.type_metadata,
+        )
+        return  # pragma: no cover
+    edge = _incoming_edge(parent, graph.label, boundary_port)
+    if edge is None:
+        _add_input(
+            cone,
+            f"{consumer_label}__{consumer_port}",
+            consumer_label,
+            consumer_port,
+            consumer_port_obj.type_hint,
+            consumer_port_obj.type_metadata,
+        )
+        return
+    source = edge.source
+    if isinstance(source, fr.schemas.SourceHandle):
+        dep = parent.nodes[source.node]
+        _add_dependency(
+            dep,
+            source.port,
+            consumer_label,
+            consumer_port,
+            ceiling,
+            cone,
+            worklist,
+            seen,
+        )
+    else:  # fr.schemas.InputSource — keep climbing
+        _resolve_boundary(
+            parent,
+            source.port,
+            consumer_label,
+            consumer_port,
+            consumer_port_obj,
+            ceiling,
+            break_out,
+            cone,
+            worklist,
+            seen,
+            pulled,
+        )
+
+
+def _build_cone(
+    node: Node, break_out_of_context: bool, expose_defaults: bool
+) -> tuple[_Cone, Node]:
+    ceiling = _ceiling(node, break_out_of_context)
+    cone = _Cone(pulled_label=_member_label(node, ceiling))
+    seen = {cone.pulled_label}
+    worklist = [node]
+    while worklist:
+        member = worklist.pop()
+        cone.members[_member_label(member, ceiling)] = member
+        for port_label, port in member.inputs.items():
+            _resolve_input(
+                member,
+                port_label,
+                port,
+                ceiling,
+                break_out_of_context,
+                expose_defaults,
+                cone,
+                worklist,
+                seen,
+                node,
+            )
+    return cone, ceiling
+
+
+def _resolve_input(
+    member: Node,
+    port_label: str,
+    port: InputPort,
+    ceiling: Node,
+    break_out: bool,
+    expose_defaults: bool,
+    cone: _Cone,
+    worklist: list[Node],
+    seen: set[str],
+    pulled: Node,
+) -> None:
+    if port.has_default and not expose_defaults:
+        return
+    graph = member.owner
+    if graph is None:
+        _require(member, port_label, port, ceiling, cone)
+        return
+    if not _is_traceable(graph):
+        # `graph` is a flow controller: its edges are prospective and may not be
+        # walked. Punching out is impossible; stopping isolates the node.
+        if break_out:
+            raise _flow_control_error(graph, pulled)
+        _require(member, port_label, port, ceiling, cone)
+        return
+    edge = _incoming_edge(graph, member.label, port_label)
+    if edge is None:
+        _require(member, port_label, port, ceiling, cone)
+        return
+    source = edge.source
+    member_label = _member_label(member, ceiling)
+    if isinstance(source, fr.schemas.SourceHandle):
+        dep = graph.nodes[source.node]
+        _add_dependency(
+            dep, source.port, member_label, port_label, ceiling, cone, worklist, seen
+        )
+    else:  # fr.schemas.InputSource
+        _resolve_boundary(
+            graph,
+            source.port,
+            member_label,
+            port_label,
+            port,
+            ceiling,
+            break_out,
+            cone,
+            worklist,
+            seen,
+            pulled,
+        )
+
+
+def pulled_workflow(
+    node: Node, break_out_of_context: bool = False, expose_defaults: bool = False, /
+) -> workflow.Workflow:
+    cone, _ = _build_cone(node, break_out_of_context, expose_defaults)
+    wf = workflow.Workflow(f"pulled_{node.label}")
+    for label, member in cone.members.items():
+        wf.add_node(constructors.node(member.recipe, label))
+    if cone.internal_edges:
+        wf.add_edge(*cone.internal_edges, type_validate=False)
+    for key, (hint, metadata) in cone.input_specs.items():
+        wf.create_input(key, type_hint=hint, type_metadata=metadata)
+    if cone.input_edges:
+        wf.add_edge(*cone.input_edges, type_validate=False)
+    for port_label, out_port in node.outputs.items():
+        wf.create_output(
+            port_label,
+            type_hint=out_port.type_hint,
+            type_metadata=out_port.type_metadata,
+        )
+        wf.add_edge(
+            EdgeTuple(
+                fr.schemas.SourceHandle(node=cone.pulled_label, port=port_label),
+                fr.schemas.OutputTarget(port=port_label),
+            ),
+            type_validate=False,
+        )
+    return wf
+
+
+def pulled_inputs(
+    node: Node, break_out_of_context: bool = False, expose_defaults: bool = False, /
+):
+    return pulled_workflow(node, break_out_of_context, expose_defaults).inputs
+
+
+def pull(
+    node: Node,
+    break_out_of_context: bool = False,
+    expose_defaults: bool = False,
+    config: execution.RunConfig | None = None,
+    /,
+    **input_kwargs: object,
+) -> execution.Run:
+    wf = pulled_workflow(node, break_out_of_context, expose_defaults)
+    needed = set(wf.inputs)
+    provided = set(input_kwargs)
+    if unknown := provided - needed:
+        raise ValueError(
+            f"Unexpected pull input(s) {sorted(unknown)} for {node.lexical_path!r}. "
+            f"Valid keys are {sorted(needed)}; inspect them with `pulled_inputs`."
+        )
+    if missing := needed - provided:
+        raise ValueError(
+            f"Missing required pull input(s) {sorted(missing)} for "
+            f"{node.lexical_path!r}. Required keys are {sorted(needed)}; inspect them "
+            f"with `pulled_inputs`."
+        )
+    return wf.run(config, **input_kwargs)

--- a/pyiron_workflow/_wfms/pull.py
+++ b/pyiron_workflow/_wfms/pull.py
@@ -317,9 +317,9 @@ def pulled_inputs(
 
 def pull(
     node: Node,
+    config: execution.RunConfig | None = None,
     break_out_of_context: bool = False,
     expose_defaults: bool = False,
-    config: execution.RunConfig | None = None,
     /,
     **input_kwargs: object,
 ) -> execution.Run:

--- a/pyiron_workflow/_wfms/pull.py
+++ b/pyiron_workflow/_wfms/pull.py
@@ -156,22 +156,10 @@ def _resolve_boundary(
             ceiling_port.type_metadata,
         )
         return
-    if parent is None or not _is_traceable(parent):
-        if parent is not None:
-            raise _flow_control_error(parent, pulled)
-        # `graph`'s boundary port is unfed at the parent level: required input,
-        # keyed by the deep consumer.
-        _add_input(  # pragma: no cover  -- only reachable if parent is None (unreachable)
-            cone,
-            f"{consumer_label}__{consumer_port}",
-            consumer_label,
-            consumer_port,
-            consumer_port_obj.type_hint,
-            consumer_port_obj.type_metadata,
-        )
-        return  # pragma: no cover
-    # else _is_traceable(parent) and parent: ImmutableDag | MutableDag
-    # TODO: structure the function better so that the inspectors can just see this
+
+    if not _is_traceable(parent):
+        raise _flow_control_error(parent, pulled)
+
     edge = _incoming_edge(parent, graph.label, boundary_port)
     if edge is None:
         _add_input(

--- a/pyiron_workflow/_wfms/pull.py
+++ b/pyiron_workflow/_wfms/pull.py
@@ -140,7 +140,11 @@ def _resolve_boundary(
     seen: set[str],
     pulled: Node,
 ) -> None:
-    if graph is ceiling:
+    if (
+        graph is ceiling
+        or graph.owner is None
+        # These are _equivalent conditions_ -- if the owner is None, this is the ceiling
+    ):
         ceiling_port = graph.inputs[boundary_port]
         _add_input(
             cone,

--- a/pyiron_workflow/_wfms/pull.py
+++ b/pyiron_workflow/_wfms/pull.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import flowrep as fr
 import typing_extensions
 
-from pyiron_workflow._wfms import constructors, execution, workflow
+from pyiron_workflow._wfms import execution, workflow
 from pyiron_workflow._wfms.datatypes import (
     EdgeList,
     EdgeTuple,
@@ -286,7 +286,7 @@ def pulled_workflow(
     cone, _ = _build_cone(node, break_out_of_context, expose_defaults)
     wf = workflow.Workflow(f"pulled_{node.label}")
     for label, member in cone.members.items():
-        wf.add_node(constructors.node(member.recipe, label))
+        wf.add_node(member.copy(label))
     if cone.internal_edges:
         wf.add_edge(*cone.internal_edges, type_validate=False)
     for key, (hint, metadata) in cone.input_specs.items():

--- a/pyiron_workflow/_wfms/workflow.py
+++ b/pyiron_workflow/_wfms/workflow.py
@@ -5,7 +5,7 @@ import dataclasses
 import functools
 import types
 from collections.abc import Callable, MutableMapping
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Self, cast
 
 import flowrep as fr
 import semantikon
@@ -186,6 +186,15 @@ class Workflow(MutableDag):
         self.undo_stack = collections.deque(maxlen=undo_limit)
         self.redo_stack = collections.deque(maxlen=undo_limit)
         self.connect_input(*positional_connections, **keyword_connections)
+
+    def copy(
+        self, new_label: fr.schemas.Label | None = None, _copy_to: Self | None = None
+    ) -> Workflow:
+        node_copy = _copy_to or self.from_recipe(new_label or self.label, self.recipe)
+        self._copy_data(self, node_copy)
+        for label, child in self.nodes.items():
+            child.copy(_copy_to=node_copy.nodes[label])
+        return node_copy
 
     def __setattr__(self, name: str, value: object) -> None:
         """Syntactic sugar for adding a fresh node to the graph.

--- a/tests/unit/_wfms/test_datatypes.py
+++ b/tests/unit/_wfms/test_datatypes.py
@@ -255,6 +255,66 @@ class TestNodeGetState(unittest.TestCase):
             )
 
 
+class TestNodeCopy(unittest.TestCase):
+    def test_atomic_copy_carries_executor_drops_parentage(self):
+        n = _fixtures.atomic_add_node()
+        exe: execution.ExecutorInstructions = (
+            futures.ThreadPoolExecutor,
+            (),
+            {"max_workers": 1},
+        )
+        n.executor = exe
+        n.last_run = "fake history"
+
+        copy = n.copy()
+
+        self.assertIsNot(copy, n, "copy must be a fresh object")
+        self.assertIs(copy.executor, exe, "executor must ride along")
+        self.assertIsNone(copy.owner, "parentage must not be carried")
+        self.assertIsNone(copy.last_run, "history must not be carried")
+
+    def test_nested_macro_copy_carries_executors_and_reparents(self):
+        nm = _fixtures.nested_macro_node()
+        child = nm.nodes["macro_0"]
+        grandchild = child.nodes["add_0"]
+
+        top_exe: execution.ExecutorInstructions = (
+            futures.ThreadPoolExecutor,
+            (),
+            {"max_workers": 1},
+        )
+        child_exe: execution.ExecutorInstructions = (
+            futures.ThreadPoolExecutor,
+            (),
+            {"max_workers": 2},
+        )
+        grandchild_exe: execution.ExecutorInstructions = (
+            futures.ThreadPoolExecutor,
+            (),
+            {"max_workers": 3},
+        )
+        nm.executor = top_exe
+        child.executor = child_exe
+        grandchild.executor = grandchild_exe
+
+        copy = nm.copy()
+        copied_child = copy.nodes["macro_0"]
+        copied_grandchild = copied_child.nodes["add_0"]
+
+        # Executors ride at every depth.
+        self.assertIs(copy.executor, top_exe)
+        self.assertIs(copied_child.executor, child_exe)
+        self.assertIs(copied_grandchild.executor, grandchild_exe)
+
+        # Copies are fresh objects re-parented into the new tree.
+        self.assertIsNot(copied_child, child)
+        self.assertIsNone(copy.owner)
+        self.assertIs(copied_child.owner, copy)
+
+        # The original tree is untouched.
+        self.assertIs(nm.nodes["macro_0"].owner, nm)
+
+
 class TestConnectAtInit(unittest.TestCase):
     """`StaticNode` / `StaticGraph` connection sugar at construction.
 

--- a/tests/unit/_wfms/test_pull.py
+++ b/tests/unit/_wfms/test_pull.py
@@ -33,7 +33,7 @@ class TestPullUnparented(unittest.TestCase):
     def test_expose_defaults_surfaces_them_as_required(self):
         m = _fixtures.multiply_with_defaults_node()
         self.assertEqual(set(m.pulled_inputs(False, True).keys()), {"x", "y"})
-        run = m.pull(False, True, x=4, y=5)
+        run = m.pull(None, False, True, x=4, y=5)
         self.assertEqual(run.outputs["output_0"].value, 20)
 
     def test_unknown_kwarg_raises_pointing_at_pulled_inputs(self):
@@ -50,7 +50,7 @@ class TestPullUnparented(unittest.TestCase):
 
     def test_free_function_matches_method(self):
         n = _fixtures.atomic_add_node()
-        run = pull.pull(n, False, False, None, x=1, y=1)
+        run = pull.pull(n, None, False, False, x=1, y=1)
         self.assertEqual(run.outputs["output_0"].value, 2)
 
 
@@ -145,7 +145,7 @@ class TestPullNestedPunchingAndStopping(unittest.TestCase):
 
     def test_punching_runs_the_full_cone(self):
         # root add_0 (z) = 1+2 = 3; inner add_0 = 1+2 = 3; inner sub = 3 - 3 = 0
-        run = self.inner_sub.pull(True, False, None, x=1, y=2)
+        run = self.inner_sub.pull(None, True, False, x=1, y=2)
         self.assertEqual(run.outputs["output_0"].value, 0)
 
 
@@ -193,7 +193,7 @@ class TestPullFlowControl(unittest.TestCase):
         fe = _fixtures.foreach_node()
         body = fe.nodes["body"]
         self.assertEqual(set(body.pulled_inputs().keys()), {"body__x", "body__y"})
-        run = body.pull(False, False, None, body__x=2, body__y=3)
+        run = body.pull(None, False, False, body__x=2, body__y=3)
         self.assertEqual(run.outputs["output_0"].value, 5)
 
     def test_macro_inside_controller_punch_fails_stop_succeeds(self):
@@ -201,7 +201,7 @@ class TestPullFlowControl(unittest.TestCase):
         inner_macro = fe.nodes["body"]
         with self.assertRaises(ValueError):
             inner_macro.pulled_workflow(True)
-        run = inner_macro.pull(False, False, None, body__x=1, body__y=2, body__z=1)
+        run = inner_macro.pull(None, False, False, body__x=1, body__y=2, body__z=1)
         self.assertEqual(run.outputs["a"].value, 3)  # add(1, 2)
         self.assertEqual(run.outputs["s"].value, 2)  # 3 - 1
 
@@ -276,9 +276,9 @@ class TestPullExposeDefaultsNestedScoping(unittest.TestCase):
         self.assertEqual(set(child.pulled_inputs(True, True).keys()), scoped)
         # The scoped ports wire correctly and feed the isolated child.
         run = child.pull(
-            True,
-            True,
             None,
+            True,
+            True,
             **{
                 "inner__multiply_with_defaults_0__x": 3,
                 "inner__multiply_with_defaults_0__y": 4,
@@ -291,7 +291,7 @@ class TestPullPublicSurface(unittest.TestCase):
     def test_exposed_via_tools(self):
         n = _fixtures.atomic_add_node()
         self.assertEqual(
-            api.tools.pull(n, False, False, None, x=1, y=4).outputs["output_0"].value, 5
+            api.tools.pull(n, None, False, False, x=1, y=4).outputs["output_0"].value, 5
         )
         self.assertEqual(set(api.tools.pulled_inputs(n).keys()), {"x", "y"})
         self.assertIsNotNone(api.tools.pulled_workflow(n))

--- a/tests/unit/_wfms/test_pull.py
+++ b/tests/unit/_wfms/test_pull.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import unittest
+
+import flowrep as fr
+
+from pyiron_workflow._wfms import api, flowcontrollers, pull
+from pyiron_workflow._wfms.datatypes import EdgeTuple
+from tests.unit._wfms import _fixtures
+
+
+class TestPullUnparented(unittest.TestCase):
+    def test_runs_and_returns_node_outputs(self):
+        n = _fixtures.atomic_add_node()  # add(x, y), unparented
+        run = n.pull(x=2, y=3)
+        self.assertEqual(run.outputs["output_0"].value, 5)
+
+    def test_required_input_keys_are_bare_port_names(self):
+        n = _fixtures.atomic_add_node()
+        self.assertEqual(set(n.pulled_inputs().keys()), {"x", "y"})
+
+    def test_pulled_workflow_contains_just_the_node(self):
+        n = _fixtures.atomic_add_node("addy")
+        wf = n.pulled_workflow()
+        self.assertEqual(set(wf.nodes.keys()), {"addy"})
+
+    def test_defaults_ride_and_are_not_surfaced(self):
+        m = _fixtures.multiply_with_defaults_node()  # x=1, y=2
+        run = m.pull()
+        self.assertEqual(run.outputs["output_0"].value, 2)
+        self.assertEqual(set(m.pulled_inputs().keys()), set())
+
+    def test_expose_defaults_surfaces_them_as_required(self):
+        m = _fixtures.multiply_with_defaults_node()
+        self.assertEqual(set(m.pulled_inputs(False, True).keys()), {"x", "y"})
+        run = m.pull(False, True, x=4, y=5)
+        self.assertEqual(run.outputs["output_0"].value, 20)
+
+    def test_unknown_kwarg_raises_pointing_at_pulled_inputs(self):
+        n = _fixtures.atomic_add_node()
+        with self.assertRaises(ValueError) as ctx:
+            n.pull(x=2, y=3, nonsense=1)
+        self.assertIn("pulled_inputs", str(ctx.exception))
+
+    def test_missing_required_input_raises(self):
+        n = _fixtures.atomic_add_node()
+        with self.assertRaises(ValueError) as ctx:
+            n.pull(x=2)  # missing y
+        self.assertIn("y", str(ctx.exception))
+
+    def test_free_function_matches_method(self):
+        n = _fixtures.atomic_add_node()
+        run = pull.pull(n, False, False, None, x=1, y=1)
+        self.assertEqual(run.outputs["output_0"].value, 2)
+
+
+def _diamond_workflow():
+    """add_0 -> sub_0; mul_0 is a parallel, unrelated branch."""
+    return _fixtures.build_workflow(
+        inputs=["x", "y", "z"],
+        outputs=["out", "side"],
+        node_specs={
+            "add_0": _fixtures.atomic_add_node,
+            "sub_0": _fixtures.atomic_sub_node,
+            "mul_0": _fixtures.multiply_with_defaults_node,
+        },
+        edges=[
+            EdgeTuple(
+                fr.schemas.InputSource(port="x"),
+                fr.schemas.TargetHandle(node="add_0", port="x"),
+            ),
+            EdgeTuple(
+                fr.schemas.InputSource(port="y"),
+                fr.schemas.TargetHandle(node="add_0", port="y"),
+            ),
+            EdgeTuple(
+                fr.schemas.SourceHandle(node="add_0", port="output_0"),
+                fr.schemas.TargetHandle(node="sub_0", port="x"),
+            ),
+            EdgeTuple(
+                fr.schemas.InputSource(port="z"),
+                fr.schemas.TargetHandle(node="sub_0", port="y"),
+            ),
+            EdgeTuple(
+                fr.schemas.SourceHandle(node="sub_0", port="output_0"),
+                fr.schemas.OutputTarget(port="out"),
+            ),
+            EdgeTuple(
+                fr.schemas.InputSource(port="x"),
+                fr.schemas.TargetHandle(node="mul_0", port="x"),
+            ),
+            EdgeTuple(
+                fr.schemas.SourceHandle(node="mul_0", port="output_0"),
+                fr.schemas.OutputTarget(port="side"),
+            ),
+        ],
+    )
+
+
+class TestPullWorkflowStopping(unittest.TestCase):
+    def test_cone_excludes_unrelated_branch(self):
+        wf = _diamond_workflow()
+        pw = wf.nodes["sub_0"].pulled_workflow()
+        self.assertEqual(set(pw.nodes.keys()), {"add_0", "sub_0"})
+
+    def test_keys_mix_peer_terminal_and_ceiling_terminal(self):
+        wf = _diamond_workflow()
+        # sub_0.x <- add_0 (peer); sub_0.y <- InputSource z (terminal); add_0.x/y <- terminals x/y
+        self.assertEqual(set(wf.nodes["sub_0"].pulled_inputs().keys()), {"x", "y", "z"})
+
+    def test_runs_the_cone(self):
+        wf = _diamond_workflow()
+        run = wf.nodes["sub_0"].pull(x=1, y=2, z=1)  # add_0=3, sub_0=3-1=2
+        self.assertEqual(run.outputs["output_0"].value, 2)
+
+    def test_macro_child_stopping(self):
+        macro = _fixtures.macro_node()  # a=add(x,y), s=sub(a,z)
+        run = macro.nodes["sub_0"].pull(x=1, y=2, z=1)
+        self.assertEqual(run.outputs["output_0"].value, 2)
+        self.assertEqual(
+            set(macro.nodes["sub_0"].pulled_inputs().keys()), {"x", "y", "z"}
+        )
+
+
+class TestPullNestedPunchingAndStopping(unittest.TestCase):
+    def setUp(self):
+        # nested_macro(x, y): z = add(x, y); a, s = macro(x, y, z); return a, s
+        # inner macro: a = add(x, y); s = sub(a, z)
+        self.nm = _fixtures.nested_macro_node()
+        self.inner_sub = self.nm.nodes["macro_0"].nodes["sub_0"]
+
+    def test_stopping_uses_inner_ceiling_keys(self):
+        # ceiling = inner macro: sub_0.x <- inner add_0 (peer), sub_0.y <- z, add_0.x/y <- x/y
+        self.assertEqual(set(self.inner_sub.pulled_inputs().keys()), {"x", "y", "z"})
+        run = self.inner_sub.pull(x=1, y=2, z=5)  # add_0=3, sub=3-5=-2
+        self.assertEqual(run.outputs["output_0"].value, -2)
+
+    def test_punching_uses_root_keys_and_flat_labels(self):
+        keys = set(self.inner_sub.pulled_inputs(True).keys())
+        self.assertEqual(keys, {"x", "y"})  # everything bottoms out at root ports
+        pw = self.inner_sub.pulled_workflow(True)
+        self.assertEqual(
+            set(pw.nodes.keys()), {"add_0", "macro_0__add_0", "macro_0__sub_0"}
+        )
+
+    def test_punching_runs_the_full_cone(self):
+        # root add_0 (z) = 1+2 = 3; inner add_0 = 1+2 = 3; inner sub = 3 - 3 = 0
+        run = self.inner_sub.pull(True, False, None, x=1, y=2)
+        self.assertEqual(run.outputs["output_0"].value, 0)
+
+
+def _foreach_with_macro_body():
+    """ForEach whose body is the `macro` fixture: a = add(x, y); s = sub(a, z)."""
+    body = fr.schemas.LabeledRecipe(label="body", node=_fixtures.macro.flowrep_recipe)
+    recipe = fr.schemas.ForEachRecipe(
+        inputs=["xs", "y", "z"],
+        outputs=["sums"],
+        body_node=body,
+        input_edges={
+            fr.schemas.TargetHandle(node="body", port="x"): fr.schemas.InputSource(
+                port="xs"
+            ),
+            fr.schemas.TargetHandle(node="body", port="y"): fr.schemas.InputSource(
+                port="y"
+            ),
+            fr.schemas.TargetHandle(node="body", port="z"): fr.schemas.InputSource(
+                port="z"
+            ),
+        },
+        output_edges={
+            fr.schemas.OutputTarget(port="sums"): fr.schemas.SourceHandle(
+                node="body", port="s"
+            ),
+        },
+        nested_ports=["x"],
+        zipped_ports=[],
+    )
+
+    return flowcontrollers.ForEach("fe", recipe)
+
+
+class TestPullFlowControl(unittest.TestCase):
+    def test_punching_out_of_a_controller_raises(self):
+        fe = _fixtures.foreach_node()  # body = add(x, y)
+        body = fe.nodes["body"]
+        with self.assertRaises(ValueError) as ctx:
+            body.pulled_workflow(True)
+        msg = str(ctx.exception)
+        self.assertIn("flow controller", msg)
+        self.assertIn("ForEach", msg)
+
+    def test_stopping_inside_a_controller_isolates_the_node(self):
+        fe = _fixtures.foreach_node()
+        body = fe.nodes["body"]
+        self.assertEqual(set(body.pulled_inputs().keys()), {"body__x", "body__y"})
+        run = body.pull(False, False, None, body__x=2, body__y=3)
+        self.assertEqual(run.outputs["output_0"].value, 5)
+
+    def test_macro_inside_controller_punch_fails_stop_succeeds(self):
+        fe = _foreach_with_macro_body()
+        inner_macro = fe.nodes["body"]
+        with self.assertRaises(ValueError):
+            inner_macro.pulled_workflow(True)
+        run = inner_macro.pull(False, False, None, body__x=1, body__y=2, body__z=1)
+        self.assertEqual(run.outputs["a"].value, 3)  # add(1, 2)
+        self.assertEqual(run.outputs["s"].value, 2)  # 3 - 1
+
+
+class TestPullCoverageEdgeCases(unittest.TestCase):
+    """Focused tests that close specific line-coverage gaps in pull.py."""
+
+    def test_unconnected_nonfed_port_in_workflow(self):
+        # Node in a Workflow where one non-default input has no edge:
+        # _incoming_edge returns None (line 67) and _resolve_input takes the
+        # edge-is-None branch (lines 253-254).
+        wf = _fixtures.build_workflow(
+            inputs=["x"],
+            node_specs={"add_0": _fixtures.atomic_add_node},
+            edges=[
+                EdgeTuple(
+                    fr.schemas.InputSource(port="x"),
+                    fr.schemas.TargetHandle(node="add_0", port="x"),
+                ),
+                # add_0.y is intentionally left unconnected
+            ],
+        )
+        keys = set(wf.nodes["add_0"].pulled_inputs().keys())
+        # x routed via ceiling InputSource port; y has no edge -> bare "add_0__y" via _require
+        self.assertEqual(keys, {"x", "add_0__y"})
+
+    def test_punching_through_macro_with_unconnected_boundary(self):
+        # Punching from a grandchild node through a Macro whose boundary ports
+        # are NOT connected in the parent Workflow: _resolve_boundary takes the
+        # edge-is-None branch (lines 169-177).
+        wf = _fixtures.build_workflow(
+            node_specs={"inner": _fixtures.macro_node},
+        )
+        inner_sub = wf.nodes["inner"].nodes["sub_0"]
+        keys = set(inner_sub.pulled_inputs(True).keys())
+        # All three of inner's boundary ports are unconnected in wf:
+        self.assertEqual(
+            keys, {"inner__sub_0__y", "inner__add_0__x", "inner__add_0__y"}
+        )
+
+    def test_punching_from_node_inside_macro_inside_foreach_raises(self):
+        # Punching (break_out=True) from a node inside a Macro that is itself
+        # inside a ForEach: _resolve_boundary hits the flow-controller barrier
+        # (lines 154-155) and raises.
+        fe = _foreach_with_macro_body()
+        inner_sub = fe.nodes["body"].nodes["sub_0"]
+        with self.assertRaises(ValueError) as ctx:
+            inner_sub.pulled_workflow(True)
+        self.assertIn("flow controller", str(ctx.exception))
+
+
+class TestPullPublicSurface(unittest.TestCase):
+    def test_exposed_via_tools(self):
+        n = _fixtures.atomic_add_node()
+        self.assertEqual(
+            api.tools.pull(n, False, False, None, x=1, y=4).outputs["output_0"].value, 5
+        )
+        self.assertEqual(set(api.tools.pulled_inputs(n).keys()), {"x", "y"})
+        self.assertIsNotNone(api.tools.pulled_workflow(n))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/_wfms/test_pull.py
+++ b/tests/unit/_wfms/test_pull.py
@@ -253,6 +253,40 @@ class TestPullCoverageEdgeCases(unittest.TestCase):
         self.assertIn("flow controller", str(ctx.exception))
 
 
+class TestPullExposeDefaultsNestedScoping(unittest.TestCase):
+    """expose_defaults must surface unconnected *defaulted* ports on nested
+    children with labels scoped by the child's path from the ceiling."""
+
+    def _nested_defaulted_child(self):
+        # Workflow root -> macro "inner" (container) -> "multiply_with_defaults_0",
+        # whose x/y inputs are defaulted and left unconnected inside the macro.
+        wf = _fixtures.build_workflow(node_specs={"inner": _fixtures.container_node})
+        return wf.nodes["inner"].nodes["multiply_with_defaults_0"]
+
+    def test_exposed_nested_defaults_get_scoped_labels_and_run(self):
+        child = self._nested_defaulted_child()
+        # Riding the defaults (expose_defaults=False), nothing is surfaced.
+        self.assertEqual(set(child.pulled_inputs(True).keys()), set())
+        # Forcing exposure surfaces both ports, scoped by the child's path from
+        # the root ceiling -- not bare "x"/"y".
+        scoped = {
+            "inner__multiply_with_defaults_0__x",
+            "inner__multiply_with_defaults_0__y",
+        }
+        self.assertEqual(set(child.pulled_inputs(True, True).keys()), scoped)
+        # The scoped ports wire correctly and feed the isolated child.
+        run = child.pull(
+            True,
+            True,
+            None,
+            **{
+                "inner__multiply_with_defaults_0__x": 3,
+                "inner__multiply_with_defaults_0__y": 4,
+            },
+        )
+        self.assertEqual(run.outputs["output_0"].value, 12)
+
+
 class TestPullPublicSurface(unittest.TestCase):
     def test_exposed_via_tools(self):
         n = _fixtures.atomic_add_node()

--- a/tests/unit/_wfms/test_pull.py
+++ b/tests/unit/_wfms/test_pull.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import unittest
+from concurrent import futures
 
 import flowrep as fr
 
-from pyiron_workflow._wfms import api, flowcontrollers, pull
+from pyiron_workflow._wfms import api, execution, flowcontrollers, pull
 from pyiron_workflow._wfms.datatypes import EdgeTuple
 from tests.unit._wfms import _fixtures
 
@@ -285,6 +286,21 @@ class TestPullExposeDefaultsNestedScoping(unittest.TestCase):
             },
         )
         self.assertEqual(run.outputs["output_0"].value, 12)
+
+
+class TestPullCopiesExecutors(unittest.TestCase):
+    def test_pulled_workflow_carries_member_executor(self):
+        n = _fixtures.atomic_add_node("addy")
+        exe: execution.ExecutorInstructions = (
+            futures.ThreadPoolExecutor,
+            (),
+            {"max_workers": 1},
+        )
+        n.executor = exe
+
+        wf = n.pulled_workflow()
+
+        self.assertIs(wf.nodes["addy"].executor, exe)
 
 
 class TestPullPublicSurface(unittest.TestCase):

--- a/tests/unit/_wfms/test_workflow.py
+++ b/tests/unit/_wfms/test_workflow.py
@@ -5,6 +5,7 @@ import contextlib
 import dataclasses
 import pickle
 import unittest
+from concurrent import futures
 
 import flowrep as fr
 import semantikon
@@ -2563,6 +2564,44 @@ class TestWorkflowData(unittest.TestCase):
         self.assertEqual(
             wf.outputs.m2cm.type_metadata, semantikon.TypeMetadata(units="centimeters")
         )
+
+
+class TestWorkflowCopy(unittest.TestCase):
+    def test_copy_carries_executors_and_drops_parentage(self):
+        # A recipe-valid (fully wired) workflow -- Workflow.copy routes through
+        # `self.recipe`, which validates that every target has a source/default.
+        wf = _fixtures.build_workflow(
+            inputs=["x", "y", "z"],
+            outputs=["a", "s"],
+            node_specs={
+                "add_0": _fixtures.atomic_add_node,
+                "sub_0": _fixtures.atomic_sub_node,
+            },
+            edges=_fixtures._MACRO_WF_EDGES,
+        )
+        child = wf.nodes["add_0"]
+        wf_exe: execution.ExecutorInstructions = (
+            futures.ThreadPoolExecutor,
+            (),
+            {"max_workers": 1},
+        )
+        child_exe: execution.ExecutorInstructions = (
+            futures.ThreadPoolExecutor,
+            (),
+            {"max_workers": 2},
+        )
+        wf.executor = wf_exe
+        child.executor = child_exe
+
+        copy = wf.copy()
+        copied_child = copy.nodes["add_0"]
+
+        self.assertIsNot(copy, wf)
+        self.assertIs(copy.executor, wf_exe)
+        self.assertIs(copied_child.executor, child_exe)
+        self.assertIsNone(copy.owner)
+        self.assertIs(copied_child.owner, copy)
+        self.assertIs(wf.nodes["add_0"].owner, wf)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Introduces a "pull" mechanism for running subsets of a graph. The heart is a `.pulled_workflow` method on all nodes which pulls out a cone-shaped flat graph for its dependencies. Related `.pulled_inputs` lets you look at the terminal inputs for this graph, and `.pull` lets you create it and run it all in one fell swoop. All three methods take a `break_out_of_context: bool` flag to determine if you should stop building the cone when you hit a supergraph barrier, or if you should punch through and build the new conical graph for the entire graph context regardless of how deeply nested the pulled node is, and a `expose_defaults: bool` flag to say whether this new graph should force-expose inputs with a default value that are not presently connected to anything. 

It is not meaningful to flatten out or punch edges through a flow control here, so if you hit one of those it just fails cleanly. You _can_ still pull from inside a flow-controll, just only with `break_out_of_context=False`.

In order to make sure that pwf-level `Node` metadata comes along to the new graph, I also introduce a new `Node.copy` method, which lets you get a new instance of the same node that is intentionally stripped of its context (no owner or pending edges) and history (no `last_run`) but keeps its WfMS "state" (currently just the `executor`, but now we have a spot to group more state later).