### PR TITLE
Reformat `Run.outputs`

### DIFF
--- a/pyiron_workflow/_wfms/execution.py
+++ b/pyiron_workflow/_wfms/execution.py
@@ -13,7 +13,7 @@ from concurrent import futures
 from typing import TYPE_CHECKING, Any, Generic, NamedTuple, TypeAlias, TypeVar
 
 import flowrep as fr
-from pyiron_snippets import import_alarm
+from pyiron_snippets import dotdict, import_alarm
 
 from pyiron_workflow._wfms import lexical
 
@@ -125,7 +125,9 @@ class Run(Generic[ResultType]):
 
     @property
     def outputs(self):
-        return self.result.output_ports
+        return dotdict.DotDict(
+            {k: v.value for k, v in self.result.output_ports.items()}
+        )
 
     @property
     def duration(self) -> datetime.timedelta | None:

--- a/tests/cluster/_wfms/slurm_test.py
+++ b/tests/cluster/_wfms/slurm_test.py
@@ -117,7 +117,7 @@ def interruption():
         dt > 0.5 * T_SLEEP
     ), f"Expected to need to wait for the job to finish, but got a small dt -- {dt}"
     assert (
-        out.outputs["n3"].value == T_SLEEP
+        out.outputs.n3 == T_SLEEP
     ), f"Sanity check that the workflow returned T_SLEEP, but got {out.outputs['n3'].value}"
 
 
@@ -135,7 +135,7 @@ def discovery():
         dt < 0.1 * T_SLEEP
     ), f"Expected to get a quick cache hit, but got a large -- {dt}"
     assert (
-        out.outputs["n3"].value == T_SLEEP
+        out.outputs.n3 == T_SLEEP
     ), f"Sanity check that the workflow returned T_SLEEP, but got {out.outputs['n3'].value}"
 
 

--- a/tests/integration/_wfms/test_caching.py
+++ b/tests/integration/_wfms/test_caching.py
@@ -45,7 +45,7 @@ class TestFlecheCaching(unittest.TestCase):
             pwf.RunConfig(run_dir=self.root / "run", fleche_cache=cache),
             t=self.T,
         )
-        return out.duration.total_seconds(), out.outputs["s"].value
+        return out.duration.total_seconds(), out.outputs.s
 
     def _assert_speedup(self, place_executors, replace_executors) -> None:
         cache = integration_fixtures.make_cache(self.root)

--- a/tests/integration/_wfms/test_compatibility.py
+++ b/tests/integration/_wfms/test_compatibility.py
@@ -39,9 +39,9 @@ class TestOutOfProcess(unittest.TestCase):
                 with futures.ProcessPoolExecutor() as exe:
                     node.executor = exe
                     result = node.run(x=-1, y=43)
-                self.assertEqual(result.outputs["total"].value, 42)
+                self.assertEqual(result.outputs.total, 42)
                 self.assertNotEqual(
-                    result.outputs["pid"].value,
+                    result.outputs.pid,
                     os.getpid(),
                     msg="The node should have executed in a separate process.",
                 )

--- a/tests/integration/_wfms/test_executors.py
+++ b/tests/integration/_wfms/test_executors.py
@@ -96,7 +96,7 @@ class TestExecutors(unittest.TestCase):
     def test_local(self):
         out = self._run()
         self.assertEqual(
-            out.outputs["pids"].value,
+            out.outputs.pids,
             [os.getpid()] * self.n,
             msg="Running locally all should have the same (main process) PID",
         )
@@ -108,7 +108,7 @@ class TestExecutors(unittest.TestCase):
                 exe
             )
             out = self._run()
-        else_ids = list(out.outputs["pids"].value)
+        else_ids = list(out.outputs.pids)
         if_id = else_ids.pop(self.expected_id)
         self.assertEqual(
             else_ids,
@@ -133,7 +133,7 @@ class TestExecutors(unittest.TestCase):
             kwargs={"max_workers": self.n},
         )
         out = self._run()
-        else_ids = list(out.outputs["pids"].value)
+        else_ids = list(out.outputs.pids)
         if_id = else_ids.pop(self.expected_id)
         self.assertEqual(
             if_id,
@@ -160,7 +160,7 @@ class TestExecutors(unittest.TestCase):
                 constructor=futures.ProcessPoolExecutor, kwargs={"max_workers": self.n}
             )
             out = self._run()
