### PR TITLE
Disallow positional connection arguments

### DIFF
--- a/src/pyiron_workflow/atomic_node.py
+++ b/src/pyiron_workflow/atomic_node.py
@@ -16,10 +16,9 @@ class Atomic(datatypes.StaticNode[fr.schemas.AtomicRecipe, fr.schemas.AtomicData
         recipe: fr.schemas.AtomicRecipe,
         label: fr.schemas.Label,
         /,
-        *positional_connections: datatypes.Port | datatypes.Node,
-        **keyword_connections: datatypes.Port | datatypes.Node,
+        **connections: datatypes.Port | datatypes.Node,
     ):
-        super().__init__(recipe, label, *positional_connections, **keyword_connections)
+        super().__init__(recipe, label, **connections)
         func = retrieve.import_from_string(recipe.fully_qualified_name)
         self._function_metadata = getattr(func, "_semantikon_metadata", None)
 

--- a/src/pyiron_workflow/datatypes.py
+++ b/src/pyiron_workflow/datatypes.py
@@ -382,8 +382,7 @@ class StaticNode(Node[RecipeType, execution.ResultType], abc.ABC):
         recipe: RecipeType,
         label: fr.schemas.Label,
         /,
-        *positional_connections: Port | Node,
-        **keyword_connections: Port | Node,
+        **connections: Port | Node,
     ):
         self._label = label  # TODO: also accept None and use function name for default
         self._owner = None
@@ -396,7 +395,7 @@ class StaticNode(Node[RecipeType, execution.ResultType], abc.ABC):
 
         self.executor = None
         self.last_run = None
-        self.connect_input(*positional_connections, **keyword_connections)
+        self.connect_input(**connections)
 
     @property
     def inputs(self) -> PortMap[InputPort, Node]:
@@ -547,10 +546,9 @@ class StaticGraph(StaticNode[RecipeType, execution.ResultType], Graph, abc.ABC):
         recipe: RecipeType,
         label: fr.schemas.Label,
         /,
-        *positional_connections: Port | Node,
-        **keyword_connections: Port | Node,
+        **connections: Port | Node,
     ):
-        super().__init__(recipe, label, *positional_connections, **keyword_connections)
+        super().__init__(recipe, label, **connections)
         self._nodes = self._build_nodes(recipe)
         self._edges = self._build_edges(recipe)
 

--- a/src/pyiron_workflow/datatypes.py
+++ b/src/pyiron_workflow/datatypes.py
@@ -267,20 +267,19 @@ class Node(
     def _copy_data(from_: Node, to_: Node, /) -> None:
         to_.executor = from_.executor
 
-    def __call__(self, *args: Port | Node, **kwargs: Port | Node) -> Self:
-        self.connect_input(*args, **kwargs)
+    def __call__(self, **kwargs: Port | Node) -> Self:
+        self.connect_input(**kwargs)
         return self
 
-    def connect_input(self, *args: Port | Node, **kwargs: Port | Node) -> None:
+    def connect_input(self, **kwargs: Port | Node) -> None:
         """
         A syntactic shortcut for adding new edges feeding this node on the owning graph.
 
         If this node does not yet have an owner, caches these edges for later use with
         :meth:`apply_pending_connections`.
         """
-        connections = dict(zip(self.inputs.keys(), args, strict=False))
-        connections.update(kwargs)
-        for k, v in connections.items():
+        connections: dict[str, Port] = {}
+        for k, v in kwargs.items():
             connections[k] = coerce_to_port(v)
         self._pending_connections.update(connections)
         if isinstance(self._owner, MutableDag):

--- a/src/pyiron_workflow/injection.py
+++ b/src/pyiron_workflow/injection.py
@@ -339,7 +339,12 @@ def _build_operation(
         else label
     )
     operation_node = Atomic(operation.flowrep_recipe, label)
-    operation_node.connect_input(*[s._injection.port for s in sources])
+    operation_node.connect_input(
+        **{
+            label: s._injection.port
+            for label, s in zip(operation_node.inputs, sources, strict=False)
+        }
+    )
 
     return operation_node
 
@@ -417,6 +422,8 @@ def _build_injection_graph(
                 "reachable."
             )
 
-    operation_node.connect_input(*negotiated_source_ports)
+    operation_node.connect_input(
+        **dict(zip(operation_node.inputs, negotiated_source_ports, strict=False))
+    )
 
     return graph

--- a/src/pyiron_workflow/workflow_node.py
+++ b/src/pyiron_workflow/workflow_node.py
@@ -166,8 +166,7 @@ class Workflow(datatypes.MutableDag):
         label: fr.schemas.Label,
         undo_limit: int = 10,
         /,
-        *positional_connections: datatypes.Port | datatypes.Node,
-        **keyword_connections: datatypes.Port | datatypes.Node,
+        **connections: datatypes.Port | datatypes.Node,
     ):
         # Add a super call later if needed
         self._label = label
@@ -183,7 +182,7 @@ class Workflow(datatypes.MutableDag):
         self._diff_accumulator: actions.GraphDiff | None = None
         self.undo_stack = collections.deque(maxlen=undo_limit)
         self.redo_stack = collections.deque(maxlen=undo_limit)
-        self.connect_input(*positional_connections, **keyword_connections)
+        self.connect_input(**connections)
 
     def copy(
         self, new_label: fr.schemas.Label | None = None, _copy_to: Self | None = None

--- a/tests/unit/test_datatypes.py
+++ b/tests/unit/test_datatypes.py
@@ -355,21 +355,6 @@ class TestConnectAtInit(unittest.TestCase):
         self.assertIsNone(m.owner)
         self.assertEqual(set(m._pending_connections), {"x", "y"})
 
-    def test_positional_connection_zips_to_first_input(self):
-        # Positional connections at construction map onto input ports in order;
-        # the fixture's inputs are (x, y, z), so a lone positional lands on `x`.
-        src = _fixtures.atomic_add_node("src")
-        port = src.outputs["output_0"]
-        m = dag.Macro(_fixtures.macro.flowrep_recipe, "m", port)
-        self.assertIs(m._pending_connections["x"], port)
-
-    def test_positional_and_keyword_connections_combine(self):
-        src = _fixtures.atomic_add_node("src")
-        port = src.outputs["output_0"]
-        m = dag.Macro(_fixtures.macro.flowrep_recipe, "m", port, z=src)
-        self.assertIs(m._pending_connections["x"], port)
-        self.assertIs(m._pending_connections["z"], src.outputs["output_0"])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_injection.py
+++ b/tests/unit/test_injection.py
@@ -219,7 +219,7 @@ class TestPendingConnectionLifting(unittest.TestCase):
         # outer workflow that also owns n1.
         n1 = _new_node()
         n2 = _new_node()
-        n2(n1)  # connect_input: caches a pending connection on the free n2
+        n2(x=n1)  # connect_input: caches a pending connection on the free n2
         result = abs(n2)
         self.assertIsInstance(result, workflow_node.Workflow)
         # n2 is absorbed; result has a pending connection 'plain_increment_0_x' <- n1.output_0


### PR DESCRIPTION
When initializing a new node or calling an existing one; in both cases the underlying `.connect_input` method is used and no longer takes positional arguments. Kwargs still work fine.