### PR TITLE
Protect `Workflow` against duplicate IO and edges

### DIFF
--- a/pyiron_workflow/injection.py
+++ b/pyiron_workflow/injection.py
@@ -367,6 +367,7 @@ def _build_injection_graph(
         graph.connect(oport, graph.outputs[port_label])
 
     negotiated_source_ports: list[datatypes.Port] = []
+    seen: set[datatypes.Port] = set()
     for source in sources:
         source_port = source._injection.port
         source_node = source_port.owner
@@ -375,11 +376,13 @@ def _build_injection_graph(
         ):
             # Create a new input to accept the source, and wire graph and child inputs
             port_label = source._injection.label
-            graph.create_input(
-                port_label,
-                type_hint=source_port.type_hint,
-                type_metadata=source_port.type_metadata,
-            )
+            if source_port not in seen:
+                graph.create_input(
+                    port_label,
+                    type_hint=source_port.type_hint,
+                    type_metadata=source_port.type_metadata,
+                )
+                seen.add(source_port)
             negotiated_source_ports.append(graph.inputs[port_label])
             graph.connect_input(**{port_label: source_port})
         elif source_node.owner is None:

--- a/pyiron_workflow/workflow_node.py
+++ b/pyiron_workflow/workflow_node.py
@@ -17,9 +17,11 @@ if TYPE_CHECKING:
     import rdflib
 
 
-def _duplicate_node_error(owner: datatypes.Graph, key: fr.schemas.Label) -> ValueError:
+def _duplicate_entry_error(
+    owner: datatypes.Graph, key: fr.schemas.Label, entry_type: str
+) -> ValueError:
     return ValueError(
-        f"{owner.lexical_path!r} already has a node {key!r}; remove or rename "
+        f"{owner.lexical_path!r} already has a {entry_type} {key!r}; remove or rename "
         f"it before assigning a new one."
     )
 
@@ -36,6 +38,8 @@ class MutablePortMap(
     MutableMapping[fr.schemas.Label, datatypes.PortType],
 ):
     def __setitem__(self, key: fr.schemas.Label, value: datatypes.PortType):
+        if key in self._pwf_lexical_map__data:
+            raise _duplicate_entry_error(self._pwf_lexical_map__owner, key, "port")
         owner = self._pwf_lexical_map__owner
         if value.owner is not owner:
             raise ValueError(
@@ -55,7 +59,7 @@ class MutableNodeMap(
 
     def __setitem__(self, key: fr.schemas.Label, value: datatypes.Node):
         if key in self._pwf_lexical_map__data:
-            raise _duplicate_node_error(self._pwf_lexical_map__owner, key)
+            raise _duplicate_entry_error(self._pwf_lexical_map__owner, key, "node")
         if value.owner is not None and value.owner is not self._pwf_lexical_map__owner:
             raise ValueError(
                 f"Node {key!r} already has owner {value.owner.lexical_path!r} and "
@@ -88,7 +92,7 @@ class MutableNodeMap(
             object.__setattr__(self, key, value)
             return
         if key in self._pwf_lexical_map__data:
-            raise _duplicate_node_error(self._pwf_lexical_map__owner, key)
+            raise _duplicate_entry_error(self._pwf_lexical_map__owner, key, "node")
         self._pwf_lexical_map__owner.add_node(constructors.node(value, key))
 
 
@@ -209,7 +213,7 @@ class Workflow(datatypes.MutableDag):
             )
 
         if name in self.nodes and self.nodes[name] is not value:
-            raise _duplicate_node_error(self, name)
+            raise _duplicate_entry_error(self, name, "node")
 
         if value in self.nodes.values():
             node = cast(datatypes.Node, value)
@@ -368,6 +372,10 @@ class Workflow(datatypes.MutableDag):
 
     @_records
     def _add_edge(self, edge: datatypes.EdgeTuple) -> actions.AddEdge:
+        if edge in self.edges:
+            raise ValueError(
+                f"Edge '{edge.source.serialize()}->{edge.target.serialize()}' already exists in {self.lexical_path!r}"
+            )
         self.edges.append(edge)
         return actions.AddEdge(edge)
 
@@ -415,6 +423,8 @@ class Workflow(datatypes.MutableDag):
             raise KeyError(
                 f"Port {old.label!r} is not owned by this workflow's inputs or outputs"
             )
+        if new.label != old.label and new.label in target_map:
+            raise _duplicate_entry_error(self, new.label, "port")
         del target_map[old.label]
         target_map[new.label] = new  # type: ignore[assignment]
         return actions.ReplacePort(old, new)
@@ -804,7 +814,7 @@ class Workflow(datatypes.MutableDag):
                 f"Cannot group an empty set of nodes on {self.lexical_path!r}."
             )
         if label in self.nodes:
-            raise _duplicate_node_error(self, label)
+            raise _duplicate_entry_error(self, label, "node")
 
         resolved = [self.get_node(n) for n in nodes]
         if duplicate := {x.label for x in resolved if resolved.count(x) > 1}:

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -45,6 +45,30 @@ class TestMutablePortMap(unittest.TestCase):
         ):
             self.wf.inputs["y"] = foreign
 
+    def test_setitem_duplicate_key_raises(self) -> None:
+        self.wf.inputs["x"] = self.port
+        replacement = datatypes.InputPort(
+            label="x", owner=self.wf, type_hint=None, type_metadata=None
+        )
+        with self.assertRaisesRegex(ValueError, "'wf' already has a port 'x'"):
+            self.wf.inputs["x"] = replacement
+        self.assertIs(
+            self.wf.inputs["x"],
+            self.port,
+            msg="The original entry must be left untouched by the rejected write",
+        )
+
+    def test_setitem_duplicate_key_raises_on_outputs(self) -> None:
+        port = datatypes.OutputPort(
+            label="z", owner=self.wf, type_hint=None, type_metadata=None
+        )
+        self.wf.outputs["z"] = port
+        replacement = datatypes.OutputPort(
+            label="z", owner=self.wf, type_hint=None, type_metadata=None
+        )
+        with self.assertRaisesRegex(ValueError, "'wf' already has a port 'z'"):
+            self.wf.outputs["z"] = replacement
+
     def test_delitem_removes_entry(self) -> None:
         self.wf.inputs["x"] = self.port
         self.assertIn("x", self.wf.inputs)
@@ -651,6 +675,45 @@ class TestEdgeMutations(unittest.TestCase):
         self.assertEqual(len(diff), 1)
         self.assertIsInstance(diff[0], actions.AddEdge)
 
+    def test_add_duplicate_edge_raises(self) -> None:
+        self.wf.add_edge(self.edge)
+        with self.assertRaisesRegex(ValueError, "Edge 'x->y' already exists in 'wf'"):
+            self.wf.add_edge(self.edge)
+        self.assertEqual(
+            [self.edge],
+            self.wf.edges,
+            msg="The edge must appear exactly once, not be duplicated",
+        )
+
+    def test_connect_same_ports_twice_raises(self) -> None:
+        node = _fixtures.atomic_add_node("adder")
+        self.wf.add_node(node)
+        self.wf.connect(node.outputs.output_0, self.wf.outputs.y)
+        with self.assertRaisesRegex(ValueError, "already exists in 'wf'"):
+            self.wf.connect(node.outputs.output_0, self.wf.outputs.y)
+
+    def test_add_duplicate_edge_partial_batch_rolls_back(self) -> None:
+        self.wf.create_output("z")
+        other = datatypes.EdgeTuple(
+            fr.schemas.InputSource(port="x"), fr.schemas.OutputTarget(port="z")
+        )
+        self.wf.add_edge(self.edge)
+        with self.assertRaises(ValueError):
+            # 'other' is new, 'self.edge' is a duplicate; the whole batch must roll back
+            self.wf.add_edge(other, self.edge)
+        self.assertNotIn(
+            other,
+            self.wf.edges,
+            msg="A failed multi-edge add must not leave the earlier edge behind",
+        )
+        self.assertEqual([self.edge], self.wf.edges)
+
+    def test_remove_then_readd_edge_allowed(self) -> None:
+        self.wf.add_edge(self.edge)
+        self.wf.remove_edge(self.edge)
+        self.wf.add_edge(self.edge)  # must not be blocked as a "duplicate"
+        self.assertEqual([self.edge], self.wf.edges)
+
     def test_remove_edge_state(self) -> None:
         self.wf.add_edge(self.edge)
         self.wf.remove_edge(self.edge)
@@ -708,9 +771,7 @@ class TestEdgeMutations(unittest.TestCase):
         self.assertIn(edge, self.wf.edges)
 
     def test_connect(self):
-        self.wf.create_input("x")
         self.wf.create_input("a")
-        self.wf.create_output("y")
         self.wf.first = _fixtures.atomic_add_node("first")
         self.wf.second = _fixtures.atomic_add_node("first")
         self.wf.connect(self.wf.inputs.x, self.wf.first.inputs.x)
@@ -850,6 +911,32 @@ class TestInputPortMutations(unittest.TestCase):
         self.wf.undo()
         self.assertNotIn("x", self.wf.inputs)
 
+    def test_create_input_duplicate_label_raises(self) -> None:
+        self.wf.create_input("x")
+        with self.assertRaisesRegex(ValueError, "'wf' already has a port 'x'"):
+            self.wf.create_input("x")
+
+    def test_create_input_repeated_positional_label_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "'wf' already has a port 'a'"):
+            self.wf.create_input("a", "a")
+
+    def test_create_input_partial_batch_rolls_back(self) -> None:
+        self.wf.create_input("b")
+        with self.assertRaises(ValueError):
+            self.wf.create_input("a", "b")  # 'a' is new, 'b' collides
+        self.assertNotIn(
+            "a",
+            self.wf.inputs,
+            msg="A failed multi-create must not leave the earlier port behind",
+        )
+        self.assertEqual(["b"], list(self.wf.inputs))
+
+    def test_input_and_output_may_share_a_label(self) -> None:
+        self.wf.create_input("shared")
+        self.wf.create_output("shared")  # separate map -- must be allowed
+        self.assertIn("shared", self.wf.inputs)
+        self.assertIn("shared", self.wf.outputs)
+
     def test_remove_input_by_label(self) -> None:
         self.wf.create_input("x")
         self.wf.remove_input("x")
@@ -927,6 +1014,17 @@ class TestInputPortMutations(unittest.TestCase):
         src = self.wf.edges[0].source
         self.assertIsInstance(src, fr.schemas.InputSource)
         self.assertEqual(src.port, "z")  # type: ignore[union-attr]
+
+    def test_rename_input_onto_existing_raises_and_preserves_state(self) -> None:
+        self.wf.create_input("a")
+        self.wf.create_input("b")
+        with self.assertRaisesRegex(ValueError, "'wf' already has a port 'b'"):
+            self.wf.rename_input("a", "b")
+        self.assertEqual(
+            ["a", "b"],
+            list(self.wf.inputs),
+            msg="A rejected rename must leave both ports intact (no lost 'a')",
+        )
 
     def test_rename_input_undo(self) -> None:
         self.wf.create_input("x")
@@ -1011,6 +1109,11 @@ class TestOutputPortMutations(unittest.TestCase):
         self.assertEqual(len(diff), 1)
         self.assertIsInstance(diff[0], actions.AddOutput)
 
+    def test_create_output_duplicate_label_raises(self) -> None:
+        self.wf.create_output("y")
+        with self.assertRaisesRegex(ValueError, "'wf' already has a port 'y'"):
+            self.wf.create_output("y")
+
     def test_create_output_undo(self) -> None:
         self.wf.create_output("y")
         self.wf.undo()
@@ -1078,6 +1181,17 @@ class TestOutputPortMutations(unittest.TestCase):
         port = self.wf.outputs["y"]
         self.wf.rename_output(port, "z")
         self.assertIn("z", self.wf.outputs)
+
+    def test_rename_output_onto_existing_raises_and_preserves_state(self) -> None:
+        self.wf.create_output("a")
+        self.wf.create_output("b")
+        with self.assertRaisesRegex(ValueError, "'wf' already has a port 'b'"):
+            self.wf.rename_output("a", "b")
+        self.assertEqual(
+            ["a", "b"],
+            list(self.wf.outputs),
+            msg="A rejected rename must leave both ports intact (no lost 'a')",
+        )
 
     def test_rename_output_rewrites_edges(self) -> None:
         node = _fixtures.atomic_add_node("adder")
@@ -1202,6 +1316,16 @@ class TestCreateInputFor(unittest.TestCase):
         self.assertEqual([], list(self.wf.inputs))
         self.assertEqual([], self.wf.edges)
 
+    def test_duplicate_label_raises(self) -> None:
+        self.wf.create_input_for(self.wf.adder.inputs.x)  # label defaults to 'x'
+        with self.assertRaisesRegex(ValueError, "'wf' already has a port 'x'"):
+            self.wf.create_input_for(self.wf.adder.inputs.y, label="x")
+        self.assertEqual(
+            ["x"],
+            list(self.wf.inputs),
+            msg="The first input must survive the rejected collision",
+        )
+
 
 class TestCreateOutputFrom(unittest.TestCase):
     def setUp(self) -> None:
@@ -1269,6 +1393,31 @@ class TestCreateOutputFrom(unittest.TestCase):
         other.add_node(_fixtures.atomic_add_node("adder"))
         with self.assertRaises(ValueError):
             self.wf.create_output_from(other.adder.outputs.output_0)
+
+    def test_duplicate_default_label_raises(self) -> None:
+        # Regression: two sources sharing a default output label ('output_0') used to
+        # silently overwrite the first port, dropping an output.
+        self.wf.add_node(_fixtures.atomic_add_node("adder2"))
+        self.wf.create_output_from(self.wf.adder)
+        with self.assertRaisesRegex(ValueError, "'wf' already has a port 'output_0'"):
+            self.wf.create_output_from(self.wf.adder2)
+        self.assertEqual(
+            ["output_0"],
+            list(self.wf.outputs),
+            msg="The first output must survive the rejected second creation",
+        )
+
+    def test_duplicate_default_label_leaves_workflow_unchanged(self) -> None:
+        self.wf.add_node(_fixtures.atomic_add_node("adder2"))
+        self.wf.create_output_from(self.wf.adder)
+        edges_before = list(self.wf.edges)
+        with contextlib.suppress(ValueError):
+            self.wf.create_output_from(self.wf.adder2)
+        self.assertEqual(
+            edges_before,
+            self.wf.edges,
+            msg="A rejected creation must not leave a dangling edge behind",
+        )
 
 
 class TestUndoRedo(unittest.TestCase):


### PR DESCRIPTION
Closes #892 

More broadly than that issue, this protects on renaming and edge adding too.