-        ids = out.outputs["pids"].value
+        ids = out.outputs.pids
         else_ids = list(ids)
         if_id = else_ids.pop(self.expected_id)
         self.assertNotIn(
@@ -196,7 +196,7 @@ class TestDagParallelism(unittest.TestCase):
         self.assertLess(diff_to_max, diff_to_tot)
 
         self.assertListEqual(
-            out.outputs["slept_for"].value,
+            out.outputs.slept_for,
             self.times,
             msg="Regardless of the fact the last entry finished first, the for-loop"
             "should be re-aggregating the results according to the original error.",
@@ -254,7 +254,7 @@ class TestCachingExecutors(unittest.TestCase):
                 t0 = time.perf_counter()
                 out_cold = node.run(cfg, t=self.T)
                 dt_first = time.perf_counter() - t0
-                self.assertEqual(out_cold.outputs["s"].value, self.T)
+                self.assertEqual(out_cold.outputs.s, self.T)
                 self._assert_cached(run_dir, node.sleepy_0.lexical_path)
 
                 # Fresh node instance + same run_dir -> reconnect to the cache
@@ -262,7 +262,7 @@ class TestCachingExecutors(unittest.TestCase):
                 t1 = time.perf_counter()
                 out_warm = warm.run(cfg, t=self.T)
                 dt_second = time.perf_counter() - t1
-                self.assertEqual(out_warm.outputs["s"].value, self.T)
+                self.assertEqual(out_warm.outputs.s, self.T)
                 self.assertLess(dt_second, dt_first / 2)
                 self.assertLess(dt_second, 1.0)
 
@@ -271,7 +271,7 @@ class TestCachingExecutors(unittest.TestCase):
                 out_stale = warm.run(cfg, t=self.T * 99)
                 dt_third = time.perf_counter() - t2
                 self.assertEqual(
-                    out_stale.outputs["s"].value,
+                    out_stale.outputs.s,
                     self.T,
                     msg="Cache key is the lexical path only; stale value expected",
                 )
@@ -280,13 +280,13 @@ class TestCachingExecutors(unittest.TestCase):
     def test_fresh_run_dir_recomputes(self):
         node_a = self._fresh_node(wfms.tools._CacheTestExecutor)
         out_a = node_a.run(wfms.RunConfig(run_dir=self.run_root / "a"), t=self.T)
-        self.assertEqual(out_a.outputs["s"].value, self.T)
+        self.assertEqual(out_a.outputs.s, self.T)
 
         # A different run_dir must miss the cache and recompute the new value
         node_b = self._fresh_node(wfms.tools._CacheTestExecutor)
         out_b = node_b.run(wfms.RunConfig(run_dir=self.run_root / "b"), t=self.T * 2)
         self.assertEqual(
-            out_b.outputs["s"].value,
+            out_b.outputs.s,
             self.T * 2,
             msg="A fresh run_dir must not return a stale cache hit",
         )
@@ -300,7 +300,7 @@ class TestCachingExecutors(unittest.TestCase):
             t0 = time.perf_counter()
             out_cold = cold.run(cfg, t=self.T)
             dt_first = time.perf_counter() - t0
-        self.assertEqual(out_cold.outputs["s"].value, self.T)
+        self.assertEqual(out_cold.outputs.s, self.T)
 
         warm = wfms.node(slow_wf.flowrep_recipe)
         with wfms.tools._CacheTestExecutor() as exe:
@@ -308,7 +308,7 @@ class TestCachingExecutors(unittest.TestCase):
             t1 = time.perf_counter()
             out_warm = warm.run(cfg, t=self.T)
             dt_second = time.perf_counter() - t1
-        self.assertEqual(out_warm.outputs["s"].value, self.T)
+        self.assertEqual(out_warm.outputs.s, self.T)
         self.assertLess(dt_second, dt_first / 2)
         self.assertLess(dt_second, 1.0)
 

--- a/tests/integration/_wfms/test_failure.py
+++ b/tests/integration/_wfms/test_failure.py
@@ -167,8 +167,8 @@ class TestLinearFailure(unittest.TestCase):
         )
 
         # Steps mirror the same picture.
-        self.assertEqual(run_obj.steps[0].outputs["x"].value, 42)
-        self.assertTrue(_is_not_data(run_obj.steps[1].outputs["x"].value))
+        self.assertEqual(run_obj.steps[0].outputs.x, 42)
+        self.assertTrue(_is_not_data(run_obj.steps[1].outputs.x))
 
 
 # --------------------------------------------------------------------------- #
@@ -193,11 +193,11 @@ class TestNestedFailure(unittest.TestCase):
         # Step tree: top -> nested macro -> raise_if_5_{0,1}.
         inner_steps = run_obj.steps[0].steps
         self.assertEqual(
-            inner_steps[0].outputs["x"].value,
+            inner_steps[0].outputs.x,
             42,
             msg="Finishes running before we get to the failure",
         )
-        self.assertTrue(_is_not_data(inner_steps[1].outputs["x"].value))
+        self.assertTrue(_is_not_data(inner_steps[1].outputs.x))
 
 
 # --------------------------------------------------------------------------- #
@@ -222,21 +222,17 @@ class TestWhileFailure(unittest.TestCase):
 
         # Iteration 0 body: raise_if_5(0) -> x=0, increment(0) -> 1.
         body_0 = while_steps[1]
-        self.assertEqual(body_0.steps[0].outputs["x"].value, 0)
+        self.assertEqual(body_0.steps[0].outputs.x, 0)
 
         # Iteration 4 body: raise_if_5(4) -> x=4.
         # Counting from the end: -1 = body_5 (crashed), -2 = cond_5, -3 = body_4.
         body_4 = while_steps[-3]
-        self.assertEqual(
-            body_4.steps[0].outputs["x"].value, 4, msg="Raise if should pass"
-        )
-        self.assertEqual(
-            body_4.steps[1].outputs["output_0"].value, 5, msg="Incremented"
-        )
+        self.assertEqual(body_4.steps[0].outputs.x, 4, msg="Raise if should pass")
+        self.assertEqual(body_4.steps[1].outputs.output_0, 5, msg="Incremented")
 
         # Iteration 5 body: raise_if_5(5) crashed; output stays NOT_DATA.
         body_5 = while_steps[-1]
-        self.assertTrue(_is_not_data(body_5.steps[0].outputs["x"].value))
+        self.assertTrue(_is_not_data(body_5.steps[0].outputs.x))
 
 
 # --------------------------------------------------------------------------- #
@@ -266,9 +262,9 @@ class TestForEachFailure(unittest.TestCase):
         for_each_step = run_obj.steps[1]
         self.assertEqual(len(for_each_step.steps), 7)
         self.assertIn("scatter", for_each_step.steps[0].label)
-        self.assertEqual(for_each_step.steps[1].outputs["m"].value, 0)
-        self.assertEqual(for_each_step.steps[-2].outputs["m"].value, 4)
-        self.assertTrue(_is_not_data(for_each_step.steps[-1].outputs["m"].value))
+        self.assertEqual(for_each_step.steps[1].outputs.m, 0)
+        self.assertEqual(for_each_step.steps[-2].outputs.m, 4)
+        self.assertTrue(_is_not_data(for_each_step.steps[-1].outputs.m))
 
 
 # --------------------------------------------------------------------------- #
@@ -285,12 +281,12 @@ class TestIfFailure(unittest.TestCase):
         self.assertEqual(run_obj.status, wfms.schemas.RunStatus.FAILED)
 
         condition_step = run_obj.steps[0].steps[0]
-        self.assertEqual(condition_step.outputs["lt"].value, False)
+        self.assertEqual(condition_step.outputs.lt, False)
         self.assertEqual(condition_step.status, wfms.schemas.RunStatus.FINISHED)
 
         else_step = run_obj.steps[0].steps[1]
         self.assertEqual(else_step.status, wfms.schemas.RunStatus.FAILED)
-        self.assertTrue(_is_not_data(else_step.outputs["x"].value))
+        self.assertTrue(_is_not_data(else_step.outputs.x))
 
 
 # --------------------------------------------------------------------------- #
@@ -360,7 +356,7 @@ class TestOutOfProcessFailure(unittest.TestCase):
                 .steps[1]  # raise_if_5_0
             )
             self.assertEqual(
-                penultimate_body_child.outputs["x"].value,
+                penultimate_body_child.outputs.x,
                 4,
                 msg="Penultimate state should be recovered, even though it's from a "
                 "remote process (and different remote than the failure process)",
@@ -375,17 +371,17 @@ class TestOutOfProcessFailure(unittest.TestCase):
             failed_body_increment = failed_body.steps[0]
             failed_body_raise_if_5 = failed_body.steps[1]
             self.assertEqual(
-                failed_body_increment.outputs["output_0"].value,
+                failed_body_increment.outputs.output_0,
                 5,
                 msg="We should be recovering state right up until the very last minute",
             )
             self.assertTrue(
-                _is_not_data(failed_body_raise_if_5.outputs["x"].value),
+                _is_not_data(failed_body_raise_if_5.outputs.x),
                 msg="And this is it, this is the last instance and we cannot recover "
                 "data from the failed atomic node",
             )
             self.assertTrue(
-                _is_not_data(failed_body.outputs["m"].value),
+                _is_not_data(failed_body.outputs.m),
                 msg="Unavailability of output should have propagated up to the parent "
                 "output.",
             )

--- a/tests/unit/_wfms/test_atomic.py
+++ b/tests/unit/_wfms/test_atomic.py
@@ -108,7 +108,7 @@ class TestAtomicEvaluate(unittest.TestCase):
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
         # `add`'s single output is named `output_0` by flowrep.
         (only_name,) = run.outputs.keys()
-        self.assertEqual(run.outputs[only_name].value, 3)
+        self.assertEqual(run.outputs[only_name], 3)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/_wfms/test_compatibility.py
+++ b/tests/unit/_wfms/test_compatibility.py
@@ -165,11 +165,11 @@ class TestAsFunctionNodeBehaviour(unittest.TestCase):
         node = add()
         self.assertEqual(node.label, add.decorated.__name__)
         run = node.run(x=-1, y=43)
-        self.assertEqual(run.outputs["z"].value, 42)
+        self.assertEqual(run.outputs.z, 42)
 
     def test_nested_scope_works(self) -> None:
         run = NestedScope.add().run(x=2, y=3)
-        self.assertEqual(run.outputs["z"].value, 5)
+        self.assertEqual(run.outputs.z, 5)
 
     def test_locals_fail_at_decoration(self) -> None:
         # A `<locals>` function can never be instantiated (it is unimportable), so we
@@ -197,7 +197,7 @@ class TestAsFunctionNodeBehaviour(unittest.TestCase):
             ["renamed"],
             msg="A positional string argument should override the scraped label.",
         )
-        self.assertEqual(run.outputs["renamed"].value, 5)
+        self.assertEqual(run.outputs.renamed, 5)
 
 
 class TestMultipleDispatch(unittest.TestCase):
@@ -246,43 +246,43 @@ class TestFlatMacroConstruction(unittest.TestCase):
 
     def test_positional_child_construction(self) -> None:
         run = macro_args().run(x=1, y=2)
-        self.assertEqual(run.outputs["summed"].value, 3)
+        self.assertEqual(run.outputs.summed, 3)
 
     def test_keyword_child_construction(self) -> None:
         run = macro_kwargs().run(x=1, y=2)
-        self.assertEqual(run.outputs["summed"].value, 3)
+        self.assertEqual(run.outputs.summed, 3)
 
     def test_single_output_node_as_input(self) -> None:
         # double(self.s) -- the whole single-output node feeds the next child.
         run = macro_node_input().run(x=1, y=2)
-        self.assertEqual(run.outputs["doubled_sum"].value, 6)
+        self.assertEqual(run.outputs.doubled_sum, 6)
 
     def test_specific_port_as_input(self) -> None:
         # double(self.s.outputs["z"]) -- a named child port feeds the next child.
         run = macro_port_input().run(x=1, y=2)
-        self.assertEqual(run.outputs["doubled_sum"].value, 6)
+        self.assertEqual(run.outputs.doubled_sum, 6)
 
 
 class TestMacroReturns(unittest.TestCase):
     def test_single_output_node_return(self) -> None:
         run = macro_args().run(x=1, y=2)
         self.assertEqual(list(run.outputs.keys()), ["summed"])
-        self.assertEqual(run.outputs["summed"].value, 3)
+        self.assertEqual(run.outputs.summed, 3)
 
     def test_specific_port_return(self) -> None:
         run = macro_port_return().run(x=1, y=2)
-        self.assertEqual(run.outputs["summed"].value, 3)
+        self.assertEqual(run.outputs.summed, 3)
 
     def test_mixed_multi_return(self) -> None:
         run = macro_multi_return().run(x=1, y=2)
-        self.assertEqual(run.outputs["summed"].value, 3)
-        self.assertEqual(run.outputs["doubled"].value, 6)
+        self.assertEqual(run.outputs.summed, 3)
+        self.assertEqual(run.outputs.doubled, 6)
 
     def test_parent_input_passthrough(self) -> None:
         # `return x, self.s` wires a parent input straight to a parent output.
         run = macro_passthrough().run(x=4, y=5)
-        self.assertEqual(run.outputs["echoed"].value, 4)
-        self.assertEqual(run.outputs["summed"].value, 9)
+        self.assertEqual(run.outputs.echoed, 4)
+        self.assertEqual(run.outputs.summed, 9)
 
 
 class TestMacroOutputLabels(unittest.TestCase):
