### PR TITLE
:bug: rename constructors

### DIFF
--- a/src/pyiron_workflow/api/tools.py
+++ b/src/pyiron_workflow/api/tools.py
@@ -1,6 +1,6 @@
 from pyiron_workflow.constructors import atomictype2node as atomictype2node
-from pyiron_workflow.constructors import function2node as function2node
 from pyiron_workflow.constructors import node as node
+from pyiron_workflow.constructors import recipe2node as recipe2node
 from pyiron_workflow.execution import run as run
 from pyiron_workflow.executorlib import NodeSingleExecutor as NodeSingleExecutor
 from pyiron_workflow.executorlib import NodeSlurmExecutor as NodeSlurmExecutor

--- a/src/pyiron_workflow/constructors.py
+++ b/src/pyiron_workflow/constructors.py
@@ -48,9 +48,9 @@ def node(value: NodeLike, label: fr.schemas.Label | None = None, /) -> datatypes
     if isinstance(value, datatypes.Node):
         return value.copy(new_label=label)
     elif isinstance(value, RecipeOptions):
-        return atomictype2node(value, label)
+        return recipe2node(value, label)
     elif isinstance(value, type | types.FunctionType):
-        return function2node(value, label)
+        return atomictype2node(value, label)
     elif fr.tools.is_jsonable(value):
         return constant.Constant.from_value(value, label)
     else:
@@ -74,7 +74,7 @@ def _disallow_locals(obj: types.FunctionType | type) -> None:
         )
 
 
