### PR TITLE
Change signature order

### DIFF
--- a/pyiron_workflow/_wfms/atomic.py
+++ b/pyiron_workflow/_wfms/atomic.py
@@ -14,13 +14,13 @@ class Atomic(StaticNode[fr.schemas.AtomicRecipe, fr.schemas.AtomicData]):
 
     def __init__(
         self,
-        label: fr.schemas.Label,
         recipe: fr.schemas.AtomicRecipe,
+        label: fr.schemas.Label,
         /,
         *positional_connections: Port | Node,
         **keyword_connections: Port | Node,
     ):
-        super().__init__(label, recipe, *positional_connections, **keyword_connections)
+        super().__init__(recipe, label, *positional_connections, **keyword_connections)
         func = retrieve.import_from_string(recipe.fully_qualified_name)
         self._function_metadata = getattr(func, "_semantikon_metadata", None)
 

--- a/pyiron_workflow/_wfms/constant.py
+++ b/pyiron_workflow/_wfms/constant.py
@@ -13,8 +13,8 @@ class Constant(StaticNode[fr.schemas.ConstantRecipe, fr.schemas.ConstantData]):
         cls, value: fr.schemas.JSONABLE, label: fr.schemas.Label | None = None
     ):
         return cls(
-            "constant" if label is None else label,
             fr.schemas.ConstantRecipe(constant=value),
+            "constant" if label is None else label,
         )
 
     @classmethod