@@ -293,7 +293,7 @@ class TestMacroOutputLabels(unittest.TestCase):
         # No decorator argument: the label is scraped from `return self.s`.
         run = macro_scraped().run(x=1, y=2)
         self.assertEqual(list(run.outputs.keys()), ["s"])
-        self.assertEqual(run.outputs["s"].value, 3)
+        self.assertEqual(run.outputs.s, 3)
 
     def test_incommensurate_explicit_labels_raise(self) -> None:
         factory = compatibility.as_macro_node("only_one")(too_few_labels)
@@ -325,7 +325,7 @@ class TestMacroDefaultCapture(unittest.TestCase):
     def test_child_default_is_used_at_run_time(self) -> None:
         # Only `x` is supplied; the child's `y=10` default is applied: 5 + 10.
         run = macro_child_default().run(x=5)
-        self.assertEqual(run.outputs["result"].value, 15)
+        self.assertEqual(run.outputs.result, 15)
 
 
 class TestNestedMacroConstruction(unittest.TestCase):
@@ -334,12 +334,12 @@ class TestNestedMacroConstruction(unittest.TestCase):
     def test_nested_macro_with_positional_child(self) -> None:
         # Sum of the inner macro's two outputs: three plus six.
         run = macro_outer_args().run(x=1, y=2)
-        self.assertEqual(run.outputs["total"].value, 9)
+        self.assertEqual(run.outputs.total, 9)
 
     def test_nested_macro_with_keyword_child(self) -> None:
         # The inner macro's single output (three), doubled.
         run = macro_outer_kwargs().run(x=1, y=2)
-        self.assertEqual(run.outputs["total"].value, 6)
+        self.assertEqual(run.outputs.total, 6)
 
 
 class TestUnsupportedReturns(unittest.TestCase):

--- a/tests/unit/_wfms/test_dag.py
+++ b/tests/unit/_wfms/test_dag.py
@@ -53,8 +53,8 @@ class TestMacro(unittest.TestCase):
         run = n.run(x=1, y=2, z=3)
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
         # Macro outputs come from inner `add` (a) and `sub` (s).
-        self.assertEqual(run.outputs["a"].value, 3)
-        self.assertEqual(run.outputs["s"].value, 0)
+        self.assertEqual(run.outputs.a, 3)
+        self.assertEqual(run.outputs.s, 0)
 
     def test_run_records_one_step_per_child(self) -> None:
         n = _fixtures.macro_node()
@@ -171,8 +171,8 @@ class TestPopulateOutputs(unittest.TestCase):
         # `macro` output `s` is fed by `sub_0.output_0` (a SourceHandle).
         n = _fixtures.macro_node()
         run = n.run(x=1, y=2, z=3)
-        self.assertEqual(run.outputs["s"].value, 0)
-        self.assertEqual(run.outputs["a"].value, 3)
+        self.assertEqual(run.outputs.s, 0)
+        self.assertEqual(run.outputs.a, 3)
 
     def test_input_source_path(self) -> None:
         # `passthrough` output `x` is fed directly by parent input `x`
@@ -180,8 +180,8 @@ class TestPopulateOutputs(unittest.TestCase):
         # check that both branches coexist in one run.
         n = _fixtures.passthrough_node()
         run = n.run(x=42, y=5)
-        self.assertEqual(run.outputs["x"].value, 42)
-        self.assertEqual(run.outputs["s"].value, 47)
+        self.assertEqual(run.outputs.x, 42)
+        self.assertEqual(run.outputs.s, 47)
 
 
 class TestMacroAttributeSugar(unittest.TestCase):

--- a/tests/unit/_wfms/test_datatypes.py
+++ b/tests/unit/_wfms/test_datatypes.py
@@ -146,7 +146,7 @@ class TestNodeRun(unittest.TestCase):
         # The fixture's `add` function returns a single value; flowrep's
         # parser auto-labels it `output_0`.
         out_label = next(iter(run.outputs.keys()))
-        self.assertEqual(run.outputs[out_label].value, 3)
+        self.assertEqual(run.outputs[out_label], 3)
 
     def test_run_forwards_positional_config(self):
         """A config passed positionally reaches `execution.run`."""
@@ -193,7 +193,7 @@ class TestNodeRun(unittest.TestCase):
         # `**input_data`.
         self.assertTrue(seen_paths)
         out_label = next(iter(run.outputs.keys()))
-        self.assertEqual(run.outputs[out_label].value, 3)
+        self.assertEqual(run.outputs[out_label], 3)
 
 
 class TestNodeGetState(unittest.TestCase):

--- a/tests/unit/_wfms/test_decorators.py
+++ b/tests/unit/_wfms/test_decorators.py
@@ -91,7 +91,7 @@ class TestInputs2Dataclass(unittest.TestCase):
 
     def test_run_constructs_instance(self) -> None:
         run = _fixtures.PlainPoint.pwf_inputs2dc.run(x=1.0, y=2.0)
-        self.assertEqual(run.outputs["dataclass"].value, _fixtures.PlainPoint(1.0, 2.0))
+        self.assertEqual(run.outputs.dataclass, _fixtures.PlainPoint(1.0, 2.0))
 
     def test_inputs_with_defaults(self) -> None:
         ref = _fixtures.WithDefaults.pwf_inputs2dc.recipe.reference
@@ -99,7 +99,7 @@ class TestInputs2Dataclass(unittest.TestCase):
 
     def test_default_factory_resolves_on_run(self) -> None:
         run = _fixtures.WithDefaults.pwf_inputs2dc.run(a=1)
-        self.assertEqual(run.outputs["dataclass"].value, _fixtures.WithDefaults(a=1))
+        self.assertEqual(run.outputs.dataclass, _fixtures.WithDefaults(a=1))
 
     def test_kw_only_recorded_as_restricted(self) -> None:
         ref = _fixtures.FrozenKw.pwf_inputs2dc.recipe.reference
@@ -126,15 +126,15 @@ class TestDataclass2Outputs(unittest.TestCase):
         run = _fixtures.PlainPoint.pwf_dc2outputs.run(
             dataclass=_fixtures.PlainPoint(1.0, 2.0)
         )
-        self.assertEqual(run.outputs["x"].value, 1.0)
-        self.assertEqual(run.outputs["y"].value, 2.0)
+        self.assertEqual(run.outputs.x, 1.0)
+        self.assertEqual(run.outputs.y, 2.0)
 
     def test_frozen_read_back(self) -> None:
         run = _fixtures.FrozenKw.pwf_dc2outputs.run(
             dataclass=_fixtures.FrozenKw(nova=1.1)
         )
-        self.assertEqual(run.outputs["nova"].value, 1.1)
-        self.assertEqual(run.outputs["foo"].value, 42)
+        self.assertEqual(run.outputs.nova, 1.1)
+        self.assertEqual(run.outputs.foo, 42)
 
     def test_init_false_field_is_output_not_input(self) -> None:
         # init=False -> real field (output) but not a constructor param (no input)
@@ -147,7 +147,7 @@ class TestDataclass2Outputs(unittest.TestCase):
         run = _fixtures.WithInitFalse.pwf_dc2outputs.run(
             dataclass=_fixtures.WithInitFalse(a=1)
         )
-        self.assertEqual(run.outputs["c"].value, 7)
+        self.assertEqual(run.outputs.c, 7)
 
     def test_init_var_is_input_not_output(self) -> None:
         # InitVar -> constructor param (input) but not a real field (no output)
@@ -166,9 +166,7 @@ class TestDataclass2Outputs(unittest.TestCase):
         wf.create_output_from(wf.to_dc)
         for k in wf.to_values.outputs:
             wf.connect(wf.to_values.outputs[k], wf.to_dc.inputs[k])
-        result = (
-            wf.run(dataclass=_fixtures.PlainPoint(1.0, 2.0)).outputs["dataclass"].value
-        )
+        result = wf.run(dataclass=_fixtures.PlainPoint(1.0, 2.0)).outputs.dataclass
         self.assertEqual(result, _fixtures.PlainPoint(1.0, 2.0))
 
 
@@ -204,7 +202,7 @@ class TestAtomicWorkflowDecorators(unittest.TestCase):
     def test_atomic_run(self) -> None:
         run = _fixtures.wfms_add.pwf.run(x=1, y=2)
         (only,) = run.outputs.keys()