-def function2node(
+def atomictype2node(
     function: types.FunctionType | type,
     label: fr.schemas.Label | None = None,
     /,
@@ -99,7 +99,7 @@ def function2node(
         # flowrep-decorated functions are all either atomic or workflow recipes
         return cast(
             atomic_node.Atomic | dag.Macro,
-            atomictype2node(
+            recipe2node(
                 cast(fr.schemas.AtomicRecipe | fr.schemas.WorkflowRecipe, recipe),
                 label or function.__name__,
             ),
@@ -110,7 +110,7 @@ def function2node(
         return atomic_node.Atomic(recipe, label or function.__name__)
 
 
-def atomictype2node(
+def recipe2node(
     recipe: RecipeOptions, label: fr.schemas.Label | None = None, /
 ) -> datatypes.StaticNode:
     label = (
@@ -221,7 +221,7 @@ def workflow2macro(wf: workflow_node.Workflow) -> dag.Macro:
 def macro2workflow(macro: dag.Macro) -> workflow_node.Workflow:
     wf = workflow_node.Workflow(macro.label)
     for label, node_recipe in macro.recipe.nodes.items():
-        wf.add_node(atomictype2node(node_recipe, label))
+        wf.add_node(recipe2node(node_recipe, label))
 
     for port_creator, reference in (
         (wf.create_input, macro.inputs),

--- a/src/pyiron_workflow/dag.py
+++ b/src/pyiron_workflow/dag.py
@@ -24,7 +24,7 @@ class Macro(datatypes.ImmutableDag):
         return datatypes.NodeMap(
             self,
             {
-                node_label: constructors.atomictype2node(node_recipe, node_label)
+                node_label: constructors.recipe2node(node_recipe, node_label)
                 for node_label, node_recipe in recipe.nodes.items()
             },
         )

--- a/src/pyiron_workflow/flowcontrollers/forflow.py
+++ b/src/pyiron_workflow/flowcontrollers/forflow.py
@@ -25,7 +25,7 @@ class ForEach(datatypes.StaticGraph[fr.schemas.ForEachRecipe, fr.schemas.ForEach
         bn = self.recipe.body_node
         return datatypes.NodeMap(
             self,
-            {bn.label: constructors.atomictype2node(bn.recipe, bn.label)},
+            {bn.label: constructors.recipe2node(bn.recipe, bn.label)},
         )
 
     def _build_edges(self, recipe: fr.schemas.ForEachRecipe) -> datatypes.EdgeList:

--- a/src/pyiron_workflow/flowcontrollers/ifflow.py
+++ b/src/pyiron_workflow/flowcontrollers/ifflow.py
@@ -15,14 +15,14 @@ class If(datatypes.StaticGraph[fr.schemas.IfRecipe, fr.schemas.IfData]):
     def _build_nodes(self, recipe: fr.schemas.IfRecipe) -> datatypes.NodeMap:
         nodes: dict[fr.schemas.Label, datatypes.Node] = {}
         for case in recipe.cases:
-            nodes[case.condition.label] = constructors.atomictype2node(
+            nodes[case.condition.label] = constructors.recipe2node(
                 case.condition.recipe, case.condition.label
             )
-            nodes[case.body.label] = constructors.atomictype2node(
+            nodes[case.body.label] = constructors.recipe2node(
                 case.body.recipe, case.body.label
             )
         if recipe.else_case is not None:
-            nodes[recipe.else_case.label] = constructors.atomictype2node(
+            nodes[recipe.else_case.label] = constructors.recipe2node(
                 recipe.else_case.recipe, recipe.else_case.label
             )
         return datatypes.NodeMap(self, nodes)

--- a/src/pyiron_workflow/flowcontrollers/tryflow.py
+++ b/src/pyiron_workflow/flowcontrollers/tryflow.py
@@ -18,12 +18,12 @@ class Try(datatypes.StaticGraph[fr.schemas.TryRecipe, fr.schemas.TryData]):
 
     def _build_nodes(self, recipe: fr.schemas.TryRecipe) -> datatypes.NodeMap:
         nodes: dict[fr.schemas.Label, datatypes.Node] = {
-            recipe.try_node.label: constructors.atomictype2node(
+            recipe.try_node.label: constructors.recipe2node(
                 recipe.try_node.recipe, recipe.try_node.label
             )
         }
         for case in recipe.exception_cases:
-            nodes[case.body.label] = constructors.atomictype2node(
+            nodes[case.body.label] = constructors.recipe2node(
                 case.body.recipe, case.body.label
             )
         return datatypes.NodeMap(self, nodes)

--- a/src/pyiron_workflow/flowcontrollers/whileflow.py
+++ b/src/pyiron_workflow/flowcontrollers/whileflow.py
@@ -16,10 +16,10 @@ class While(datatypes.StaticGraph[fr.schemas.WhileRecipe, fr.schemas.WhileData])
         return datatypes.NodeMap(
             self,
             {
-                recipe.case.condition.label: constructors.atomictype2node(
+                recipe.case.condition.label: constructors.recipe2node(
                     recipe.case.condition.recipe, recipe.case.condition.label
                 ),
-                recipe.case.body.label: constructors.atomictype2node(
+                recipe.case.body.label: constructors.recipe2node(
                     recipe.case.body.recipe, recipe.case.body.label
                 ),
             },

--- a/tests/unit/_fixtures.py
+++ b/tests/unit/_fixtures.py
@@ -253,62 +253,62 @@ def for_wf(xs, ys, z):
 
 def atomic_add_node(label: str = "add"):
     """Return a fresh `Atomic` wrapping `add`."""
-    return wfms.tools.function2node(add, label)
+    return wfms.tools.atomictype2node(add, label)
 
 
 def atomic_sub_node(label: str = "sub"):
     """Return a fresh `Atomic` wrapping `sub`."""
-    return wfms.tools.function2node(sub, label)
+    return wfms.tools.atomictype2node(sub, label)
 
 
 def macro_node(label: str = "my_macro"):
     """Return a fresh `Macro` wrapping `macro`."""
-    return wfms.tools.function2node(macro, label)
+    return wfms.tools.atomictype2node(macro, label)
 
 
 def annotated_macro_node(label: str = "my_annotated_macro"):
     """Return a fresh `Macro` wrapping `annotated_macro`."""
-    return wfms.tools.function2node(annotated_macro, label)
+    return wfms.tools.atomictype2node(annotated_macro, label)
 
 
 def nested_macro_node(label: str = "my_nested_macro"):
     """Return a fresh `Macro` wrapping `nested_macro`."""
-    return wfms.tools.function2node(nested_macro, label)
+    return wfms.tools.atomictype2node(nested_macro, label)
 
 
 def passthrough_node(label: str = "my_passthrough"):
     """Return a fresh `Macro` wrapping `passthrough`."""
-    return wfms.tools.function2node(passthrough, label)
+    return wfms.tools.atomictype2node(passthrough, label)
 
 
 def container_node(label: str = "container"):
     """Return a fresh `Macro` wrapping `container`."""
-    return wfms.tools.function2node(container, label)
+    return wfms.tools.atomictype2node(container, label)
 
 
 def uses_constant_node(label: str = "uses_constant"):
     """Return a fresh `Macro` wrapping `uses_constant` (exploits a parsed constant)."""
-    return wfms.tools.function2node(uses_constant, label)
+    return wfms.tools.atomictype2node(uses_constant, label)
 
 
 def autoencoder_node(label: str = "autoencoder"):
     """Return a fresh `Macro` wrapping `autoencoder`."""
-    return wfms.tools.function2node(autoencoder, label)
+    return wfms.tools.atomictype2node(autoencoder, label)
 
 
 def multiply_with_defaults_node(label: str = "multiply_with_defaults"):
     """Return a fresh `Atomic` wrapping `multiply_with_defaults`."""
-    return wfms.tools.function2node(multiply_with_defaults, label)
+    return wfms.tools.atomictype2node(multiply_with_defaults, label)
 
 
 def typed_int_node(label: str = "typed_int"):
     """Return a fresh `Atomic` wrapping `typed_int` (input/output hinted `int`)."""
-    return wfms.tools.function2node(typed_int, label)
+    return wfms.tools.atomictype2node(typed_int, label)
 
 
 def typed_float_node(label: str = "typed_float"):
     """Return a fresh `Atomic` wrapping `typed_float` (input/output hinted `float`)."""
-    return wfms.tools.function2node(typed_float, label)
+    return wfms.tools.atomictype2node(typed_float, label)
 
 
 # --------------------------------------------------------------------------- #
@@ -367,7 +367,7 @@ def build_workflow(inputs=(), outputs=(), node_specs=None, edges=(), label="wf")
 
 def for_wf_node(label: str = "for_wf"):
     """Return a fresh `Macro` wrapping `for_wf`."""
-    return wfms.tools.function2node(for_wf, label)
+    return wfms.tools.atomictype2node(for_wf, label)
 
 
 def foreach_node(label: str = "fe"):
@@ -399,17 +399,17 @@ def foreach_node(label: str = "fe"):
 
 def if_abs_node(label: str = "if_abs"):
     """Return a fresh `Macro` wrapping `if_abs`."""
-    return wfms.tools.function2node(if_abs, label)
+    return wfms.tools.atomictype2node(if_abs, label)
 
 
 def while_countdown_node(label: str = "while_countdown"):
     """Return a fresh `Macro` wrapping `while_countdown`."""
-    return wfms.tools.function2node(while_countdown, label)
+    return wfms.tools.atomictype2node(while_countdown, label)
 
 
 def try_safe_divide_node(label: str = "try_safe_divide"):
     """Return a fresh `Macro` wrapping `try_safe_divide`."""
-    return wfms.tools.function2node(try_safe_divide, label)
+    return wfms.tools.atomictype2node(try_safe_divide, label)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_constructors.py
+++ b/tests/unit/test_constructors.py
@@ -227,34 +227,34 @@ class TestNode(unittest.TestCase):
 
 class TestFunction2Node(unittest.TestCase):
     def test_atomic_decorated_default_label(self) -> None:
-        n = constructors.function2node(_fixtures.add)
+        n = constructors.atomictype2node(_fixtures.add)
         self.assertIsInstance(n, atomic_node.Atomic)
         self.assertEqual(n.label, "add")
 
     def test_atomic_decorated_explicit_label(self) -> None:
-        n = constructors.function2node(_fixtures.add, "custom")
+        n = constructors.atomictype2node(_fixtures.add, "custom")
         self.assertIsInstance(n, atomic_node.Atomic)
         self.assertEqual(n.label, "custom")
 
     def test_workflow_decorated_default_label(self) -> None:
-        n = constructors.function2node(_fixtures.macro)
+        n = constructors.atomictype2node(_fixtures.macro)
         self.assertIsInstance(n, dag.Macro)
         self.assertEqual(n.label, "macro")
 
     def test_undecorated_function_parses_as_atomic(self) -> None:
-        n = constructors.function2node(plain_add)
+        n = constructors.atomictype2node(plain_add)
         self.assertIsInstance(n, atomic_node.Atomic)
         self.assertEqual(n.label, "plain_add")
 
     def test_decorated_class_default_label(self) -> None:
-        n = constructors.function2node(DecoratedClass)
+        n = constructors.atomictype2node(DecoratedClass)
         self.assertIsInstance(n, atomic_node.Atomic)
         self.assertEqual(n.label, "DecoratedClass")
         self.assertIs(n.recipe, DecoratedClass.flowrep_recipe)
 
     def test_undecorated_subclass_is_parsed_afresh(self) -> None:
         """An inherited recipe must be ignored, or the child would build its parent."""
-        n = constructors.function2node(PlainSubclass)
+        n = constructors.atomictype2node(PlainSubclass)
         self.assertIsNot(n.recipe, DecoratedClass.flowrep_recipe)
         self.assertTrue(
             n.recipe.reference.info.fully_qualified_name.endswith("PlainSubclass"),
@@ -267,7 +267,7 @@ class TestFunction2Node(unittest.TestCase):
         )
 
     def test_decorated_subclass_uses_its_own_recipe(self) -> None:
-        n = constructors.function2node(DecoratedSubclass)
+        n = constructors.atomictype2node(DecoratedSubclass)
         self.assertIs(n.recipe, DecoratedSubclass.flowrep_recipe)
         self.assertTrue(
             n.recipe.reference.info.fully_qualified_name.endswith("DecoratedSubclass"),
@@ -276,7 +276,7 @@ class TestFunction2Node(unittest.TestCase):
 
     def test_non_recipe_flowrep_attribute_raises(self) -> None:
         with self.assertRaisesRegex(TypeError, "not a 'NodeRecipe'"):
-            constructors.function2node(NotARecipeHolder)
+            constructors.atomictype2node(NotARecipeHolder)
 
 
 # --------------------------------------------------------------------------- #
@@ -287,41 +287,41 @@ class TestFunction2Node(unittest.TestCase):
 class TestRecipe2Node(unittest.TestCase):
     def test_atomic_recipe_returns_atomic(self) -> None:
         recipe = transformers.Transform1toN(2).recipe
-        n = constructors.atomictype2node(recipe)
+        n = constructors.recipe2node(recipe)
         self.assertIsInstance(n, atomic_node.Atomic)
 
     def test_label(self) -> None:
         recipe = transformers.Transform1toN(2).recipe
-        n = constructors.atomictype2node(recipe)
+        n = constructors.recipe2node(recipe)
         self.assertEqual(n.label, "atomic_recipe_node")
-        n = constructors.atomictype2node(recipe, "explicit_label")
+        n = constructors.recipe2node(recipe, "explicit_label")
         self.assertEqual(n.label, "explicit_label")
 
     def test_workflow_recipe_returns_macro(self) -> None:
         recipe = _fixtures.macro.flowrep_recipe
-        n = constructors.atomictype2node(recipe)
+        n = constructors.recipe2node(recipe)
         self.assertIsInstance(n, dag.Macro)
 
     def test_for_each_recipe_returns_for_each(self) -> None:
         recipe = _fixtures.for_wf.flowrep_recipe.nodes["for_each_0"]
-        n = constructors.atomictype2node(recipe)
+        n = constructors.recipe2node(recipe)
         self.assertIsInstance(n, flowcontrollers.ForEach)
 
     def test_if_recipe_returns_if(self) -> None:
-        n = constructors.atomictype2node(_if_recipe())
+        n = constructors.recipe2node(_if_recipe())
         self.assertIsInstance(n, flowcontrollers.If)
 
     def test_try_recipe_returns_try(self) -> None:
-        n = constructors.atomictype2node(_try_recipe())
+        n = constructors.recipe2node(_try_recipe())
         self.assertIsInstance(n, flowcontrollers.Try)
 
     def test_while_recipe_returns_while(self) -> None:
-        n = constructors.atomictype2node(_while_recipe())
+        n = constructors.recipe2node(_while_recipe())
         self.assertIsInstance(n, flowcontrollers.While)
 
     def test_unknown_recipe_type_raises_type_error(self) -> None:
         with self.assertRaises(TypeError) as ctx:
-            constructors.atomictype2node(object(), "x")  # type: ignore[arg-type]
+            constructors.recipe2node(object(), "x")  # type: ignore[arg-type]
         self.assertIn("Unknown recipe type", str(ctx.exception))
 
 

--- a/tests/unit/test_ifflow.py
+++ b/tests/unit/test_ifflow.py
@@ -275,7 +275,7 @@ class TestMacroDownstreamOfFalsyIfIsSkipped(unittest.TestCase):
 
     def setUp(self) -> None:
         self.recipe = _macro_with_no_else_and_downstream()
-        self.macro = constructors.atomictype2node(self.recipe, "macro")
+        self.macro = constructors.recipe2node(self.recipe, "macro")
         # cond = add(1, -1) = 0 (falsy); no else → if_0.out stays NOT_DATA.
         self.run = self.macro.run(x=1, y=-1)
 

--- a/tests/unit/test_std.py
+++ b/tests/unit/test_std.py
@@ -31,217 +31,217 @@ class _Mat:
 class TestStdExecution(unittest.TestCase):
 
     def test_abs(self):
-        n = constructors.atomictype2node(fr.std.abs.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.abs.flowrep_recipe)
         self.assertEqual(3, n.run(a=-3).outputs.absolute)
 
     def test_add(self):
-        n = constructors.atomictype2node(fr.std.add.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.add.flowrep_recipe)
         self.assertEqual(3, n.run(a=1, b=2).outputs.added)
 
     def test_index(self):
-        n = constructors.atomictype2node(fr.std.index.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.index.flowrep_recipe)
         self.assertEqual(5, n.run(a=5).outputs.index)
 
     def test_inv(self):
-        n = constructors.atomictype2node(fr.std.inv.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.inv.flowrep_recipe)
         self.assertEqual(-1, n.run(a=0).outputs.inverted)
 
     def test_invert(self):
-        n = constructors.atomictype2node(fr.std.invert.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.invert.flowrep_recipe)
         self.assertEqual(-1, n.run(a=0).outputs.inverted)
 
     def test_neg(self):
-        n = constructors.atomictype2node(fr.std.neg.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.neg.flowrep_recipe)
         self.assertEqual(-2, n.run(a=2).outputs.negative)
 
     def test_pos(self):
-        n = constructors.atomictype2node(fr.std.pos.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.pos.flowrep_recipe)
         self.assertEqual(-2, n.run(a=-2).outputs.positive)
 
     def test_not_(self):
-        n = constructors.atomictype2node(fr.std.not_.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.not_.flowrep_recipe)
         self.assertEqual(True, n.run(a=False).outputs.negated)
 
     def test_truth(self):
-        n = constructors.atomictype2node(fr.std.truth.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.truth.flowrep_recipe)
         self.assertEqual(False, n.run(a=[]).outputs.truth)
 
     def test_length_hint(self):
-        n = constructors.atomictype2node(fr.std.length_hint.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.length_hint.flowrep_recipe)
         self.assertEqual(3, n.run(obj=[1, 2, 3]).outputs.length)
 
     def test_sub(self):
-        n = constructors.atomictype2node(fr.std.sub.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.sub.flowrep_recipe)
         self.assertEqual(3, n.run(a=5, b=2).outputs.difference)
 
     def test_isub(self):
-        n = constructors.atomictype2node(fr.std.isub.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.isub.flowrep_recipe)
         self.assertEqual(3, n.run(a=5, b=2).outputs.difference)
 
     def test_iadd(self):
-        n = constructors.atomictype2node(fr.std.iadd.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.iadd.flowrep_recipe)
         self.assertEqual(3, n.run(a=1, b=2).outputs.added)
 
     def test_mul(self):
-        n = constructors.atomictype2node(fr.std.mul.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.mul.flowrep_recipe)
         self.assertEqual(6, n.run(a=2, b=3).outputs.product)
 
     def test_imul(self):
-        n = constructors.atomictype2node(fr.std.imul.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.imul.flowrep_recipe)
         self.assertEqual(6, n.run(a=2, b=3).outputs.product)
 
     def test_floordiv(self):
-        n = constructors.atomictype2node(fr.std.floordiv.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.floordiv.flowrep_recipe)
         self.assertEqual(3, n.run(a=7, b=2).outputs.quotient)
 
     def test_ifloordiv(self):
-        n = constructors.atomictype2node(fr.std.ifloordiv.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.ifloordiv.flowrep_recipe)
         self.assertEqual(3, n.run(a=7, b=2).outputs.quotient)
 
     def test_truediv(self):
-        n = constructors.atomictype2node(fr.std.truediv.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.truediv.flowrep_recipe)
         self.assertEqual(3.0, n.run(a=6, b=2).outputs.quotient)
 
     def test_itruediv(self):
-        n = constructors.atomictype2node(fr.std.itruediv.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.itruediv.flowrep_recipe)
         self.assertEqual(3.0, n.run(a=6, b=2).outputs.quotient)
 
     def test_mod(self):
-        n = constructors.atomictype2node(fr.std.mod.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.mod.flowrep_recipe)
         self.assertEqual(1, n.run(a=7, b=3).outputs.remainder)
 
     def test_imod(self):
-        n = constructors.atomictype2node(fr.std.imod.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.imod.flowrep_recipe)
         self.assertEqual(1, n.run(a=7, b=3).outputs.remainder)
 
     def test_pow(self):
-        n = constructors.atomictype2node(fr.std.pow.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.pow.flowrep_recipe)
         self.assertEqual(8, n.run(a=2, b=3).outputs.power)
 
     def test_ipow(self):
-        n = constructors.atomictype2node(fr.std.ipow.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.ipow.flowrep_recipe)
         self.assertEqual(8, n.run(a=2, b=3).outputs.power)
 
     def test_and_(self):
-        n = constructors.atomictype2node(fr.std.and_.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.and_.flowrep_recipe)
         self.assertEqual(2, n.run(a=6, b=3).outputs.conjunction)
 
     def test_iand(self):
-        n = constructors.atomictype2node(fr.std.iand.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.iand.flowrep_recipe)
         self.assertEqual(2, n.run(a=6, b=3).outputs.conjunction)
 
     def test_or_(self):
-        n = constructors.atomictype2node(fr.std.or_.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.or_.flowrep_recipe)
         self.assertEqual(7, n.run(a=6, b=1).outputs.disjunction)
 
     def test_ior(self):
-        n = constructors.atomictype2node(fr.std.ior.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.ior.flowrep_recipe)
         self.assertEqual(7, n.run(a=6, b=1).outputs.disjunction)
 
     def test_xor(self):
-        n = constructors.atomictype2node(fr.std.xor.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.xor.flowrep_recipe)
         self.assertEqual(5, n.run(a=6, b=3).outputs.exclusive_or)
 
     def test_ixor(self):
-        n = constructors.atomictype2node(fr.std.ixor.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.ixor.flowrep_recipe)
         self.assertEqual(5, n.run(a=6, b=3).outputs.exclusive_or)
 
     def test_lshift(self):
-        n = constructors.atomictype2node(fr.std.lshift.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.lshift.flowrep_recipe)
         self.assertEqual(8, n.run(a=1, b=3).outputs.left_shifted)
 
     def test_ilshift(self):
-        n = constructors.atomictype2node(fr.std.ilshift.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.ilshift.flowrep_recipe)
         self.assertEqual(8, n.run(a=1, b=3).outputs.left_shifted)
 
     def test_rshift(self):
-        n = constructors.atomictype2node(fr.std.rshift.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.rshift.flowrep_recipe)
         self.assertEqual(2, n.run(a=8, b=2).outputs.right_shifted)
 
     def test_irshift(self):
-        n = constructors.atomictype2node(fr.std.irshift.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.irshift.flowrep_recipe)
         self.assertEqual(2, n.run(a=8, b=2).outputs.right_shifted)
 
     def test_matmul(self):
-        n = constructors.atomictype2node(fr.std.matmul.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.matmul.flowrep_recipe)
         result = n.run(a=_Mat(1), b=_Mat(2)).outputs.matrix_product
         self.assertEqual(("mm", 1, 2), result)
 
     def test_imatmul(self):
-        n = constructors.atomictype2node(fr.std.imatmul.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.imatmul.flowrep_recipe)
         result = n.run(a=_Mat(1), b=_Mat(2)).outputs.matrix_product
         self.assertEqual(("imm", 1, 2), result)
 
     def test_eq(self):
-        n = constructors.atomictype2node(fr.std.eq.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.eq.flowrep_recipe)
         self.assertEqual(True, n.run(a=1, b=1).outputs.equal)
 
     def test_ne(self):
-        n = constructors.atomictype2node(fr.std.ne.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.ne.flowrep_recipe)
         self.assertEqual(True, n.run(a=1, b=2).outputs.not_equal)
 
     def test_lt(self):
-        n = constructors.atomictype2node(fr.std.lt.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.lt.flowrep_recipe)
         self.assertEqual(True, n.run(a=1, b=2).outputs.less)
 
     def test_le(self):
-        n = constructors.atomictype2node(fr.std.le.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.le.flowrep_recipe)
         self.assertEqual(True, n.run(a=2, b=2).outputs.less_equal)
 
     def test_gt(self):
-        n = constructors.atomictype2node(fr.std.gt.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.gt.flowrep_recipe)
         self.assertEqual(True, n.run(a=2, b=1).outputs.greater)
 
     def test_ge(self):
-        n = constructors.atomictype2node(fr.std.ge.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.ge.flowrep_recipe)
         self.assertEqual(True, n.run(a=2, b=2).outputs.greater_equal)
 
     def test_is_(self):
-        n = constructors.atomictype2node(fr.std.is_.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.is_.flowrep_recipe)
         self.assertEqual(True, n.run(a=None, b=None).outputs.identical)
 
     def test_is_not(self):
-        n = constructors.atomictype2node(fr.std.is_not.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.is_not.flowrep_recipe)
         self.assertEqual(True, n.run(a=1, b=2).outputs.not_identical)
 
     def test_contains(self):
-        n = constructors.atomictype2node(fr.std.contains.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.contains.flowrep_recipe)
         self.assertEqual(True, n.run(a=[1, 2, 3], b=2).outputs.contains)
 
     def test_countOf(self):
-        n = constructors.atomictype2node(fr.std.countOf.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.countOf.flowrep_recipe)
         self.assertEqual(2, n.run(a=[1, 2, 2, 3], b=2).outputs.count)
 
     def test_indexOf(self):
-        n = constructors.atomictype2node(fr.std.indexOf.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.indexOf.flowrep_recipe)
         self.assertEqual(2, n.run(a=[1, 2, 3], b=3).outputs.index)
 
     def test_concat(self):
-        n = constructors.atomictype2node(fr.std.concat.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.concat.flowrep_recipe)
         self.assertEqual([1, 2], n.run(a=[1], b=[2]).outputs.concatenated)
 
     def test_iconcat(self):
-        n = constructors.atomictype2node(fr.std.iconcat.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.iconcat.flowrep_recipe)
         self.assertEqual([1, 2], n.run(a=[1], b=[2]).outputs.concatenated)
 
     def test_getitem(self):
-        n = constructors.atomictype2node(fr.std.getitem.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.getitem.flowrep_recipe)
         self.assertEqual(20, n.run(a=[10, 20], b=1).outputs.item)
 
     def test_setitem(self):
         d = {}
-        n = constructors.atomictype2node(fr.std.setitem.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.setitem.flowrep_recipe)
         n.run(a=d, b="k", c=1)
         self.assertEqual(1, d["k"])
 
     def test_delitem(self):
         d = {"k": 1}
-        n = constructors.atomictype2node(fr.std.delitem.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.delitem.flowrep_recipe)
         n.run(a=d, b="k")
         self.assertNotIn("k", d)
 
     def test_call(self):
-        n = constructors.atomictype2node(fr.std.call.flowrep_recipe)
+        n = constructors.recipe2node(fr.std.call.flowrep_recipe)
         with self.subTest("no variadics"):
             self.assertEqual(42, n.run(obj=_return_42).outputs.result)
         with self.subTest("args"):


### PR DESCRIPTION
I did sloppy editing during a previous re-name, these names were flat-out wrong. The fix is easy, and thankfully they're second tier constructors burried inside the tools namespace, but still.