### PR TITLE
Make node constructors operate on nodelike stuff

### DIFF
--- a/src/pyiron_workflow/api/tools.py
+++ b/src/pyiron_workflow/api/tools.py
@@ -1,6 +1,6 @@
+from pyiron_workflow.constructors import atomictype2node as atomictype2node
 from pyiron_workflow.constructors import function2node as function2node
 from pyiron_workflow.constructors import node as node
-from pyiron_workflow.constructors import recipe2node as recipe2node
 from pyiron_workflow.decorators import atomic as atomic
 from pyiron_workflow.decorators import dataclass as dataclass
 from pyiron_workflow.decorators import workflow as workflow

--- a/src/pyiron_workflow/constructors.py
+++ b/src/pyiron_workflow/constructors.py
@@ -50,7 +50,7 @@ def node(value: NodeLike, label: fr.schemas.Label | None = None) -> datatypes.No
             value.label = label
         return value
     elif isinstance(value, RecipeOptions):
-        return recipe2node(value, label)
+        return atomictype2node(value, label)
     elif isinstance(value, type | types.FunctionType):
         return function2node(value, label)
     elif fr.tools.is_jsonable(value):
@@ -86,7 +86,7 @@ def function2node(
         # flowrep-decorated functions are all either atomic or workflow recipes
         return cast(
             atomic_node.Atomic | dag.Macro,
-            recipe2node(
+            atomictype2node(
                 cast(fr.schemas.AtomicRecipe | fr.schemas.WorkflowRecipe, recipe),
                 label or function.__name__,
             ),
@@ -97,7 +97,7 @@ def function2node(
         return atomic_node.Atomic(recipe, label or function.__name__)
 
 
-def recipe2node(
+def atomictype2node(
     recipe: RecipeOptions, label: fr.schemas.Label | None = None
 ) -> datatypes.StaticNode:
     label = (
@@ -208,7 +208,7 @@ def workflow2macro(wf: workflow_node.Workflow) -> dag.Macro:
 def macro2workflow(macro: dag.Macro) -> workflow_node.Workflow:
     wf = workflow_node.Workflow(macro.label)
     for label, node_recipe in macro.recipe.nodes.items():
-        wf.add_node(recipe2node(node_recipe, label))
+        wf.add_node(atomictype2node(node_recipe, label))
 
     for port_creator, reference in (
         (wf.create_input, macro.inputs),

--- a/src/pyiron_workflow/constructors.py
+++ b/src/pyiron_workflow/constructors.py
@@ -27,17 +27,23 @@ RecipeOptions: TypeAlias = (
 )
 
 
-def node(value: object, label: fr.schemas.Label | None = None) -> datatypes.Node:
+NodeLike: TypeAlias = (
+    datatypes.Node | RecipeOptions | types.FunctionType | type | fr.schemas.JSONABLE
+)
+
+
+def node(value: NodeLike, label: fr.schemas.Label | None = None) -> datatypes.Node:
     """
     Convert a node-like `value` into a `Node` labelled `label`.
 
-    Accepts a `Node`, an `flowrep` recipe, or a plain function. Raises
+    Accepts a `Node`, an `flowrep` recipe, or a plain function or class. Raises
     `TypeError` otherwise.
 
     When the passed object is already a node instance, simply attempts to relabel it.
 
-    Functions will be searched for an attached `flowrep` recipe, and otherwise parsed
-    as atomic nodes. Un-parseable functions will raise the underlying `flowrep` error.
+    Functions and classes will be searched for an attached `flowrep` recipe, and
+    otherwise parsed as atomic nodes. Un-parseable callables will raise the underlying
+    `flowrep` error.
     """
     if isinstance(value, datatypes.Node):
         if label is not None:
@@ -45,23 +51,38 @@ def node(value: object, label: fr.schemas.Label | None = None) -> datatypes.Node
         return value
     elif isinstance(value, RecipeOptions):
         return recipe2node(value, label)
-    elif isinstance(value, types.FunctionType):
+    elif isinstance(value, type | types.FunctionType):
         return function2node(value, label)
     elif fr.tools.is_jsonable(value):
         return constant.Constant.from_value(value, label)
     else:
         raise TypeError(
             f"Cannot assign {value!r} as node {label!r}: expected a Node, "
-            f"flowrep recipe, or function (with or without a flowrep recipe attached)."
+            f"flowrep recipe, or function or class (with or without a flowrep recipe "
+            f"attached)."
         )
 
 
 def function2node(
-    function: types.FunctionType,
+    function: types.FunctionType | type,
     label: fr.schemas.Label | None = None,
 ) -> atomic_node.Atomic | dag.Macro:
-    recipe = getattr(function, "flowrep_recipe", None)
-    if recipe:
+    """
+    Convert a function or class into a node labelled `label` (defaulting to its
+    `__name__`).
+
+    Only a recipe attached to `function` _itself_ is honoured; an inherited recipe is
+    ignored, so that an undecorated subclass of a decorated class gets parsed afresh
+    instead of silently referencing its parent.
+    """
+    recipe = vars(function).get("flowrep_recipe", None)
+    if recipe is not None:
+        if not isinstance(recipe, fr.schemas.NodeRecipe):
+            raise TypeError(
+                f"Cannot convert {function!r} to a Node: it has a 'flowrep_recipe' "
+                f"attribute, but this is not a '{fr.schemas.NodeRecipe.__name__}' "
+                f"-- got {type(recipe)!r}: {recipe}"
+            )
         # flowrep-decorated functions are all either atomic or workflow recipes
         return cast(
             atomic_node.Atomic | dag.Macro,

--- a/src/pyiron_workflow/constructors.py
+++ b/src/pyiron_workflow/constructors.py
@@ -39,16 +39,14 @@ def node(value: NodeLike, label: fr.schemas.Label | None = None) -> datatypes.No
     Accepts a `Node`, an `flowrep` recipe, a plain function or class, or a JSONable
     constant. Raises `TypeError` otherwise.
 
-    When the passed object is already a node instance, simply attempts to relabel it.
+    When the passed object is already a node instance, returns a copy.
 
     Functions and classes will be searched for an attached `flowrep` recipe, and
     otherwise parsed as atomic nodes. Un-parseable callables will raise the underlying
     `flowrep` error.
     """
     if isinstance(value, datatypes.Node):
-        if label is not None:
-            value.label = label
-        return value
+        return value.copy(new_label=label)
     elif isinstance(value, RecipeOptions):
         return atomictype2node(value, label)
     elif isinstance(value, type | types.FunctionType):

--- a/src/pyiron_workflow/constructors.py
+++ b/src/pyiron_workflow/constructors.py
@@ -36,8 +36,8 @@ def node(value: NodeLike, label: fr.schemas.Label | None = None) -> datatypes.No
     """
     Convert a node-like `value` into a `Node` labelled `label`.
 
-    Accepts a `Node`, an `flowrep` recipe, or a plain function or class. Raises
-    `TypeError` otherwise.
+    Accepts a `Node`, an `flowrep` recipe, a plain function or class, or a JSONable
+    constant. Raises `TypeError` otherwise.
 
     When the passed object is already a node instance, simply attempts to relabel it.
 

--- a/src/pyiron_workflow/constructors.py
+++ b/src/pyiron_workflow/constructors.py
@@ -32,7 +32,7 @@ NodeLike: TypeAlias = (
 )
 
 
-def node(value: NodeLike, label: fr.schemas.Label | None = None) -> datatypes.Node:
+def node(value: NodeLike, label: fr.schemas.Label | None = None, /) -> datatypes.Node:
     """
     Convert a node-like `value` into a `Node` labelled `label`.
 
@@ -64,6 +64,7 @@ def node(value: NodeLike, label: fr.schemas.Label | None = None) -> datatypes.No
 def function2node(
     function: types.FunctionType | type,
     label: fr.schemas.Label | None = None,
+    /,
 ) -> atomic_node.Atomic | dag.Macro:
     """
     Convert a function or class into a node labelled `label` (defaulting to its
@@ -96,7 +97,7 @@ def function2node(
 
 
 def atomictype2node(
-    recipe: RecipeOptions, label: fr.schemas.Label | None = None
+    recipe: RecipeOptions, label: fr.schemas.Label | None = None, /
 ) -> datatypes.StaticNode:
     label = (
         f"{_pascal_to_snake(recipe.__class__.__name__)}_node"

--- a/src/pyiron_workflow/dag.py
+++ b/src/pyiron_workflow/dag.py
@@ -24,7 +24,7 @@ class Macro(datatypes.ImmutableDag):
         return datatypes.NodeMap(
             self,
             {
-                node_label: constructors.recipe2node(node_recipe, node_label)
+                node_label: constructors.atomictype2node(node_recipe, node_label)
                 for node_label, node_recipe in recipe.nodes.items()
             },
         )

--- a/src/pyiron_workflow/flowcontrollers/forflow.py
+++ b/src/pyiron_workflow/flowcontrollers/forflow.py
@@ -25,7 +25,7 @@ class ForEach(datatypes.StaticGraph[fr.schemas.ForEachRecipe, fr.schemas.ForEach
         bn = self.recipe.body_node
         return datatypes.NodeMap(
             self,
-            {bn.label: constructors.recipe2node(bn.recipe, bn.label)},
+            {bn.label: constructors.atomictype2node(bn.recipe, bn.label)},
         )
 
     def _build_edges(self, recipe: fr.schemas.ForEachRecipe) -> datatypes.EdgeList:

--- a/src/pyiron_workflow/flowcontrollers/ifflow.py
+++ b/src/pyiron_workflow/flowcontrollers/ifflow.py
@@ -15,14 +15,14 @@ class If(datatypes.StaticGraph[fr.schemas.IfRecipe, fr.schemas.IfData]):
     def _build_nodes(self, recipe: fr.schemas.IfRecipe) -> datatypes.NodeMap:
         nodes: dict[fr.schemas.Label, datatypes.Node] = {}
         for case in recipe.cases:
-            nodes[case.condition.label] = constructors.recipe2node(
+            nodes[case.condition.label] = constructors.atomictype2node(
                 case.condition.recipe, case.condition.label
             )
-            nodes[case.body.label] = constructors.recipe2node(
+            nodes[case.body.label] = constructors.atomictype2node(
                 case.body.recipe, case.body.label
             )
         if recipe.else_case is not None:
-            nodes[recipe.else_case.label] = constructors.recipe2node(
+            nodes[recipe.else_case.label] = constructors.atomictype2node(
                 recipe.else_case.recipe, recipe.else_case.label
             )
         return datatypes.NodeMap(self, nodes)

--- a/src/pyiron_workflow/flowcontrollers/tryflow.py
+++ b/src/pyiron_workflow/flowcontrollers/tryflow.py
@@ -18,12 +18,12 @@ class Try(datatypes.StaticGraph[fr.schemas.TryRecipe, fr.schemas.TryData]):
 
     def _build_nodes(self, recipe: fr.schemas.TryRecipe) -> datatypes.NodeMap:
         nodes: dict[fr.schemas.Label, datatypes.Node] = {
-            recipe.try_node.label: constructors.recipe2node(
+            recipe.try_node.label: constructors.atomictype2node(
                 recipe.try_node.recipe, recipe.try_node.label
             )
         }
         for case in recipe.exception_cases:
-            nodes[case.body.label] = constructors.recipe2node(
+            nodes[case.body.label] = constructors.atomictype2node(
                 case.body.recipe, case.body.label
             )
         return datatypes.NodeMap(self, nodes)

--- a/src/pyiron_workflow/flowcontrollers/whileflow.py
+++ b/src/pyiron_workflow/flowcontrollers/whileflow.py
@@ -16,10 +16,10 @@ class While(datatypes.StaticGraph[fr.schemas.WhileRecipe, fr.schemas.WhileData])
         return datatypes.NodeMap(
             self,
             {
-                recipe.case.condition.label: constructors.recipe2node(
+                recipe.case.condition.label: constructors.atomictype2node(
                     recipe.case.condition.recipe, recipe.case.condition.label
                 ),
-                recipe.case.body.label: constructors.recipe2node(
+                recipe.case.body.label: constructors.atomictype2node(
                     recipe.case.body.recipe, recipe.case.body.label
                 ),
             },

--- a/src/pyiron_workflow/workflow_node.py
+++ b/src/pyiron_workflow/workflow_node.py
@@ -93,7 +93,12 @@ class MutableNodeMap(
             return
         if key in self._pwf_lexical_map__data:
             raise _duplicate_entry_error(self._pwf_lexical_map__owner, key, "node")
-        self._pwf_lexical_map__owner.add_node(constructors.node(value, key))
+        if isinstance(value, datatypes.Node):
+            value.label = key
+            to_add = value
+        else:
+            to_add = constructors.node(value, key)
+        self._pwf_lexical_map__owner.add_node(to_add)
 
 
 class Workflow(datatypes.MutableDag):
@@ -220,7 +225,12 @@ class Workflow(datatypes.MutableDag):
             if node.label != name:
                 self.rename_node(node, name)
         else:
-            self.add_node(constructors.node(value, name))
+            if isinstance(value, datatypes.Node):
+                value.label = name
+                to_add = value
+            else:
+                to_add = constructors.node(value, name)
+            self.add_node(to_add)
 
     @property
     def inputs(self) -> MutablePortMap[datatypes.InputPort]:

--- a/tests/integration/test_failure.py
+++ b/tests/integration/test_failure.py
@@ -126,7 +126,7 @@ def _run_and_reload(wf_fnc, **input_data) -> wfms.schemas.Run:
     """Run ``wf_fnc``, expect RuntimeError, return the loaded pickled failure."""
     with tempfile.TemporaryDirectory() as tmp:
         run_dir = pathlib.Path(tmp)
-        wf = wfms.node(wf_fnc, label=_LABEL)
+        wf = wfms.node(wf_fnc, _LABEL)
         config = wfms.RunConfig(
             run_dir=run_dir,
             progress_hooks=[],
@@ -333,7 +333,7 @@ class TestOutOfProcessFailure(unittest.TestCase):
     def test_while_failure_on_process_pool(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             run_dir = pathlib.Path(tmp)
-            wf = wfms.node(composite_failure, label=_LABEL)
+            wf = wfms.node(composite_failure, _LABEL)
             config = wfms.RunConfig(
                 run_dir=run_dir,
                 progress_hooks=[],

--- a/tests/unit/test_constructors.py
+++ b/tests/unit/test_constructors.py
@@ -232,7 +232,7 @@ class TestFunction2Node(unittest.TestCase):
         self.assertEqual(n.label, "add")
 
     def test_atomic_decorated_explicit_label(self) -> None:
-        n = constructors.function2node(_fixtures.add, label="custom")
+        n = constructors.function2node(_fixtures.add, "custom")
         self.assertIsInstance(n, atomic_node.Atomic)
         self.assertEqual(n.label, "custom")
 
@@ -294,7 +294,7 @@ class TestRecipe2Node(unittest.TestCase):
         recipe = transformers.Transform1toN(2).recipe
         n = constructors.atomictype2node(recipe)
         self.assertEqual(n.label, "atomic_recipe_node")
-        n = constructors.atomictype2node(recipe, label="explicit_label")
+        n = constructors.atomictype2node(recipe, "explicit_label")
         self.assertEqual(n.label, "explicit_label")
 
     def test_workflow_recipe_returns_macro(self) -> None:
@@ -321,7 +321,7 @@ class TestRecipe2Node(unittest.TestCase):
 
     def test_unknown_recipe_type_raises_type_error(self) -> None:
         with self.assertRaises(TypeError) as ctx:
-            constructors.atomictype2node(recipe=object(), label="x")  # type: ignore[arg-type]
+            constructors.atomictype2node(object(), "x")  # type: ignore[arg-type]
         self.assertIn("Unknown recipe type", str(ctx.exception))
 
 

--- a/tests/unit/test_constructors.py
+++ b/tests/unit/test_constructors.py
@@ -27,6 +27,44 @@ def plain_add(x, y):
     return x + y
 
 
+@fr.atomic
+class DecoratedClass:
+    """Decorated class — classes are node-like just like functions."""
+
+    def __init__(self, x: int) -> None:
+        self.x = x
+
+
+class PlainSubclass(DecoratedClass):
+    """Undecorated child of a decorated class — must _not_ reuse the parent recipe."""
+
+    def __init__(self, x: int, y: int = 2) -> None:
+        super().__init__(x)
+        self.y = y
+
+
+@fr.atomic
+class DecoratedSubclass(DecoratedClass):
+    """Decorated child of a decorated class — carries its own recipe."""
+
+    def __init__(self, x: int, y: int = 2) -> None:
+        super().__init__(x)
+        self.y = y
+
+
+class PlainClass:
+    """Undecorated class — parsed as an atomic node from its constructor."""
+
+    def __init__(self, x: int) -> None:
+        self.x = x
+
+
+class NotARecipeHolder:
+    """Occupies `flowrep_recipe` with something that isn't a recipe at all."""
+
+    flowrep_recipe = "not a recipe"
+
+
 # --------------------------------------------------------------------------- #
 # Helpers for building minimal If / Try / While recipes.                      #
 # --------------------------------------------------------------------------- #
@@ -153,6 +191,26 @@ class TestNode(unittest.TestCase):
         self.assertIsInstance(result, atomic_node.Atomic)
         self.assertEqual(result.label, "inc")
 
+    def test_unlabelled_decorated_function_takes_its_own_name(self) -> None:
+        """Without a label, the function name wins — not a generic recipe-class name."""
+        self.assertEqual(constructors.node(_fixtures.add).label, "add")
+        self.assertEqual(constructors.node(_fixtures.macro).label, "macro")
+
+    def test_decorated_class(self) -> None:
+        result = constructors.node(DecoratedClass)
+        self.assertIsInstance(result, atomic_node.Atomic)
+        self.assertEqual(result.label, "DecoratedClass")
+
+    def test_undecorated_class(self) -> None:
+        result = constructors.node(PlainClass)
+        self.assertIsInstance(result, atomic_node.Atomic)
+        self.assertEqual(result.label, "PlainClass")
+
+    def test_rejects_instance_of_decorated_class(self) -> None:
+        """Instances carry `flowrep_recipe` from their class, but aren't node-like."""
+        with self.assertRaisesRegex(TypeError, "expected a Node"):
+            constructors.node(DecoratedClass(1))
+
     def test_jsonable_constant(self) -> None:
         result = constructors.node([42], "forty_two")
         self.assertIsInstance(result, constant.Constant)
@@ -184,6 +242,38 @@ class TestFunction2Node(unittest.TestCase):
         n = constructors.function2node(plain_add)
         self.assertIsInstance(n, atomic_node.Atomic)
         self.assertEqual(n.label, "plain_add")
+
+    def test_decorated_class_default_label(self) -> None:
+        n = constructors.function2node(DecoratedClass)
+        self.assertIsInstance(n, atomic_node.Atomic)
+        self.assertEqual(n.label, "DecoratedClass")
+        self.assertIs(n.recipe, DecoratedClass.flowrep_recipe)
+
+    def test_undecorated_subclass_is_parsed_afresh(self) -> None:
+        """An inherited recipe must be ignored, or the child would build its parent."""
+        n = constructors.function2node(PlainSubclass)
+        self.assertIsNot(n.recipe, DecoratedClass.flowrep_recipe)
+        self.assertTrue(
+            n.recipe.reference.info.fully_qualified_name.endswith("PlainSubclass"),
+            msg=f"Got {n.recipe.reference.info.fully_qualified_name}",
+        )
+        self.assertListEqual(
+            ["x", "y"],
+            list(n.inputs.keys()),
+            msg="The child's own constructor signature should be parsed",
+        )
+
+    def test_decorated_subclass_uses_its_own_recipe(self) -> None:
+        n = constructors.function2node(DecoratedSubclass)
+        self.assertIs(n.recipe, DecoratedSubclass.flowrep_recipe)
+        self.assertTrue(
+            n.recipe.reference.info.fully_qualified_name.endswith("DecoratedSubclass"),
+            msg=f"Got {n.recipe.reference.info.fully_qualified_name}",
+        )
+
+    def test_non_recipe_flowrep_attribute_raises(self) -> None:
+        with self.assertRaisesRegex(TypeError, "not a 'NodeRecipe'"):
+            constructors.function2node(NotARecipeHolder)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_constructors.py
+++ b/tests/unit/test_constructors.py
@@ -284,41 +284,41 @@ class TestFunction2Node(unittest.TestCase):
 class TestRecipe2Node(unittest.TestCase):
     def test_atomic_recipe_returns_atomic(self) -> None:
         recipe = transformers.Transform1toN(2).recipe
-        n = constructors.recipe2node(recipe)
+        n = constructors.atomictype2node(recipe)
         self.assertIsInstance(n, atomic_node.Atomic)
 
     def test_label(self) -> None:
         recipe = transformers.Transform1toN(2).recipe
-        n = constructors.recipe2node(recipe)
+        n = constructors.atomictype2node(recipe)
         self.assertEqual(n.label, "atomic_recipe_node")
-        n = constructors.recipe2node(recipe, label="explicit_label")
+        n = constructors.atomictype2node(recipe, label="explicit_label")
         self.assertEqual(n.label, "explicit_label")
 
     def test_workflow_recipe_returns_macro(self) -> None:
         recipe = _fixtures.macro.flowrep_recipe
-        n = constructors.recipe2node(recipe)
+        n = constructors.atomictype2node(recipe)
         self.assertIsInstance(n, dag.Macro)
 
     def test_for_each_recipe_returns_for_each(self) -> None:
         recipe = _fixtures.for_wf.flowrep_recipe.nodes["for_each_0"]
-        n = constructors.recipe2node(recipe)
+        n = constructors.atomictype2node(recipe)
         self.assertIsInstance(n, flowcontrollers.ForEach)
 
     def test_if_recipe_returns_if(self) -> None:
-        n = constructors.recipe2node(_if_recipe())
+        n = constructors.atomictype2node(_if_recipe())
         self.assertIsInstance(n, flowcontrollers.If)
 
     def test_try_recipe_returns_try(self) -> None:
-        n = constructors.recipe2node(_try_recipe())
+        n = constructors.atomictype2node(_try_recipe())
         self.assertIsInstance(n, flowcontrollers.Try)
 
     def test_while_recipe_returns_while(self) -> None:
-        n = constructors.recipe2node(_while_recipe())
+        n = constructors.atomictype2node(_while_recipe())
         self.assertIsInstance(n, flowcontrollers.While)
 
     def test_unknown_recipe_type_raises_type_error(self) -> None:
         with self.assertRaises(TypeError) as ctx:
-            constructors.recipe2node(recipe=object(), label="x")  # type: ignore[arg-type]
+            constructors.atomictype2node(recipe=object(), label="x")  # type: ignore[arg-type]
         self.assertIn("Unknown recipe type", str(ctx.exception))
 
 

--- a/tests/unit/test_constructors.py
+++ b/tests/unit/test_constructors.py
@@ -156,15 +156,18 @@ def _try_recipe() -> fr.schemas.TryRecipe:
 
 
 class TestNode(unittest.TestCase):
-    def test_node_passes_through_node_instances(self) -> None:
+    def test_node_copies_node_instances(self) -> None:
         node = _fixtures.atomic_add_node("original")
         still_node = constructors.node(node)
-        self.assertIs(still_node, node)
+        self.assertIsInstance(still_node, datatypes.Node)
+        self.assertEqual(node.recipe, still_node.recipe)
+        self.assertEqual(node.label, still_node.label)
+        self.assertIsNot(node, still_node)
 
     def test_node_relabels_node(self) -> None:
         node = _fixtures.atomic_add_node("original")
         result = constructors.node(node, "renamed")
-        self.assertIs(result, node)
+        self.assertEqual(node.label, "original")
         self.assertEqual(result.label, "renamed")
 
     def test_node_rejects_non_node_non_jsonable(self) -> None:

--- a/tests/unit/test_ifflow.py
+++ b/tests/unit/test_ifflow.py
@@ -275,7 +275,7 @@ class TestMacroDownstreamOfFalsyIfIsSkipped(unittest.TestCase):
 
     def setUp(self) -> None:
         self.recipe = _macro_with_no_else_and_downstream()
-        self.macro = constructors.recipe2node(self.recipe, "macro")
+        self.macro = constructors.atomictype2node(self.recipe, "macro")
         # cond = add(1, -1) = 0 (falsy); no else → if_0.out stays NOT_DATA.
         self.run = self.macro.run(x=1, y=-1)
 

--- a/tests/unit/test_std.py
+++ b/tests/unit/test_std.py
@@ -31,217 +31,217 @@ class _Mat:
 class TestStdExecution(unittest.TestCase):
 
     def test_abs(self):
-        n = constructors.recipe2node(fr.std.abs.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.abs.flowrep_recipe)
         self.assertEqual(3, n.run(a=-3).outputs.absolute)
 
     def test_add(self):
-        n = constructors.recipe2node(fr.std.add.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.add.flowrep_recipe)
         self.assertEqual(3, n.run(a=1, b=2).outputs.added)
 
     def test_index(self):
-        n = constructors.recipe2node(fr.std.index.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.index.flowrep_recipe)
         self.assertEqual(5, n.run(a=5).outputs.index)
 
     def test_inv(self):
-        n = constructors.recipe2node(fr.std.inv.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.inv.flowrep_recipe)
         self.assertEqual(-1, n.run(a=0).outputs.inverted)
 
     def test_invert(self):
-        n = constructors.recipe2node(fr.std.invert.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.invert.flowrep_recipe)
         self.assertEqual(-1, n.run(a=0).outputs.inverted)
 
     def test_neg(self):
-        n = constructors.recipe2node(fr.std.neg.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.neg.flowrep_recipe)
         self.assertEqual(-2, n.run(a=2).outputs.negative)
 
     def test_pos(self):
-        n = constructors.recipe2node(fr.std.pos.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.pos.flowrep_recipe)
         self.assertEqual(-2, n.run(a=-2).outputs.positive)
 
     def test_not_(self):
-        n = constructors.recipe2node(fr.std.not_.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.not_.flowrep_recipe)
         self.assertEqual(True, n.run(a=False).outputs.negated)
 
     def test_truth(self):
-        n = constructors.recipe2node(fr.std.truth.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.truth.flowrep_recipe)
         self.assertEqual(False, n.run(a=[]).outputs.truth)
 
     def test_length_hint(self):
-        n = constructors.recipe2node(fr.std.length_hint.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.length_hint.flowrep_recipe)
         self.assertEqual(3, n.run(obj=[1, 2, 3]).outputs.length)
 
     def test_sub(self):
-        n = constructors.recipe2node(fr.std.sub.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.sub.flowrep_recipe)
         self.assertEqual(3, n.run(a=5, b=2).outputs.difference)
 
     def test_isub(self):
-        n = constructors.recipe2node(fr.std.isub.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.isub.flowrep_recipe)
         self.assertEqual(3, n.run(a=5, b=2).outputs.difference)
 
     def test_iadd(self):
-        n = constructors.recipe2node(fr.std.iadd.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.iadd.flowrep_recipe)
         self.assertEqual(3, n.run(a=1, b=2).outputs.added)
 
     def test_mul(self):
-        n = constructors.recipe2node(fr.std.mul.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.mul.flowrep_recipe)
         self.assertEqual(6, n.run(a=2, b=3).outputs.product)
 
     def test_imul(self):
-        n = constructors.recipe2node(fr.std.imul.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.imul.flowrep_recipe)
         self.assertEqual(6, n.run(a=2, b=3).outputs.product)
 
     def test_floordiv(self):
-        n = constructors.recipe2node(fr.std.floordiv.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.floordiv.flowrep_recipe)
         self.assertEqual(3, n.run(a=7, b=2).outputs.quotient)
 
     def test_ifloordiv(self):
-        n = constructors.recipe2node(fr.std.ifloordiv.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.ifloordiv.flowrep_recipe)
         self.assertEqual(3, n.run(a=7, b=2).outputs.quotient)
 
     def test_truediv(self):
-        n = constructors.recipe2node(fr.std.truediv.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.truediv.flowrep_recipe)
         self.assertEqual(3.0, n.run(a=6, b=2).outputs.quotient)
 
     def test_itruediv(self):
-        n = constructors.recipe2node(fr.std.itruediv.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.itruediv.flowrep_recipe)
         self.assertEqual(3.0, n.run(a=6, b=2).outputs.quotient)
 
     def test_mod(self):
-        n = constructors.recipe2node(fr.std.mod.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.mod.flowrep_recipe)
         self.assertEqual(1, n.run(a=7, b=3).outputs.remainder)
 
     def test_imod(self):
-        n = constructors.recipe2node(fr.std.imod.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.imod.flowrep_recipe)
         self.assertEqual(1, n.run(a=7, b=3).outputs.remainder)
 
     def test_pow(self):
-        n = constructors.recipe2node(fr.std.pow.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.pow.flowrep_recipe)
         self.assertEqual(8, n.run(a=2, b=3).outputs.power)
 
     def test_ipow(self):
-        n = constructors.recipe2node(fr.std.ipow.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.ipow.flowrep_recipe)
         self.assertEqual(8, n.run(a=2, b=3).outputs.power)
 
     def test_and_(self):
-        n = constructors.recipe2node(fr.std.and_.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.and_.flowrep_recipe)
         self.assertEqual(2, n.run(a=6, b=3).outputs.conjunction)
 
     def test_iand(self):
-        n = constructors.recipe2node(fr.std.iand.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.iand.flowrep_recipe)
         self.assertEqual(2, n.run(a=6, b=3).outputs.conjunction)
 
     def test_or_(self):
-        n = constructors.recipe2node(fr.std.or_.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.or_.flowrep_recipe)
         self.assertEqual(7, n.run(a=6, b=1).outputs.disjunction)
 
     def test_ior(self):
-        n = constructors.recipe2node(fr.std.ior.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.ior.flowrep_recipe)
         self.assertEqual(7, n.run(a=6, b=1).outputs.disjunction)
 
     def test_xor(self):
-        n = constructors.recipe2node(fr.std.xor.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.xor.flowrep_recipe)
         self.assertEqual(5, n.run(a=6, b=3).outputs.exclusive_or)
 
     def test_ixor(self):
-        n = constructors.recipe2node(fr.std.ixor.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.ixor.flowrep_recipe)
         self.assertEqual(5, n.run(a=6, b=3).outputs.exclusive_or)
 
     def test_lshift(self):
-        n = constructors.recipe2node(fr.std.lshift.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.lshift.flowrep_recipe)
         self.assertEqual(8, n.run(a=1, b=3).outputs.left_shifted)
 
     def test_ilshift(self):
-        n = constructors.recipe2node(fr.std.ilshift.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.ilshift.flowrep_recipe)
         self.assertEqual(8, n.run(a=1, b=3).outputs.left_shifted)
 
     def test_rshift(self):
-        n = constructors.recipe2node(fr.std.rshift.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.rshift.flowrep_recipe)
         self.assertEqual(2, n.run(a=8, b=2).outputs.right_shifted)
 
     def test_irshift(self):
-        n = constructors.recipe2node(fr.std.irshift.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.irshift.flowrep_recipe)
         self.assertEqual(2, n.run(a=8, b=2).outputs.right_shifted)
 
     def test_matmul(self):
-        n = constructors.recipe2node(fr.std.matmul.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.matmul.flowrep_recipe)
         result = n.run(a=_Mat(1), b=_Mat(2)).outputs.matrix_product
         self.assertEqual(("mm", 1, 2), result)
 
     def test_imatmul(self):
-        n = constructors.recipe2node(fr.std.imatmul.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.imatmul.flowrep_recipe)
         result = n.run(a=_Mat(1), b=_Mat(2)).outputs.matrix_product
         self.assertEqual(("imm", 1, 2), result)
 
     def test_eq(self):
-        n = constructors.recipe2node(fr.std.eq.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.eq.flowrep_recipe)
         self.assertEqual(True, n.run(a=1, b=1).outputs.equal)
 
     def test_ne(self):
-        n = constructors.recipe2node(fr.std.ne.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.ne.flowrep_recipe)
         self.assertEqual(True, n.run(a=1, b=2).outputs.not_equal)
 
     def test_lt(self):
-        n = constructors.recipe2node(fr.std.lt.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.lt.flowrep_recipe)
         self.assertEqual(True, n.run(a=1, b=2).outputs.less)
 
     def test_le(self):
-        n = constructors.recipe2node(fr.std.le.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.le.flowrep_recipe)
         self.assertEqual(True, n.run(a=2, b=2).outputs.less_equal)
 
     def test_gt(self):
-        n = constructors.recipe2node(fr.std.gt.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.gt.flowrep_recipe)
         self.assertEqual(True, n.run(a=2, b=1).outputs.greater)
 
     def test_ge(self):
-        n = constructors.recipe2node(fr.std.ge.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.ge.flowrep_recipe)
         self.assertEqual(True, n.run(a=2, b=2).outputs.greater_equal)
 
     def test_is_(self):
-        n = constructors.recipe2node(fr.std.is_.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.is_.flowrep_recipe)
         self.assertEqual(True, n.run(a=None, b=None).outputs.identical)
 
     def test_is_not(self):
-        n = constructors.recipe2node(fr.std.is_not.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.is_not.flowrep_recipe)
         self.assertEqual(True, n.run(a=1, b=2).outputs.not_identical)
 
     def test_contains(self):
-        n = constructors.recipe2node(fr.std.contains.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.contains.flowrep_recipe)
         self.assertEqual(True, n.run(a=[1, 2, 3], b=2).outputs.contains)
 
     def test_countOf(self):
-        n = constructors.recipe2node(fr.std.countOf.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.countOf.flowrep_recipe)
         self.assertEqual(2, n.run(a=[1, 2, 2, 3], b=2).outputs.count)
 
     def test_indexOf(self):
-        n = constructors.recipe2node(fr.std.indexOf.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.indexOf.flowrep_recipe)
         self.assertEqual(2, n.run(a=[1, 2, 3], b=3).outputs.index)
 
     def test_concat(self):
-        n = constructors.recipe2node(fr.std.concat.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.concat.flowrep_recipe)
         self.assertEqual([1, 2], n.run(a=[1], b=[2]).outputs.concatenated)
 
     def test_iconcat(self):
-        n = constructors.recipe2node(fr.std.iconcat.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.iconcat.flowrep_recipe)
         self.assertEqual([1, 2], n.run(a=[1], b=[2]).outputs.concatenated)
 
     def test_getitem(self):
-        n = constructors.recipe2node(fr.std.getitem.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.getitem.flowrep_recipe)
         self.assertEqual(20, n.run(a=[10, 20], b=1).outputs.item)
 
     def test_setitem(self):
         d = {}
-        n = constructors.recipe2node(fr.std.setitem.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.setitem.flowrep_recipe)
         n.run(a=d, b="k", c=1)
         self.assertEqual(1, d["k"])
 
     def test_delitem(self):
         d = {"k": 1}
-        n = constructors.recipe2node(fr.std.delitem.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.delitem.flowrep_recipe)
         n.run(a=d, b="k")
         self.assertNotIn("k", d)
 
     def test_call(self):
-        n = constructors.recipe2node(fr.std.call.flowrep_recipe)
+        n = constructors.atomictype2node(fr.std.call.flowrep_recipe)
         with self.subTest("no variadics"):
             self.assertEqual(42, n.run(obj=_return_42).outputs.result)
         with self.subTest("args"):


### PR DESCRIPTION
`pyiron_workflow.node(...)` now gracefully handles

```python
NodeLike: TypeAlias = (
    datatypes.Node | RecipeOptions | types.FunctionType | type | fr.schemas.JSONABLE
)
```

And it is a true constructor, so if you pass a `pyiron_workflow.schemas.Node` in, you get a _copy_ back out.

I renamed the `function2node` to reflect the fact that flowrep now lets us use it on types too.