-        self.assertEqual(run.outputs[only].value, 3)
+        self.assertEqual(run.outputs[only], 3)
 
     def test_string_dispatch_relabels_output(self) -> None:
         self.assertIsInstance(

--- a/tests/unit/_wfms/test_execution.py
+++ b/tests/unit/_wfms/test_execution.py
@@ -207,7 +207,7 @@ class TestRunHappyPath(unittest.TestCase):
             run = execution.run(node, config, x=1, y=2)
 
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
-        self.assertEqual(run.outputs["output_0"].value, 3)
+        self.assertEqual(run.outputs.output_0, 3)
         self.assertIsNotNone(run.duration)
 
         # Hook sees RUNNING and FINISHED (never PENDING).
@@ -271,7 +271,7 @@ class TestRunExecutorBranches(unittest.TestCase):
             config = execution.RunConfig(run_dir=pathlib.Path(tmp))
             run = execution.run(node, config, x=1, y=2)
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
-        self.assertEqual(run.outputs["output_0"].value, 3)
+        self.assertEqual(run.outputs.output_0, 3)
 
     def test_live_executor_branch_succeeds(self) -> None:
         node = _fixtures.atomic_add_node()
@@ -281,7 +281,7 @@ class TestRunExecutorBranches(unittest.TestCase):
                 config = execution.RunConfig(run_dir=pathlib.Path(tmp))
                 run = execution.run(node, config, x=1, y=2)
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
-        self.assertEqual(run.outputs["output_0"].value, 3)
+        self.assertEqual(run.outputs.output_0, 3)
 
     def test_none_executor_branch_succeeds(self) -> None:
         node = _fixtures.atomic_add_node()
@@ -290,7 +290,7 @@ class TestRunExecutorBranches(unittest.TestCase):
             config = execution.RunConfig(run_dir=pathlib.Path(tmp))
             run = execution.run(node, config, x=1, y=2)
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
-        self.assertEqual(run.outputs["output_0"].value, 3)
+        self.assertEqual(run.outputs.output_0, 3)
 
     def test_invalid_executor_type_raises_with_lexical_path(self) -> None:
         # The prime-mover failure branch will call `node.dump` after the
@@ -531,7 +531,7 @@ class TestRunDoesNotBlockOnHooks(unittest.TestCase):
             self.assertTrue(entered.wait(timeout=5))
             self.assertFalse(release.is_set())
             self.assertEqual(run.status, execution.RunStatus.FINISHED)
-            self.assertEqual(run.outputs["output_0"].value, 3)
+            self.assertEqual(run.outputs.output_0, 3)
             release.set()  # let the hook finish before teardown flushes the pool
 
 

--- a/tests/unit/_wfms/test_ifflow.py
+++ b/tests/unit/_wfms/test_ifflow.py
@@ -163,7 +163,7 @@ class TestEvaluateSingleCaseTrue(unittest.TestCase):
         self.assertEqual(self.run.status, execution.RunStatus.FINISHED)
 
     def test_body_output_routed_to_parent(self) -> None:
-        self.assertEqual(self.run.outputs["out"].value, 3)
+        self.assertEqual(self.run.outputs.out, 3)
 
     def test_steps_in_run_order(self) -> None:
         labels = [step.label for step in self.run.steps]
@@ -184,7 +184,7 @@ class TestEvaluateSingleCaseFalseNoElse(unittest.TestCase):
         self.assertEqual(self.run.status, execution.RunStatus.FINISHED)
 
     def test_output_stays_not_data(self) -> None:
-        self.assertIsInstance(self.run.outputs["out"].value, fr.schemas.NotData)
+        self.assertIsInstance(self.run.outputs.out, fr.schemas.NotData)
 
     def test_only_condition_ran(self) -> None:
         labels = [step.label for step in self.run.steps]
@@ -206,7 +206,7 @@ class TestEvaluateSingleCaseFalseWithElse(unittest.TestCase):
         self.assertEqual(self.run.status, execution.RunStatus.FINISHED)
 
     def test_else_body_output_routed(self) -> None:
-        self.assertEqual(self.run.outputs["y"].value, 5)
+        self.assertEqual(self.run.outputs.y, 5)
 
     def test_steps_visit_condition_then_else_body(self) -> None:
         labels = [step.label for step in self.if_step.steps]
@@ -228,7 +228,7 @@ class TestEvaluateMultipleCases(unittest.TestCase):
         ifn = ifflow.If("ifn", _two_case_recipe(with_else=True))
         # x=5: is_positive(5) → True, identity(5) → 5. cond_neg must not run.
         run = ifn.run(x=5)
-        self.assertEqual(run.outputs["out"].value, 5)
+        self.assertEqual(run.outputs.out, 5)
         labels = [step.label for step in run.steps]
         self.assertEqual(labels, ["cond_pos", "body_pos"])
 
@@ -236,7 +236,7 @@ class TestEvaluateMultipleCases(unittest.TestCase):
         ifn = ifflow.If("ifn", _two_case_recipe(with_else=True))
         # x=-5: cond_pos False, cond_neg True, negate(-5)=5.
         run = ifn.run(x=-5)
-        self.assertEqual(run.outputs["out"].value, 5)
+        self.assertEqual(run.outputs.out, 5)
         labels = [step.label for step in run.steps]
         self.assertEqual(labels, ["cond_pos", "cond_neg", "body_neg"])
 
@@ -244,7 +244,7 @@ class TestEvaluateMultipleCases(unittest.TestCase):
         ifn = ifflow.If("ifn", _two_case_recipe(with_else=True))
         # x=0: both predicates False, else returns identity(0)=0.
         run = ifn.run(x=0)
-        self.assertEqual(run.outputs["out"].value, 0)
+        self.assertEqual(run.outputs.out, 0)
         labels = [step.label for step in run.steps]
         self.assertEqual(labels, ["cond_pos", "cond_neg", "else_body"])
 
@@ -252,7 +252,7 @@ class TestEvaluateMultipleCases(unittest.TestCase):
         ifn = ifflow.If("ifn", _two_case_recipe(with_else=False))
         run = ifn.run(x=0)
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
-        self.assertIsInstance(run.outputs["out"].value, fr.schemas.NotData)
+        self.assertIsInstance(run.outputs.out, fr.schemas.NotData)
         labels = [step.label for step in run.steps]
         self.assertEqual(labels, ["cond_pos", "cond_neg"])
         self.assertEqual(run.result.output_edges, {})
@@ -283,7 +283,7 @@ class TestMacroDownstreamOfFalsyIfIsSkipped(unittest.TestCase):
         self.assertEqual(self.run.status, execution.RunStatus.FINISHED)
 
     def test_macro_output_is_not_data(self) -> None:
-        self.assertIsInstance(self.run.outputs["z"].value, fr.schemas.NotData)
+        self.assertIsInstance(self.run.outputs.z, fr.schemas.NotData)
 
     def test_downstream_step_not_recorded(self) -> None:
         labels = [step.label for step in self.run.steps]

--- a/tests/unit/_wfms/test_injection.py
+++ b/tests/unit/_wfms/test_injection.py
@@ -39,7 +39,7 @@ def _run_binary(label, op, a_val, b_val):
     wf.create_output("out")
     wf.r = op(wf.inputs.a, wf.inputs.b)
     wf.connect(wf.r, wf.outputs.out)
-    return wf.run(a=a_val, b=b_val).outputs["out"].value
+    return wf.run(a=a_val, b=b_val).outputs.out
 
 
 class TestUnaryInjection(unittest.TestCase):
@@ -50,7 +50,7 @@ class TestUnaryInjection(unittest.TestCase):
         self.assertEqual(2, len(result.nodes))
         in_label = _only(result.inputs)
         out_label = _only(result.outputs)
-        value = result.run(**{in_label: -5}).outputs[out_label].value
+        value = result.run(**{in_label: -5}).outputs[out_label]
         self.assertEqual(abs(-5 + 1), value)  # abs(-4) == 4
 
     def test_unary_on_input_port(self):
@@ -59,7 +59,7 @@ class TestUnaryInjection(unittest.TestCase):
         wf.create_output("out")
         wf.absn = abs(wf.inputs.n)
         wf.connect(wf.absn, wf.outputs.out)
-        self.assertEqual(42, wf.run(n=-42).outputs["out"].value)
+        self.assertEqual(42, wf.run(n=-42).outputs.out)
 
     def test_unary_on_output_port(self):
         wf = workflow.Workflow("unary_output")
@@ -69,7 +69,7 @@ class TestUnaryInjection(unittest.TestCase):
         wf.connect(wf.inputs.n, wf.first.inputs.x)
         wf.absf = abs(wf.first.outputs.output_0)
         wf.connect(wf.absf, wf.outputs.out)
-        self.assertEqual(42, wf.run(n=-43).outputs["out"].value)  # abs(-43 + 1) == 42
+        self.assertEqual(42, wf.run(n=-43).outputs.out)  # abs(-43 + 1) == 42
 
     def test_owned_unary(self):
         wf = workflow.Workflow("owned_unary")
@@ -79,7 +79,7 @@ class TestUnaryInjection(unittest.TestCase):
         wf.absf = abs(wf.first)
         wf.connect(wf.inputs.n, wf.first.inputs.x)
         wf.connect(wf.absf, wf.outputs.out)
-        self.assertEqual(42, wf.run(n=-43).outputs["out"].value)
+        self.assertEqual(42, wf.run(n=-43).outputs.out)
 
     def test_repeated_injection_unique_labels(self):
         wf = workflow.Workflow("repeated_unary")
@@ -101,7 +101,7 @@ class TestBinaryInjection(unittest.TestCase):
         # inputs to the add operation. Running result directly feeds those plumbing
         # inputs; the increment nodes inside wf do not execute again here.
         out_label = _only(result.outputs)
-        value = result.run(first=1, second=2).outputs[out_label].value
+        value = result.run(first=1, second=2).outputs[out_label]
         self.assertEqual(1 + 2, value)  # 3
 
     def test_binary_naming_node_vs_output_port(self):
@@ -114,10 +114,10 @@ class TestBinaryInjection(unittest.TestCase):
 
         node_out = _only(by_node.outputs)
         port_out = _only(by_port.outputs)
-        self.assertEqual(3, by_node.run(first=1, second=2).outputs[node_out].value)
+        self.assertEqual(3, by_node.run(first=1, second=2).outputs[node_out])
         self.assertEqual(
             3,
-            by_port.run(first_output_0=1, second_output_0=2).outputs[port_out].value,
+            by_port.run(first_output_0=1, second_output_0=2).outputs[port_out],
         )
 
     def test_binary_on_input_ports(self):
@@ -127,7 +127,7 @@ class TestBinaryInjection(unittest.TestCase):
         wf.create_output("product")
         wf.prod = wf.inputs.m * wf.inputs.n
         wf.connect(wf.prod, wf.outputs.product)
-        self.assertEqual(6, wf.run(m=2, n=3).outputs["product"].value)
+        self.assertEqual(6, wf.run(m=2, n=3).outputs.product)
 
     def test_self_binary_same_port(self):
         wf = workflow.Workflow("self_binary")
@@ -135,7 +135,7 @@ class TestBinaryInjection(unittest.TestCase):
         wf.create_output("out")
         wf.doubled = wf.inputs.m + wf.inputs.m
         wf.connect(wf.doubled, wf.outputs.out)
-        self.assertEqual(8, wf.run(m=4).outputs["out"].value)
+        self.assertEqual(8, wf.run(m=4).outputs.out)
 
 
 class TestMixedOwnership(unittest.TestCase):
@@ -154,7 +154,7 @@ class TestMixedOwnership(unittest.TestCase):
         wf.connect(wf.inputs.b, wf.y.inputs["plain_increment_0_x"])
         wf.create_output("y")
         wf.connect(wf.y, wf.outputs.y)
-        self.assertEqual(5.5, wf.run(m=1, x=2, b=0.5).outputs["y"].value)
+        self.assertEqual(5.5, wf.run(m=1, x=2, b=0.5).outputs.y)
 
     def test_right_owned_left_free(self):
         # (increment(k) + b) with b owned, increment free.
@@ -169,7 +169,7 @@ class TestMixedOwnership(unittest.TestCase):
         wf.connect(wf.y, wf.outputs.out)
         self.assertEqual(
             (5 + 1) + 10,
-            wf.run(k=5, b=10).outputs["out"].value,
+            wf.run(k=5, b=10).outputs.out,
         )
 
 
@@ -182,7 +182,7 @@ class TestChainedInjection(unittest.TestCase):
         wf.y = (wf.inputs.m * wf.inputs.x) + wf.inputs.b
         wf.create_output("result")
         wf.connect(wf.y, wf.outputs.result)
-        self.assertEqual((2 * 3) + 4, wf.run(m=2, x=3, b=4).outputs["result"].value)
+        self.assertEqual((2 * 3) + 4, wf.run(m=2, x=3, b=4).outputs.result)
 
     def test_no_context_chain_still_works(self):
         # Regression: chaining unowned nodes must keep working.
@@ -198,9 +198,7 @@ class TestChainedInjection(unittest.TestCase):
                 plain_increment_mul_plain_increment_0_plain_increment_0_x=1,
                 plain_increment_mul_plain_increment_0_plain_increment_1_x=2,
                 plain_increment_0_x=0.5,
-            )
-            .outputs[out_label]
-            .value,
+            ).outputs[out_label],
         )
 
     def test_cross_context_via_pending_rejected_early(self):