--- a/pyiron_workflow/_wfms/constructors.py
+++ b/pyiron_workflow/_wfms/constructors.py
@@ -74,7 +74,7 @@ def function2node(
     else:
         # Otherwise parse undecorated functions as atomic nodes
         recipe = fr.tools.parse_atomic(function)
-        return atomic.Atomic(label or function.__name__, recipe)
+        return atomic.Atomic(recipe, label or function.__name__)
 
 
 def recipe2node(
@@ -87,19 +87,19 @@ def recipe2node(
     )
 
     if isinstance(recipe, fr.schemas.AtomicRecipe):
-        return atomic.Atomic(label, recipe)
+        return atomic.Atomic(recipe, label)
     elif isinstance(recipe, fr.schemas.ForEachRecipe):
-        return flowcontrollers.ForEach(label, recipe)
+        return flowcontrollers.ForEach(recipe, label)
     elif isinstance(recipe, fr.schemas.IfRecipe):
-        return flowcontrollers.If(label, recipe)
+        return flowcontrollers.If(recipe, label)
     elif isinstance(recipe, fr.schemas.TryRecipe):
-        return flowcontrollers.Try(label, recipe)
+        return flowcontrollers.Try(recipe, label)
     elif isinstance(recipe, fr.schemas.WhileRecipe):
-        return flowcontrollers.While(label, recipe)
+        return flowcontrollers.While(recipe, label)
     elif isinstance(recipe, fr.schemas.WorkflowRecipe):
-        return dag.Macro(label, recipe)
+        return dag.Macro(recipe, label)
     elif isinstance(recipe, fr.schemas.ConstantRecipe):
-        return constant.Constant(label, recipe)
+        return constant.Constant(recipe, label)
     else:
         raise TypeError(
             f"Unknown recipe type: {recipe}. Expected one of {RecipeOptions}."
@@ -178,7 +178,7 @@ def _copy_executors(src: datatypes.Node, dst: datatypes.Node) -> None:
 
 
 def workflow2macro(wf: workflow.Workflow) -> dag.Macro:
-    macro = dag.Macro(wf.label, wf.recipe)
+    macro = dag.Macro(wf.recipe, wf.label)
     _copy_port_annotations(wf.inputs, macro.inputs)
     _copy_port_annotations(wf.outputs, macro.outputs)
     _copy_executors(wf, macro)

--- a/pyiron_workflow/_wfms/datatypes.py
+++ b/pyiron_workflow/_wfms/datatypes.py
@@ -379,8 +379,8 @@ class StaticNode(Node[RecipeType, execution.ResultType], abc.ABC):
 
     def __init__(
         self,
-        label: fr.schemas.Label,
         recipe: RecipeType,
+        label: fr.schemas.Label,
         /,
         *positional_connections: Port | Node,
         **keyword_connections: Port | Node,
@@ -413,7 +413,7 @@ class StaticNode(Node[RecipeType, execution.ResultType], abc.ABC):
     def copy(
         self, new_label: fr.schemas.Label | None = None, _copy_to: Self | None = None
     ) -> Self:
-        node_copy = _copy_to or self.__class__(new_label or self.label, self.recipe)
+        node_copy = _copy_to or self.__class__(self.recipe, new_label or self.label)
         self._copy_data(self, node_copy)
         return node_copy
 
@@ -544,13 +544,13 @@ class StaticGraph(StaticNode[RecipeType, execution.ResultType], Graph, abc.ABC):
 
     def __init__(
         self,
-        label: fr.schemas.Label,
         recipe: RecipeType,
+        label: fr.schemas.Label,
         /,
         *positional_connections: Port | Node,
         **keyword_connections: Port | Node,
     ):
-        super().__init__(label, recipe, *positional_connections, **keyword_connections)
+        super().__init__(recipe, label, *positional_connections, **keyword_connections)
         self._nodes = self._build_nodes(recipe)
         self._edges = self._build_edges(recipe)
 

--- a/pyiron_workflow/_wfms/decorators.py
+++ b/pyiron_workflow/_wfms/decorators.py
@@ -40,7 +40,7 @@ class _PwfTools(Generic[_DecoratedType, _RecipeType, _NodeType], abc.ABC):
     def node(
         self, label: fr.schemas.Label | None = None, /, *positional, **keyword
     ) -> _NodeType:
-        return self._node_type(self._label(label), self.recipe, *positional, **keyword)
+        return self._node_type(self.recipe, self._label(label), *positional, **keyword)
 
     def run(self, config: execution.RunConfig | None = None, **input_data):
         return self.node().run(config, **input_data)

--- a/pyiron_workflow/_wfms/injection.py
+++ b/pyiron_workflow/_wfms/injection.py
@@ -339,7 +339,7 @@ def _build_operation(
         if context_graph
         else label
     )
-    operation_node = atomic.Atomic(label, operation.flowrep_recipe)
+    operation_node = atomic.Atomic(operation.flowrep_recipe, label)
     operation_node.connect_input(*[s._injection.port for s in sources])
 
     return operation_node

--- a/pyiron_workflow/_wfms/transformers.py
+++ b/pyiron_workflow/_wfms/transformers.py
@@ -37,7 +37,7 @@ class Transform1toN:
         self,
         label: fr.schemas.Label,
     ) -> atomic.Atomic:
-        return atomic.Atomic(label, self.recipe)
+        return atomic.Atomic(self.recipe, label)
 
 
 class TransformNto1:
@@ -72,4 +72,4 @@ class TransformNto1:
         self,
         label: fr.schemas.Label,
     ) -> atomic.Atomic:
-        return atomic.Atomic(label, self.recipe)
+        return atomic.Atomic(self.recipe, label)

--- a/pyiron_workflow/_wfms/validation.py
+++ b/pyiron_workflow/_wfms/validation.py
@@ -134,7 +134,7 @@ def validate_types(
     if isinstance(target, dag.Macro | workflow.Workflow):
         owner: StaticGraph | workflow.Workflow = target
     elif isinstance(target, fr.schemas.WorkflowRecipe):
-        owner = dag.Macro("from_recipe", target)
+        owner = dag.Macro(target, "from_recipe")
     else:
         raise TypeError(
             f"Cannot validate types for {target!r}; expected a "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,8 @@ ignore = [
     "PLR0915",
     # Too many return statements
     "PLR0911",
+    # Too many not-keyword-only arguments,
+    "PLR0917"
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/unit/_wfms/_fixtures.py
+++ b/tests/unit/_wfms/_fixtures.py
@@ -394,7 +394,7 @@ def foreach_node(label: str = "fe"):
         nested_ports=["x"],
         zipped_ports=[],
     )
-    return wfms.schemas.ForEach(label, recipe)
+    return wfms.schemas.ForEach(recipe, label)
 
 
 def if_abs_node(label: str = "if_abs"):
@@ -545,7 +545,7 @@ def attr_sugar_recipe() -> fr.schemas.WorkflowRecipe:
 
 def attr_sugar_macro_node(label: str = "attr_sugar_macro"):
     """Return a fresh `Macro` whose node labels collide with graph attributes."""
-    return wfms.schemas.Macro(label, attr_sugar_recipe())
+    return wfms.schemas.Macro(attr_sugar_recipe(), label)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/_wfms/test_atomic.py
+++ b/tests/unit/_wfms/test_atomic.py
@@ -89,7 +89,7 @@ class TestAtomicInit(unittest.TestCase):
             inputs=["x"],
             outputs=["out"],
         )
-        node = atomic.Atomic("lbl", recipe)
+        node = atomic.Atomic(recipe, "lbl")
         self.assertIs(node.function_metadata, _METADATA_SENTINEL)
 
 

--- a/tests/unit/_wfms/test_constant.py
+++ b/tests/unit/_wfms/test_constant.py
@@ -13,7 +13,7 @@ def _constant_recipe(value: object) -> fr.schemas.ConstantRecipe:
 
 class TestConstantConstruction(unittest.TestCase):
     def test_from_value(self):
-        reference = constant.Constant("foo", _constant_recipe(42))
+        reference = constant.Constant(_constant_recipe(42), "foo")
         from_value = constant.Constant.from_value(42, "foo")
         self.assertEqual(reference.recipe, from_value.recipe)
         self.assertEqual(reference.label, from_value.label)
@@ -30,7 +30,7 @@ class TestConstantEvaluate(unittest.TestCase):
         # on the single output port named `constant`.
         for value in (42, "hi", [1, 2, 3], {"a": [1, 2]}):
             with self.subTest(value=value):
-                node = constant.Constant("c", _constant_recipe(value))
+                node = constant.Constant(_constant_recipe(value), "c")
                 run = node.run()
                 self.assertEqual(run.status, execution.RunStatus.FINISHED)
                 self.assertEqual(run.outputs.constant, value)

--- a/tests/unit/_wfms/test_dag.py
+++ b/tests/unit/_wfms/test_dag.py
@@ -235,8 +235,8 @@ class TestMacroPickle(unittest.TestCase):
 
 class TestErrorParallelism(unittest.TestCase):
     def setUp(self) -> None:
-        self.single = dag.Macro("single", _single_error.flowrep_recipe)
-        self.double = dag.Macro("double", _double_error.flowrep_recipe)
+        self.single = dag.Macro(_single_error.flowrep_recipe, "single")
+        self.double = dag.Macro(_double_error.flowrep_recipe, "double")
 
     def test_single_error_raises(self):
         with self.assertRaises(ValueError):

--- a/tests/unit/_wfms/test_datatypes.py
+++ b/tests/unit/_wfms/test_datatypes.py
@@ -326,7 +326,7 @@ class TestConnectAtInit(unittest.TestCase):
 
     @staticmethod
     def _macro(**connections):
-        return dag.Macro("m", _fixtures.macro.flowrep_recipe, **connections)
+        return dag.Macro(_fixtures.macro.flowrep_recipe, "m", **connections)
 
     def test_connect_port_is_pending(self):
         src = _fixtures.atomic_add_node("src")
@@ -359,13 +359,13 @@ class TestConnectAtInit(unittest.TestCase):
         # the fixture's inputs are (x, y, z), so a lone positional lands on `x`.
         src = _fixtures.atomic_add_node("src")
         port = src.outputs["output_0"]
-        m = dag.Macro("m", _fixtures.macro.flowrep_recipe, port)
+        m = dag.Macro(_fixtures.macro.flowrep_recipe, "m", port)
         self.assertIs(m._pending_connections["x"], port)
 
     def test_positional_and_keyword_connections_combine(self):
         src = _fixtures.atomic_add_node("src")
         port = src.outputs["output_0"]
-        m = dag.Macro("m", _fixtures.macro.flowrep_recipe, port, z=src)
+        m = dag.Macro(_fixtures.macro.flowrep_recipe, "m", port, z=src)
         self.assertIs(m._pending_connections["x"], port)
         self.assertIs(m._pending_connections["z"], src.outputs["output_0"])
 

--- a/tests/unit/_wfms/test_execution.py
+++ b/tests/unit/_wfms/test_execution.py
@@ -42,7 +42,7 @@ class _FailingAtomic(atomic.Atomic):
 
 def _make_failing_node(label: str = "boom_node") -> _FailingAtomic:
     """Build a :class:`_FailingDumpingAtomic` reusing the `add` recipe."""
-    return _FailingAtomic(label, _fixtures.add.flowrep_recipe)
+    return _FailingAtomic(_fixtures.add.flowrep_recipe, label)
 
 
 # --------------------------------------------------------------------------- #
@@ -377,7 +377,7 @@ class TestRunExecutorBranches(unittest.TestCase):
         # The prime-mover failure branch will call `node.dump` after the
         # TypeError. Use `_DumpingAtomic` so that no-op succeeds rather than
         # surfacing `NotImplementedError`.
-        node = _FailingAtomic("add_invalid", _fixtures.add.flowrep_recipe)
+        node = _FailingAtomic(_fixtures.add.flowrep_recipe, "add_invalid")
         # Bypass static type checking — the branch under test is specifically
         # the "anything other than ExecutorInstructions / futures.Executor"
         # fallthrough.

--- a/tests/unit/_wfms/test_foreach.py
+++ b/tests/unit/_wfms/test_foreach.py
@@ -142,7 +142,7 @@ def _prepare_run(
 class TestBuildRuntimeDagNestedOnly(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _build_nested_only_recipe()
-        self.fe = forflow.ForEach("fe", self.recipe)
+        self.fe = forflow.ForEach(self.recipe, "fe")
         self.dag_run = _prepare_run(self.fe, {"xs": [1, 2], "y": 100})
         self.nodes = self.fe._build_runtime_dag(self.dag_run)
 
@@ -211,7 +211,7 @@ class TestBuildRuntimeDagNestedOnly(unittest.TestCase):
 class TestBuildRuntimeDagZippedOnly(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _build_zipped_only_recipe()
-        self.fe = forflow.ForEach("fe", self.recipe)
+        self.fe = forflow.ForEach(self.recipe, "fe")
         self.dag_run = _prepare_run(self.fe, {"xs": [1, 2, 3], "ys": [10, 20, 30]})
         self.nodes = self.fe._build_runtime_dag(self.dag_run)
 
@@ -250,7 +250,7 @@ class TestBuildRuntimeDagZippedOnly(unittest.TestCase):
 class TestBuildRuntimeDagMixed(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _build_mixed_recipe()
-        self.fe = forflow.ForEach("fe", self.recipe)
+        self.fe = forflow.ForEach(self.recipe, "fe")
         self.dag_run = _prepare_run(
             self.fe,
             {"xs": [1, 2], "ys": [10, 20, 30], "ws": [100, 200, 300]},
@@ -348,7 +348,7 @@ class TestBuildRuntimeDagBroadcastOnly(unittest.TestCase):
         # Build with a valid seed recipe whose inputs (x, y) match the
         # broadcast-only recipe; then swap recipes on the live.
         seed_recipe = _build_broadcast_seed_recipe()
-        self.fe = forflow.ForEach("fe", seed_recipe)
+        self.fe = forflow.ForEach(seed_recipe, "fe")
         self.dag_run = _prepare_run(self.fe, {"x": 42, "y": 100})
 
         self.dag_run.result.recipe = _make_broadcast_only_recipe()

--- a/tests/unit/_wfms/test_ifflow.py
+++ b/tests/unit/_wfms/test_ifflow.py
@@ -154,7 +154,7 @@ def _macro_with_no_else_and_downstream() -> fr.schemas.WorkflowRecipe:
 class TestEvaluateSingleCaseTrue(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _fixtures.if_recipe()
-        self.ifn = ifflow.If("ifn", self.recipe)
+        self.ifn = ifflow.If(self.recipe, "ifn")
         # cond and body both wrap `add`; with x=1, y=2 the condition returns
         # 3 (truthy) and the body returns 3.
         self.run = self.ifn.run(x=1, y=2)
@@ -176,7 +176,7 @@ class TestEvaluateSingleCaseTrue(unittest.TestCase):
 class TestEvaluateSingleCaseFalseNoElse(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _no_else_recipe()
-        self.ifn = ifflow.If("ifn", self.recipe)
+        self.ifn = ifflow.If(self.recipe, "ifn")
         # x=1, y=-1 → add → 0 (falsy); no else → output stays NOT_DATA.
         self.run = self.ifn.run(x=1, y=-1)
 
@@ -225,7 +225,7 @@ class TestEvaluateSingleCaseFalseWithElse(unittest.TestCase):
 
 class TestEvaluateMultipleCases(unittest.TestCase):
     def test_first_true_wins_and_short_circuits(self) -> None:
-        ifn = ifflow.If("ifn", _two_case_recipe(with_else=True))
+        ifn = ifflow.If(_two_case_recipe(with_else=True), "ifn")
         # x=5: is_positive(5) → True, identity(5) → 5. cond_neg must not run.
         run = ifn.run(x=5)
         self.assertEqual(run.outputs.out, 5)
@@ -233,7 +233,7 @@ class TestEvaluateMultipleCases(unittest.TestCase):
         self.assertEqual(labels, ["cond_pos", "body_pos"])
 
     def test_second_case_fires_when_first_false(self) -> None:
-        ifn = ifflow.If("ifn", _two_case_recipe(with_else=True))
+        ifn = ifflow.If(_two_case_recipe(with_else=True), "ifn")
         # x=-5: cond_pos False, cond_neg True, negate(-5)=5.
         run = ifn.run(x=-5)
         self.assertEqual(run.outputs.out, 5)
@@ -241,7 +241,7 @@ class TestEvaluateMultipleCases(unittest.TestCase):
         self.assertEqual(labels, ["cond_pos", "cond_neg", "body_neg"])
 
     def test_all_false_falls_to_else(self) -> None:
-        ifn = ifflow.If("ifn", _two_case_recipe(with_else=True))
+        ifn = ifflow.If(_two_case_recipe(with_else=True), "ifn")
         # x=0: both predicates False, else returns identity(0)=0.
         run = ifn.run(x=0)
         self.assertEqual(run.outputs.out, 0)
@@ -249,7 +249,7 @@ class TestEvaluateMultipleCases(unittest.TestCase):
         self.assertEqual(labels, ["cond_pos", "cond_neg", "else_body"])
 
     def test_all_false_no_else_leaves_not_data(self) -> None:
-        ifn = ifflow.If("ifn", _two_case_recipe(with_else=False))
+        ifn = ifflow.If(_two_case_recipe(with_else=False), "ifn")
         run = ifn.run(x=0)
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
         self.assertIsInstance(run.outputs.out, fr.schemas.NotData)
@@ -302,7 +302,7 @@ class TestStageNodeInputEdges(unittest.TestCase):
 
     def setUp(self) -> None:
         self.recipe = _fixtures.if_recipe()
-        self.ifn = ifflow.If("ifn", self.recipe)
+        self.ifn = ifflow.If(self.recipe, "ifn")
         self.live = self.ifn.generate_flowrep_live_node()
 
     def test_only_matching_target_node_edges_copied(self) -> None:
@@ -329,7 +329,7 @@ class TestStageBodyOutputEdges(unittest.TestCase):
 
     def setUp(self) -> None:
         self.recipe = _two_case_recipe(with_else=True)
-        self.ifn = ifflow.If("ifn", self.recipe)
+        self.ifn = ifflow.If(self.recipe, "ifn")
         self.live = self.ifn.generate_flowrep_live_node()
 
     def test_picks_body_pos_handle(self) -> None:
@@ -393,7 +393,7 @@ class TestStageBodyOutputEdges(unittest.TestCase):
                 ],
             },
         )
-        ifn = ifflow.If("ifn", unrelated_body_recipe)
+        ifn = ifflow.If(unrelated_body_recipe, "ifn")
         live = ifn.generate_flowrep_live_node()
         ifflow.If._stage_body_output_edges("body_a", live, unrelated_body_recipe)
         self.assertEqual(
@@ -405,7 +405,7 @@ class TestStageBodyOutputEdges(unittest.TestCase):
 class TestConditionValue(unittest.TestCase):
     def test_falls_back_to_sole_output_label(self) -> None:
         recipe = _fixtures.if_recipe()
-        ifn = ifflow.If("ifn", recipe)
+        ifn = ifflow.If(recipe, "ifn")
         live = ifn.generate_flowrep_live_node()
         case = recipe.cases[0]
         cond_live = fr.schemas.AtomicData.from_recipe(case.condition.recipe)
@@ -442,7 +442,7 @@ class TestConditionValue(unittest.TestCase):
                 ],
             },
         )
-        ifn = ifflow.If("ifn", recipe)
+        ifn = ifflow.If(recipe, "ifn")
         live = ifn.generate_flowrep_live_node()
         cond_live = fr.schemas.AtomicData.from_recipe(cond_recipe)
         cond_live.output_ports["output_0"].value = 0  # falsy via explicit label

--- a/tests/unit/_wfms/test_pull.py
+++ b/tests/unit/_wfms/test_pull.py
@@ -177,7 +177,7 @@ def _foreach_with_macro_body():
         zipped_ports=[],
     )
 
-    return flowcontrollers.ForEach("fe", recipe)
+    return flowcontrollers.ForEach(recipe, "fe")
 
 
 class TestPullFlowControl(unittest.TestCase):

--- a/tests/unit/_wfms/test_tryflow.py
+++ b/tests/unit/_wfms/test_tryflow.py
@@ -220,7 +220,7 @@ def _macro_wrapping_try() -> fr.schemas.WorkflowRecipe:
 class TestEvaluateTrySucceeds(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _fixtures.try_recipe()
-        self.tryn = tryflow.Try("tryn", self.recipe)
+        self.tryn = tryflow.Try(self.recipe, "tryn")
         self.run = self.tryn.run(x=10, y=2)
 
     def test_run_finished(self) -> None:
@@ -248,7 +248,7 @@ class TestEvaluateTrySucceeds(unittest.TestCase):
 class TestEvaluateExceptionHandled(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _fixtures.try_recipe()
-        self.tryn = tryflow.Try("tryn", self.recipe)
+        self.tryn = tryflow.Try(self.recipe, "tryn")
         self.run = self.tryn.run(x=10, y=0)
 
     def test_run_finished(self) -> None:
@@ -283,7 +283,7 @@ class TestEvaluateExceptionUnmatched(unittest.TestCase):
 
     def setUp(self) -> None:
         self.recipe = _no_match_recipe()
-        self.tryn = tryflow.Try("tryn", self.recipe)
+        self.tryn = tryflow.Try(self.recipe, "tryn")
 
     def test_unmatched_exception_propagates(self) -> None:
         with self.assertRaises(tryflow.UnmatchedExceptionError) as ctx:
@@ -299,7 +299,7 @@ class TestEvaluateExceptionUnmatched(unittest.TestCase):
 class TestEvaluateMultiCaseFirstMatchWins(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _multi_case_recipe()
-        self.tryn = tryflow.Try("tryn", self.recipe)
+        self.tryn = tryflow.Try(self.recipe, "tryn")
         # x="bad" triggers TypeError in divide("bad", 1)
         self.run = self.tryn.run(x="bad", y=1)
 
@@ -323,14 +323,14 @@ class TestEvaluateMultiCaseFirstMatchWins(unittest.TestCase):
 class TestEvaluateTupleExceptions(unittest.TestCase):
     def test_zero_division_matches_tuple(self) -> None:
         recipe = _tuple_exceptions_recipe()
-        tryn = tryflow.Try("tryn", recipe)
+        tryn = tryflow.Try(recipe, "tryn")
         run = tryn.run(x=10, y=0)
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
         self.assertEqual(run.outputs.z, 10)
 
     def test_type_error_matches_tuple(self) -> None:
         recipe = _tuple_exceptions_recipe()
-        tryn = tryflow.Try("tryn", recipe)
+        tryn = tryflow.Try(recipe, "tryn")
         run = tryn.run(x="bad", y=1)
         self.assertEqual(run.status, execution.RunStatus.FINISHED)
         self.assertEqual(run.outputs.z, "bad")
@@ -346,12 +346,12 @@ class TestEvaluateHandlerBodyRaisesPropagates(unittest.TestCase):
 
     def setUp(self) -> None:
         self.recipe = _handler_raises_recipe()
-        self.tryn = tryflow.Try("tryn", self.recipe)
+        self.tryn = tryflow.Try(self.recipe, "tryn")
         # Both try and handler call divide(x, y) with y=0 → ZeroDivisionError twice
 
     def test_propagated_exception_is_from_handler(self) -> None:
         with self.assertRaises(self._EXPECTED_EXC):
-            tryflow.Try("tryn2", self.recipe).run(x=10, y=0)
+            tryflow.Try(self.recipe, "tryn2").run(x=10, y=0)
 
 
 # --------------------------------------------------------------------------- #
@@ -449,7 +449,7 @@ class TestResolveExceptionTypes(unittest.TestCase):
 class TestStageNodeInputEdges(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _fixtures.try_recipe()
-        self.tryn = tryflow.Try("tryn", self.recipe)
+        self.tryn = tryflow.Try(self.recipe, "tryn")
         self.live = self.tryn.generate_flowrep_live_node()
 
     def test_only_matching_target_node_edges_copied(self) -> None:
@@ -480,7 +480,7 @@ class TestStageNodeInputEdges(unittest.TestCase):
 class TestStageBodyOutputEdges(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _fixtures.try_recipe()
-        self.tryn = tryflow.Try("tryn", self.recipe)
+        self.tryn = tryflow.Try(self.recipe, "tryn")
         self.live = self.tryn.generate_flowrep_live_node()
 
     def test_picks_try_body_source(self) -> None:

--- a/tests/unit/_wfms/test_whileflow.py
+++ b/tests/unit/_wfms/test_whileflow.py
@@ -77,7 +77,7 @@ def _non_looping_recipe() -> fr.schemas.WhileRecipe:
 class TestEvaluateZeroIterations(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _fixtures.while_recipe()
-        self.whl = whileflow.While("whl", self.recipe)
+        self.whl = whileflow.While(self.recipe, "whl")
         self.run = self.whl.run(n=0)
 
     def test_run_finished(self) -> None:
@@ -105,7 +105,7 @@ class TestEvaluateZeroIterations(unittest.TestCase):
 class TestEvaluateSingleIteration(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _fixtures.while_recipe()
-        self.whl = whileflow.While("whl", self.recipe)
+        self.whl = whileflow.While(self.recipe, "whl")
         self.run = self.whl.run(n=1)
 
     def test_run_finished(self) -> None:
@@ -133,7 +133,7 @@ class TestEvaluateSingleIteration(unittest.TestCase):
 class TestEvaluateMultipleIterations(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _fixtures.while_recipe()
-        self.whl = whileflow.While("whl", self.recipe)
+        self.whl = whileflow.While(self.recipe, "whl")
         self.run = self.whl.run(n=3)
 
     def test_output_value(self) -> None:
@@ -235,7 +235,7 @@ class TestMacroWrappedWhile(unittest.TestCase):
 class TestStageChildEdges(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _fixtures.while_recipe()
-        self.whl = whileflow.While("whl", self.recipe)
+        self.whl = whileflow.While(self.recipe, "whl")
         self.result = self.whl.generate_flowrep_live_node()
 
     def test_first_call_routes_all_to_input_edges(self) -> None:
@@ -266,7 +266,7 @@ class TestStageChildEdges(unittest.TestCase):
 
     def test_non_looping_port_always_from_input_edges(self) -> None:
         recipe = _non_looping_recipe()
-        whl = whileflow.While("whl", recipe)
+        whl = whileflow.While(recipe, "whl")
         result = whl.generate_flowrep_live_node()
 
         # Second call (last_body_label set): "step" is not a while output,
@@ -291,7 +291,7 @@ class TestStageChildEdges(unittest.TestCase):
 class TestStageFinalOutputEdges(unittest.TestCase):
     def setUp(self) -> None:
         self.recipe = _fixtures.while_recipe()
-        self.whl = whileflow.While("whl", self.recipe)
+        self.whl = whileflow.While(self.recipe, "whl")
 
     def test_no_iterations_produces_input_source_fallback(self) -> None:
         result = self.whl.generate_flowrep_live_node()
@@ -320,7 +320,7 @@ class TestConditionValue(unittest.TestCase):
         self, cond_label: str, output_val: object
     ) -> fr.schemas.WhileData:
         recipe = _fixtures.while_recipe()
-        whl = whileflow.While("whl", recipe)
+        whl = whileflow.While(recipe, "whl")
         result = whl.generate_flowrep_live_node()
         cond_live = fr.schemas.AtomicData.from_recipe(recipe.case.condition.recipe)
         cond_live.output_ports["output_0"].value = output_val
@@ -368,7 +368,7 @@ class TestConditionValue(unittest.TestCase):
                 ),
             },
         )
-        whl = whileflow.While("whl", recipe)
+        whl = whileflow.While(recipe, "whl")
         result = whl.generate_flowrep_live_node()
         cond_live = fr.schemas.AtomicData.from_recipe(cond_recipe)
         cond_live.output_ports["output_0"].value = 0  # falsy via explicit label
@@ -389,7 +389,7 @@ class TestNonLoopingInputs(unittest.TestCase):
 
     def setUp(self) -> None:
         self.recipe = _non_looping_recipe()
-        self.whl = whileflow.While("whl", self.recipe)
+        self.whl = whileflow.While(self.recipe, "whl")
         # n=3, step=1 → 3-1=2, 2-1=1, 1-1=0 → terminates
         self.run = self.whl.run(n=3, step=1)
 


### PR DESCRIPTION
Always take the flowrep recipe first, and then a label when constructing pwf nodes, because we might be able to come up with a default label but the recipe actually defines the nature of the object.

That at least is the general lesson. More concretely, we currently take `*args` and use them to make new edges in order for the compatibility module to work; once we release a version _without_ the compatibility back-porting, we'll be free to insist that all node parameter arguments are positional, all edge-creation arguments are keyword, and proved a _positional default_ for the label (probably something like the class name + "_node"). That is a ways off, but let's get the argument order correct immediately.