@@ -235,7 +233,7 @@ class TestPendingConnectionLifting(unittest.TestCase):
         )
         outer.connect(outer.sub, outer.outputs.out)
         # abs((x+1)+1) with x=-7 -> abs(-5) == 5
-        self.assertEqual(5, outer.run(x=-7).outputs["out"].value)
+        self.assertEqual(5, outer.run(x=-7).outputs.out)
 
 
 class TestInjectionFailures(unittest.TestCase):
@@ -288,7 +286,7 @@ class TestInjectionFailures(unittest.TestCase):
         wf.connect(wf.added, wf.outputs.out)
         self.assertEqual(
             (1 + 1) + (2 + 1),
-            wf.run(a=1, b_in=2).outputs["out"].value,
+            wf.run(a=1, b_in=2).outputs.out,
         )
 
 
@@ -380,7 +378,7 @@ class TestUnaryOperators(unittest.TestCase):
         wf.create_output("out")
         wf.r = -wf.inputs.a
         wf.connect(wf.r, wf.outputs.out)
-        self.assertEqual(-5, wf.run(a=5).outputs["out"].value)
+        self.assertEqual(-5, wf.run(a=5).outputs.out)
 
     def test_pos(self):
         wf = workflow.Workflow("pos")
@@ -388,7 +386,7 @@ class TestUnaryOperators(unittest.TestCase):
         wf.create_output("out")
         wf.r = +wf.inputs.a
         wf.connect(wf.r, wf.outputs.out)
-        self.assertEqual(-5, wf.run(a=-5).outputs["out"].value)
+        self.assertEqual(-5, wf.run(a=-5).outputs.out)
 
     def test_invert(self):
         wf = workflow.Workflow("invert")
@@ -396,7 +394,7 @@ class TestUnaryOperators(unittest.TestCase):
         wf.create_output("out")
         wf.r = ~wf.inputs.a
         wf.connect(wf.r, wf.outputs.out)
-        self.assertEqual(-6, wf.run(a=5).outputs["out"].value)  # ~5 == -6
+        self.assertEqual(-6, wf.run(a=5).outputs.out)  # ~5 == -6
 
 
 if __name__ == "__main__":

--- a/tests/unit/_wfms/test_pull.py
+++ b/tests/unit/_wfms/test_pull.py
@@ -14,7 +14,7 @@ class TestPullUnparented(unittest.TestCase):
     def test_runs_and_returns_node_outputs(self):
         n = _fixtures.atomic_add_node()  # add(x, y), unparented
         run = n.pull(x=2, y=3)
-        self.assertEqual(run.outputs["output_0"].value, 5)
+        self.assertEqual(run.outputs.output_0, 5)
 
     def test_required_input_keys_are_bare_port_names(self):
         n = _fixtures.atomic_add_node()
@@ -28,14 +28,14 @@ class TestPullUnparented(unittest.TestCase):
     def test_defaults_ride_and_are_not_surfaced(self):
         m = _fixtures.multiply_with_defaults_node()  # x=1, y=2
         run = m.pull()
-        self.assertEqual(run.outputs["output_0"].value, 2)
+        self.assertEqual(run.outputs.output_0, 2)
         self.assertEqual(set(m.pulled_inputs().keys()), set())
 
     def test_expose_defaults_surfaces_them_as_required(self):
         m = _fixtures.multiply_with_defaults_node()
         self.assertEqual(set(m.pulled_inputs(False, True).keys()), {"x", "y"})
         run = m.pull(None, False, True, x=4, y=5)
-        self.assertEqual(run.outputs["output_0"].value, 20)
+        self.assertEqual(run.outputs.output_0, 20)
 
     def test_unknown_kwarg_raises_pointing_at_pulled_inputs(self):
         n = _fixtures.atomic_add_node()
@@ -52,7 +52,7 @@ class TestPullUnparented(unittest.TestCase):
     def test_free_function_matches_method(self):
         n = _fixtures.atomic_add_node()
         run = pull.pull(n, None, False, False, x=1, y=1)
-        self.assertEqual(run.outputs["output_0"].value, 2)
+        self.assertEqual(run.outputs.output_0, 2)
 
 
 def _diamond_workflow():
@@ -112,12 +112,12 @@ class TestPullWorkflowStopping(unittest.TestCase):
     def test_runs_the_cone(self):
         wf = _diamond_workflow()
         run = wf.nodes["sub_0"].pull(x=1, y=2, z=1)  # add_0=3, sub_0=3-1=2
-        self.assertEqual(run.outputs["output_0"].value, 2)
+        self.assertEqual(run.outputs.output_0, 2)
 
     def test_macro_child_stopping(self):
         macro = _fixtures.macro_node()  # a=add(x,y), s=sub(a,z)
         run = macro.nodes["sub_0"].pull(x=1, y=2, z=1)
-        self.assertEqual(run.outputs["output_0"].value, 2)
+        self.assertEqual(run.outputs.output_0, 2)
         self.assertEqual(
             set(macro.nodes["sub_0"].pulled_inputs().keys()), {"x", "y", "z"}
         )
@@ -134,7 +134,7 @@ class TestPullNestedPunchingAndStopping(unittest.TestCase):
         # ceiling = inner macro: sub_0.x <- inner add_0 (peer), sub_0.y <- z, add_0.x/y <- x/y
         self.assertEqual(set(self.inner_sub.pulled_inputs().keys()), {"x", "y", "z"})
         run = self.inner_sub.pull(x=1, y=2, z=5)  # add_0=3, sub=3-5=-2
-        self.assertEqual(run.outputs["output_0"].value, -2)
+        self.assertEqual(run.outputs.output_0, -2)
 
     def test_punching_uses_root_keys_and_flat_labels(self):
         keys = set(self.inner_sub.pulled_inputs(True).keys())
@@ -147,7 +147,7 @@ class TestPullNestedPunchingAndStopping(unittest.TestCase):
     def test_punching_runs_the_full_cone(self):
         # root add_0 (z) = 1+2 = 3; inner add_0 = 1+2 = 3; inner sub = 3 - 3 = 0
         run = self.inner_sub.pull(None, True, False, x=1, y=2)
-        self.assertEqual(run.outputs["output_0"].value, 0)
+        self.assertEqual(run.outputs.output_0, 0)
 
 
 def _foreach_with_macro_body():
@@ -195,7 +195,7 @@ class TestPullFlowControl(unittest.TestCase):
         body = fe.nodes["body"]
         self.assertEqual(set(body.pulled_inputs().keys()), {"body__x", "body__y"})
         run = body.pull(None, False, False, body__x=2, body__y=3)
-        self.assertEqual(run.outputs["output_0"].value, 5)
+        self.assertEqual(run.outputs.output_0, 5)
 
     def test_macro_inside_controller_punch_fails_stop_succeeds(self):
         fe = _foreach_with_macro_body()
@@ -203,8 +203,8 @@ class TestPullFlowControl(unittest.TestCase):
         with self.assertRaises(ValueError):
             inner_macro.pulled_workflow(True)
         run = inner_macro.pull(None, False, False, body__x=1, body__y=2, body__z=1)
-        self.assertEqual(run.outputs["a"].value, 3)  # add(1, 2)
-        self.assertEqual(run.outputs["s"].value, 2)  # 3 - 1
+        self.assertEqual(run.outputs.a, 3)  # add(1, 2)
+        self.assertEqual(run.outputs.s, 2)  # 3 - 1
 
 
 class TestPullCoverageEdgeCases(unittest.TestCase):
@@ -285,7 +285,7 @@ class TestPullExposeDefaultsNestedScoping(unittest.TestCase):
                 "inner__multiply_with_defaults_0__y": 4,
             },
         )
-        self.assertEqual(run.outputs["output_0"].value, 12)
+        self.assertEqual(run.outputs.output_0, 12)
 
 
 class TestPullCopiesExecutors(unittest.TestCase):
@@ -307,7 +307,7 @@ class TestPullPublicSurface(unittest.TestCase):
     def test_exposed_via_tools(self):
         n = _fixtures.atomic_add_node()
         self.assertEqual(
-            api.tools.pull(n, None, False, False, x=1, y=4).outputs["output_0"].value, 5
+            api.tools.pull(n, None, False, False, x=1, y=4).outputs.output_0, 5
         )
         self.assertEqual(set(api.tools.pulled_inputs(n).keys()), {"x", "y"})
         self.assertIsNotNone(api.tools.pulled_workflow(n))

--- a/tests/unit/_wfms/test_std.py
+++ b/tests/unit/_wfms/test_std.py
@@ -30,201 +30,201 @@ class TestStdExecution(unittest.TestCase):
 
     def test_abs(self):
         n = constructors.recipe2node(std.abs.node)
-        self.assertEqual(3, n.run(a=-3).outputs["absolute"].value)
+        self.assertEqual(3, n.run(a=-3).outputs.absolute)
 
     def test_add(self):
         n = constructors.recipe2node(std.add.node)
-        self.assertEqual(3, n.run(a=1, b=2).outputs["added"].value)
+        self.assertEqual(3, n.run(a=1, b=2).outputs.added)
 
     def test_index(self):
         n = constructors.recipe2node(std.index.node)
-        self.assertEqual(5, n.run(a=5).outputs["index"].value)
+        self.assertEqual(5, n.run(a=5).outputs.index)
 
     def test_inv(self):
         n = constructors.recipe2node(std.inv.node)
-        self.assertEqual(-1, n.run(a=0).outputs["inverted"].value)
+        self.assertEqual(-1, n.run(a=0).outputs.inverted)
 
     def test_invert(self):
         n = constructors.recipe2node(std.invert.node)
-        self.assertEqual(-1, n.run(a=0).outputs["inverted"].value)
+        self.assertEqual(-1, n.run(a=0).outputs.inverted)
 
     def test_neg(self):
         n = constructors.recipe2node(std.neg.node)
-        self.assertEqual(-2, n.run(a=2).outputs["negative"].value)
+        self.assertEqual(-2, n.run(a=2).outputs.negative)
 
     def test_pos(self):
         n = constructors.recipe2node(std.pos.node)
-        self.assertEqual(-2, n.run(a=-2).outputs["positive"].value)
+        self.assertEqual(-2, n.run(a=-2).outputs.positive)
 
     def test_not_(self):
         n = constructors.recipe2node(std.not_.node)
-        self.assertEqual(True, n.run(a=False).outputs["negated"].value)
+        self.assertEqual(True, n.run(a=False).outputs.negated)
 
     def test_truth(self):
         n = constructors.recipe2node(std.truth.node)
-        self.assertEqual(False, n.run(a=[]).outputs["truth"].value)
+        self.assertEqual(False, n.run(a=[]).outputs.truth)
 
     def test_length_hint(self):
         n = constructors.recipe2node(std.length_hint.node)
-        self.assertEqual(3, n.run(obj=[1, 2, 3]).outputs["length"].value)
+        self.assertEqual(3, n.run(obj=[1, 2, 3]).outputs.length)
 
     def test_sub(self):
         n = constructors.recipe2node(std.sub.node)
-        self.assertEqual(3, n.run(a=5, b=2).outputs["difference"].value)
+        self.assertEqual(3, n.run(a=5, b=2).outputs.difference)
 
     def test_isub(self):
         n = constructors.recipe2node(std.isub.node)
-        self.assertEqual(3, n.run(a=5, b=2).outputs["difference"].value)
+        self.assertEqual(3, n.run(a=5, b=2).outputs.difference)
 
     def test_iadd(self):
         n = constructors.recipe2node(std.iadd.node)
-        self.assertEqual(3, n.run(a=1, b=2).outputs["added"].value)
+        self.assertEqual(3, n.run(a=1, b=2).outputs.added)
 
     def test_mul(self):
         n = constructors.recipe2node(std.mul.node)
-        self.assertEqual(6, n.run(a=2, b=3).outputs["product"].value)
+        self.assertEqual(6, n.run(a=2, b=3).outputs.product)
 
     def test_imul(self):
         n = constructors.recipe2node(std.imul.node)
-        self.assertEqual(6, n.run(a=2, b=3).outputs["product"].value)
+        self.assertEqual(6, n.run(a=2, b=3).outputs.product)
 
     def test_floordiv(self):
         n = constructors.recipe2node(std.floordiv.node)
-        self.assertEqual(3, n.run(a=7, b=2).outputs["quotient"].value)
+        self.assertEqual(3, n.run(a=7, b=2).outputs.quotient)
 
     def test_ifloordiv(self):
         n = constructors.recipe2node(std.ifloordiv.node)
-        self.assertEqual(3, n.run(a=7, b=2).outputs["quotient"].value)
+        self.assertEqual(3, n.run(a=7, b=2).outputs.quotient)
 
     def test_truediv(self):
         n = constructors.recipe2node(std.truediv.node)
-        self.assertEqual(3.0, n.run(a=6, b=2).outputs["quotient"].value)
+        self.assertEqual(3.0, n.run(a=6, b=2).outputs.quotient)
 
     def test_itruediv(self):
         n = constructors.recipe2node(std.itruediv.node)
-        self.assertEqual(3.0, n.run(a=6, b=2).outputs["quotient"].value)
+        self.assertEqual(3.0, n.run(a=6, b=2).outputs.quotient)
 
     def test_mod(self):
         n = constructors.recipe2node(std.mod.node)
-        self.assertEqual(1, n.run(a=7, b=3).outputs["remainder"].value)
+        self.assertEqual(1, n.run(a=7, b=3).outputs.remainder)
 
     def test_imod(self):
         n = constructors.recipe2node(std.imod.node)
-        self.assertEqual(1, n.run(a=7, b=3).outputs["remainder"].value)
+        self.assertEqual(1, n.run(a=7, b=3).outputs.remainder)
 
     def test_pow(self):
         n = constructors.recipe2node(std.pow.node)
-        self.assertEqual(8, n.run(a=2, b=3).outputs["power"].value)
+        self.assertEqual(8, n.run(a=2, b=3).outputs.power)
 
     def test_ipow(self):
         n = constructors.recipe2node(std.ipow.node)
-        self.assertEqual(8, n.run(a=2, b=3).outputs["power"].value)
+        self.assertEqual(8, n.run(a=2, b=3).outputs.power)
 
     def test_and_(self):
         n = constructors.recipe2node(std.and_.node)
-        self.assertEqual(2, n.run(a=6, b=3).outputs["conjunction"].value)
+        self.assertEqual(2, n.run(a=6, b=3).outputs.conjunction)
 
     def test_iand(self):
         n = constructors.recipe2node(std.iand.node)
-        self.assertEqual(2, n.run(a=6, b=3).outputs["conjunction"].value)
+        self.assertEqual(2, n.run(a=6, b=3).outputs.conjunction)
 
     def test_or_(self):
         n = constructors.recipe2node(std.or_.node)
-        self.assertEqual(7, n.run(a=6, b=1).outputs["disjunction"].value)
+        self.assertEqual(7, n.run(a=6, b=1).outputs.disjunction)
 
     def test_ior(self):
         n = constructors.recipe2node(std.ior.node)
-        self.assertEqual(7, n.run(a=6, b=1).outputs["disjunction"].value)
+        self.assertEqual(7, n.run(a=6, b=1).outputs.disjunction)
 
     def test_xor(self):
         n = constructors.recipe2node(std.xor.node)
-        self.assertEqual(5, n.run(a=6, b=3).outputs["exclusive_or"].value)
+        self.assertEqual(5, n.run(a=6, b=3).outputs.exclusive_or)
 
     def test_ixor(self):
         n = constructors.recipe2node(std.ixor.node)
-        self.assertEqual(5, n.run(a=6, b=3).outputs["exclusive_or"].value)
+        self.assertEqual(5, n.run(a=6, b=3).outputs.exclusive_or)
 
     def test_lshift(self):
         n = constructors.recipe2node(std.lshift.node)
-        self.assertEqual(8, n.run(a=1, b=3).outputs["left_shifted"].value)
+        self.assertEqual(8, n.run(a=1, b=3).outputs.left_shifted)
 
     def test_ilshift(self):
         n = constructors.recipe2node(std.ilshift.node)
-        self.assertEqual(8, n.run(a=1, b=3).outputs["left_shifted"].value)
+        self.assertEqual(8, n.run(a=1, b=3).outputs.left_shifted)
 
     def test_rshift(self):
         n = constructors.recipe2node(std.rshift.node)
-        self.assertEqual(2, n.run(a=8, b=2).outputs["right_shifted"].value)
+        self.assertEqual(2, n.run(a=8, b=2).outputs.right_shifted)
 
     def test_irshift(self):
         n = constructors.recipe2node(std.irshift.node)
-        self.assertEqual(2, n.run(a=8, b=2).outputs["right_shifted"].value)
+        self.assertEqual(2, n.run(a=8, b=2).outputs.right_shifted)
 
     def test_matmul(self):
         n = constructors.recipe2node(std.matmul.node)
-        result = n.run(a=_Mat(1), b=_Mat(2)).outputs["matrix_product"].value
+        result = n.run(a=_Mat(1), b=_Mat(2)).outputs.matrix_product
         self.assertEqual(("mm", 1, 2), result)
 
     def test_imatmul(self):
         n = constructors.recipe2node(std.imatmul.node)
-        result = n.run(a=_Mat(1), b=_Mat(2)).outputs["matrix_product"].value
+        result = n.run(a=_Mat(1), b=_Mat(2)).outputs.matrix_product
         self.assertEqual(("imm", 1, 2), result)
 
     def test_eq(self):
         n = constructors.recipe2node(std.eq.node)
-        self.assertEqual(True, n.run(a=1, b=1).outputs["equal"].value)
+        self.assertEqual(True, n.run(a=1, b=1).outputs.equal)
 
     def test_ne(self):
         n = constructors.recipe2node(std.ne.node)
-        self.assertEqual(True, n.run(a=1, b=2).outputs["not_equal"].value)
+        self.assertEqual(True, n.run(a=1, b=2).outputs.not_equal)
 
     def test_lt(self):
         n = constructors.recipe2node(std.lt.node)
-        self.assertEqual(True, n.run(a=1, b=2).outputs["less"].value)
+        self.assertEqual(True, n.run(a=1, b=2).outputs.less)
 
     def test_le(self):
         n = constructors.recipe2node(std.le.node)
-        self.assertEqual(True, n.run(a=2, b=2).outputs["less_equal"].value)
+        self.assertEqual(True, n.run(a=2, b=2).outputs.less_equal)
 
     def test_gt(self):
         n = constructors.recipe2node(std.gt.node)
-        self.assertEqual(True, n.run(a=2, b=1).outputs["greater"].value)
+        self.assertEqual(True, n.run(a=2, b=1).outputs.greater)
 
     def test_ge(self):
         n = constructors.recipe2node(std.ge.node)
-        self.assertEqual(True, n.run(a=2, b=2).outputs["greater_equal"].value)
+        self.assertEqual(True, n.run(a=2, b=2).outputs.greater_equal)
 
     def test_is_(self):
         n = constructors.recipe2node(std.is_.node)
-        self.assertEqual(True, n.run(a=None, b=None).outputs["identical"].value)
+        self.assertEqual(True, n.run(a=None, b=None).outputs.identical)
 
     def test_is_not(self):
         n = constructors.recipe2node(std.is_not.node)
-        self.assertEqual(True, n.run(a=1, b=2).outputs["not_identical"].value)
+        self.assertEqual(True, n.run(a=1, b=2).outputs.not_identical)
 
     def test_contains(self):
         n = constructors.recipe2node(std.contains.node)
-        self.assertEqual(True, n.run(a=[1, 2, 3], b=2).outputs["contains"].value)
+        self.assertEqual(True, n.run(a=[1, 2, 3], b=2).outputs.contains)
 
     def test_countOf(self):
         n = constructors.recipe2node(std.countOf.node)
-        self.assertEqual(2, n.run(a=[1, 2, 2, 3], b=2).outputs["count"].value)
+        self.assertEqual(2, n.run(a=[1, 2, 2, 3], b=2).outputs.count)
 
     def test_indexOf(self):
         n = constructors.recipe2node(std.indexOf.node)
-        self.assertEqual(2, n.run(a=[1, 2, 3], b=3).outputs["index"].value)
+        self.assertEqual(2, n.run(a=[1, 2, 3], b=3).outputs.index)
 
     def test_concat(self):
         n = constructors.recipe2node(std.concat.node)
-        self.assertEqual([1, 2], n.run(a=[1], b=[2]).outputs["concatenated"].value)
+        self.assertEqual([1, 2], n.run(a=[1], b=[2]).outputs.concatenated)
 
     def test_iconcat(self):
         n = constructors.recipe2node(std.iconcat.node)
-        self.assertEqual([1, 2], n.run(a=[1], b=[2]).outputs["concatenated"].value)
+        self.assertEqual([1, 2], n.run(a=[1], b=[2]).outputs.concatenated)
 
     def test_getitem(self):
         n = constructors.recipe2node(std.getitem.node)
-        self.assertEqual(20, n.run(a=[10, 20], b=1).outputs["item"].value)
+        self.assertEqual(20, n.run(a=[10, 20], b=1).outputs.item)
 
     def test_setitem(self):
         d = {}
@@ -241,23 +241,23 @@ class TestStdExecution(unittest.TestCase):
     def test_call(self):
         n = constructors.recipe2node(std.call.node)
         with self.subTest("no variadics"):
-            self.assertEqual(42, n.run(obj=_return_42).outputs["result"].value)
+            self.assertEqual(42, n.run(obj=_return_42).outputs.result)
         with self.subTest("args"):
             self.assertEqual(
                 (42, (1, 2)),
-                n.run(obj=_return_42, args_=(1, 2)).outputs["result"].value,
+                n.run(obj=_return_42, args_=(1, 2)).outputs.result,
             )
         with self.subTest("kwargs"):
             self.assertEqual(
                 (42, {"a": 3, "b": 4}),
-                n.run(obj=_return_42, kwargs_={"a": 3, "b": 4}).outputs["result"].value,
+                n.run(obj=_return_42, kwargs_={"a": 3, "b": 4}).outputs.result,
             )
         with self.subTest("both"):
             self.assertEqual(
                 (42, (1, 2), {"a": 3, "b": 4}),
-                n.run(obj=_return_42, args_=(1, 2), kwargs_={"a": 3, "b": 4})
-                .outputs["result"]
-                .value,
+                n.run(obj=_return_42, args_=(1, 2), kwargs_={"a": 3, "b": 4}).outputs[
+                    "result"
+                ],
             )
 
 

--- a/tests/unit/_wfms/test_transformers.py
+++ b/tests/unit/_wfms/test_transformers.py
@@ -102,9 +102,9 @@ class TestAutoencoderRoundTrip(unittest.TestCase):
     def test_values_round_trip_through_compress_then_expand(self) -> None:
         node = _fixtures.autoencoder_node()
         run = node.run(a=1, b=20, c=300)
-        self.assertEqual(run.outputs["x"].value, 1)
-        self.assertEqual(run.outputs["y"].value, 20)
-        self.assertEqual(run.outputs["z"].value, 300)
+        self.assertEqual(run.outputs.x, 1)
+        self.assertEqual(run.outputs.y, 20)
+        self.assertEqual(run.outputs.z, 300)
 
 
 if __name__ == "__main__":

--- a/tests/unit/_wfms/test_tryflow.py
+++ b/tests/unit/_wfms/test_tryflow.py
@@ -227,7 +227,7 @@ class TestEvaluateTrySucceeds(unittest.TestCase):
         self.assertEqual(self.run.status, execution.RunStatus.FINISHED)
 
     def test_output_value(self) -> None:
-        self.assertEqual(self.run.outputs["z"].value, 5.0)
+        self.assertEqual(self.run.outputs.z, 5.0)
 
     def test_only_try_body_in_steps(self) -> None:
         labels = [step.label for step in self.run.steps]
@@ -255,7 +255,7 @@ class TestEvaluateExceptionHandled(unittest.TestCase):
         self.assertEqual(self.run.status, execution.RunStatus.FINISHED)
 
     def test_output_is_identity_fallback(self) -> None:
-        self.assertEqual(self.run.outputs["z"].value, 10)
+        self.assertEqual(self.run.outputs.z, 10)
 
     def test_steps_include_both_bodies(self) -> None:
         labels = [step.label for step in self.run.steps]
@@ -312,7 +312,7 @@ class TestEvaluateMultiCaseFirstMatchWins(unittest.TestCase):
 
     def test_output_from_second_handler(self) -> None:
         # identity("bad") → "bad"
-        self.assertEqual(self.run.outputs["z"].value, "bad")
+        self.assertEqual(self.run.outputs.z, "bad")
 
 
 # --------------------------------------------------------------------------- #
@@ -326,14 +326,14 @@ class TestEvaluateTupleExceptions(unittest.TestCase):
         tryn = tryflow.Try("tryn", recipe)
         run = tryn.run(x=10, y=0)
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
-        self.assertEqual(run.outputs["z"].value, 10)
+        self.assertEqual(run.outputs.z, 10)
 
     def test_type_error_matches_tuple(self) -> None:
         recipe = _tuple_exceptions_recipe()
         tryn = tryflow.Try("tryn", recipe)
         run = tryn.run(x="bad", y=1)
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
-        self.assertEqual(run.outputs["z"].value, "bad")
+        self.assertEqual(run.outputs.z, "bad")
 
 
 # --------------------------------------------------------------------------- #
@@ -364,13 +364,13 @@ class TestMacroWrappedTry(unittest.TestCase):
         node = _fixtures.try_safe_divide_node()
         run = node.run(x=10, y=2)
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
-        self.assertEqual(run.outputs["z"].value, 5.0)
+        self.assertEqual(run.outputs.z, 5.0)
 
     def test_exception_path(self) -> None:
         node = _fixtures.try_safe_divide_node()
         run = node.run(x=10, y=0)
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
-        self.assertEqual(run.outputs["z"].value, 10)
+        self.assertEqual(run.outputs.z, 10)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/_wfms/test_whileflow.py
+++ b/tests/unit/_wfms/test_whileflow.py
@@ -84,7 +84,7 @@ class TestEvaluateZeroIterations(unittest.TestCase):
         self.assertEqual(self.run.status, execution.RunStatus.FINISHED)
 
     def test_output_sourced_from_input(self) -> None:
-        self.assertEqual(self.run.outputs["n"].value, 0)
+        self.assertEqual(self.run.outputs.n, 0)
 
     def test_only_condition_ran(self) -> None:
         labels = [step.label for step in self.run.steps]
@@ -112,7 +112,7 @@ class TestEvaluateSingleIteration(unittest.TestCase):
         self.assertEqual(self.run.status, execution.RunStatus.FINISHED)
 
     def test_output_value(self) -> None:
-        self.assertEqual(self.run.outputs["n"].value, 0)
+        self.assertEqual(self.run.outputs.n, 0)
 
     def test_steps_order(self) -> None:
         labels = [step.label for step in self.run.steps]
@@ -137,7 +137,7 @@ class TestEvaluateMultipleIterations(unittest.TestCase):
         self.run = self.whl.run(n=3)
 
     def test_output_value(self) -> None:
-        self.assertEqual(self.run.outputs["n"].value, 0)
+        self.assertEqual(self.run.outputs.n, 0)
 
     def test_step_count_and_order(self) -> None:
         labels = [step.label for step in self.run.steps]
@@ -209,7 +209,7 @@ class TestMacroWrappedWhile(unittest.TestCase):
         self.whl = self.node.nodes.while_0
 
     def test_output_matches_python_countdown(self) -> None:
-        self.assertEqual(self.run.outputs["n"].value, _fixtures.while_countdown(n=3))
+        self.assertEqual(self.run.outputs.n, _fixtures.while_countdown(n=3))
 
     def test_inner_while_steps_are_wired(self) -> None:
         inner_steps = self.run.steps[0].steps
@@ -394,7 +394,7 @@ class TestNonLoopingInputs(unittest.TestCase):
         self.run = self.whl.run(n=3, step=1)
 
     def test_output_value(self) -> None:
-        self.assertEqual(self.run.outputs["n"].value, 0)
+        self.assertEqual(self.run.outputs.n, 0)
 
     def test_step_always_sourced_from_input(self) -> None:
         for key, val in self.run.result.input_edges.items():

--- a/tests/unit/_wfms/test_workflow.py
+++ b/tests/unit/_wfms/test_workflow.py
@@ -717,7 +717,7 @@ class TestEdgeMutations(unittest.TestCase):
         self.wf.connect(self.wf.inputs.a, self.wf.second.inputs.y)
         self.wf.connect(self.wf.first.outputs.output_0, self.wf.second.inputs.x)
         self.wf.connect(self.wf.second, self.wf.outputs.y)
-        self.assertEqual(42 + 2, self.wf.run(x=42, a=1).outputs["y"].value)
+        self.assertEqual(42 + 2, self.wf.run(x=42, a=1).outputs.y)
         self.wf.undo(5)  # n connect calls
         self.assertEqual([], self.wf.edges)
 
@@ -1662,7 +1662,7 @@ class TestWorkflowEvaluate(unittest.TestCase):
             ],
         )
         run = wf.run()
-        self.assertEqual(run.outputs["out"].value, 2)  # 1*2=2
+        self.assertEqual(run.outputs.out, 2)  # 1*2=2
 
     def test_sibling_edge_sequences_nodes(self) -> None:
         # n1 uses defaults (1*2=2); n2 receives x=n1.output_0=2, uses default y=2 → 4.
@@ -1685,7 +1685,7 @@ class TestWorkflowEvaluate(unittest.TestCase):
         )
         run = wf.run()
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
-        self.assertEqual(run.outputs["result"].value, 4)
+        self.assertEqual(run.outputs.result, 4)
 
     def test_full_wiring_matches_expected_values(self) -> None:
         wf = _fixtures.build_workflow(
@@ -1698,8 +1698,8 @@ class TestWorkflowEvaluate(unittest.TestCase):
             edges=_fixtures._MACRO_WF_EDGES,
         )
         run = wf.run(x=1, y=2, z=3)
-        self.assertEqual(run.outputs["a"].value, 3)  # 1+2
-        self.assertEqual(run.outputs["s"].value, 0)  # 3-3
+        self.assertEqual(run.outputs.a, 3)  # 1+2
+        self.assertEqual(run.outputs.s, 0)  # 3-3
 
     def test_passthrough_input_to_output(self) -> None:
         # No child nodes: InputSource edge wired directly to OutputTarget.
@@ -1714,7 +1714,7 @@ class TestWorkflowEvaluate(unittest.TestCase):
             ],
         )
         run = wf.run(x=42)
-        self.assertEqual(run.outputs["out"].value, 42)
+        self.assertEqual(run.outputs.out, 42)
 
     def test_steps_and_status(self) -> None:
         wf = _fixtures.build_workflow(
@@ -2480,8 +2480,8 @@ class TestWorkflowFromRecipe(unittest.TestCase):
         rebuilt = workflow.Workflow.from_recipe("rebuilt", src.recipe)
         rebuilt_run = rebuilt.run(x=2, y=3, z=4)
         self.assertEqual(
-            src_run.outputs["diff"].value,
-            rebuilt_run.outputs["diff"].value,
+            src_run.outputs.diff,
+            rebuilt_run.outputs.diff,
         )
 
     def test_undo_stack_empty(self) -> None:


### PR DESCRIPTION
This property was just a shortcut to `Run.result.output_ports`. First, it was unwise of me to make an alias to something but with a different name (`outputs` vs `output_ports`); second, I find this is just not actually the shortcut I want. If I want the whole ports map, I can just type the extra `.result.`. What I find I _do_ want very often is just quick dot/key-access to the result port _values_.

So now the `Run.outputs` property just builds a dot-dict out of the underlying port map `.value`s.