### PR TITLE
Constant injection

### DIFF
--- a/notebooks/user_guide.ipynb
+++ b/notebooks/user_guide.ipynb
@@ -2272,7 +2272,7 @@
    "source": [
     "try:\n",
     "    # try to rewire a child of the locked macro\n",
-    "    wf.grp.scale.connect_input(x=wf.grp.inputs.shift__y)\n",
+    "    wf.grp.scale(x=wf.grp.inputs.shift__y)\n",
     "except TypeError as error:\n",
     "    print(\"blocked: \", error)"
    ],

--- a/src/pyiron_workflow/atomic_node.py
+++ b/src/pyiron_workflow/atomic_node.py
@@ -16,7 +16,7 @@ class Atomic(datatypes.StaticNode[fr.schemas.AtomicRecipe, fr.schemas.AtomicData
         recipe: fr.schemas.AtomicRecipe,
         label: fr.schemas.Label | None = None,
         /,
-        **connections: datatypes.Port | datatypes.Node,
+        **connections: datatypes.Port | datatypes.Node | fr.schemas.JSONABLE,
     ):
         super().__init__(recipe, label, **connections)
         func = retrieve.import_from_string(recipe.fully_qualified_name)

--- a/src/pyiron_workflow/constructors.py
+++ b/src/pyiron_workflow/constructors.py
@@ -36,7 +36,7 @@ def node(
     value: NodeLike,
     label: fr.schemas.Label | None = None,
     /,
-    **connections: datatypes.Port | datatypes.Node,
+    **connections: datatypes.Port | datatypes.Node | fr.schemas.JSONABLE,
 ) -> datatypes.Node:
     """
     Convert a node-like `value` into a `Node` labelled `label`.
@@ -52,7 +52,7 @@ def node(
     """
     if isinstance(value, datatypes.Node):
         copied = value.copy(label)
-        copied.connect_input(**connections)
+        copied.establish_sources(**connections)
         return copied
     elif isinstance(value, RecipeOptions):
         return recipe2node(value, label, **connections)
@@ -91,7 +91,7 @@ def atomictype2node(
     function: types.FunctionType | type,
     label: fr.schemas.Label | None = None,
     /,
-    **connections: datatypes.Port | datatypes.Node,
+    **connections: datatypes.Port | datatypes.Node | fr.schemas.JSONABLE,
 ) -> atomic_node.Atomic | dag.Macro:
     """
     Convert a function or class into a node labelled `label` (defaulting to its
@@ -129,7 +129,7 @@ def recipe2node(
     recipe: RecipeOptions,
     label: fr.schemas.Label | None = None,
     /,
-    **connections: datatypes.Port | datatypes.Node,
+    **connections: datatypes.Port | datatypes.Node | fr.schemas.JSONABLE,
 ) -> datatypes.StaticNode:
     label = (
         f"{_pascal_to_snake(recipe.__class__.__name__)}_node"

--- a/src/pyiron_workflow/constructors.py
+++ b/src/pyiron_workflow/constructors.py
@@ -52,7 +52,7 @@ def node(
     """
     if isinstance(value, datatypes.Node):
         copied = value.copy(label)
-        copied.establish_sources(**connections)
+        copied._establish_sources(**connections)
         return copied
     elif isinstance(value, RecipeOptions):
         return recipe2node(value, label, **connections)

--- a/src/pyiron_workflow/datatypes.py
+++ b/src/pyiron_workflow/datatypes.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import abc
+import contextlib
 import dataclasses
-from collections.abc import Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from concurrent import futures
 from typing import (
     TYPE_CHECKING,
@@ -149,6 +150,7 @@ class Node(
     _owner: Graph | None
     _detached_root: lexical.LexicalPath | None
     _pending_connections: dict[str, Port]
+    _pending_constants: dict[fr.schemas.Label, fr.schemas.JSONABLE]
     executor: futures.Executor | execution.ExecutorInstructions | None
     last_run: execution.Run[execution.ResultType] | None
 
@@ -267,9 +269,80 @@ class Node(
     def _copy_data(from_: Node, to_: Node, /) -> None:
         to_.executor = from_.executor
 
-    def __call__(self, **kwargs: Port | Node) -> Self:
-        self.connect_input(**kwargs)
+    def __call__(self, **kwargs: Port | Node | fr.schemas.JSONABLE) -> Self:
+        self.establish_sources(**kwargs)
         return self
+
+    @contextlib.contextmanager
+    def _pending_state_restored_on_error(self) -> Iterator[None]:
+        """
+        Restore both pending stores if the body raises.
+
+        Pending state is drained or written before the operations that can fail
+        (validation, edge resolution). :func:`workflow_node._undoable` rolls the
+        *graph* back on failure; this keeps the node's own state in step, so a node
+        that failed to be realized stays reusable rather than silently losing its
+        sources.
+
+        Nesting is safe: each level restores to its own snapshot, so the outermost
+        wins and the net result is the state from before the outermost call.
+        """
+        constants = dict(self._pending_constants)
+        connections = dict(self._pending_connections)
+        try:
+            yield
+        except Exception:
+            self._pending_constants.clear()
+            self._pending_constants.update(constants)
+            self._pending_connections.clear()
+            self._pending_connections.update(connections)
+            raise
+
+    def establish_sources(self, **kwargs: Port | Node | fr.schemas.JSONABLE) -> None:
+        """
+        Register the sources feeding this node's inputs.
+
+        :class:`Port` and :class:`Node` values become edges; JSONable values become
+        :class:`~pyiron_workflow.constant.Constant` sibling nodes. Both are deferred
+        until this node has a mutable owner.
+        """
+        self._reject_unknown_targets(kwargs.keys())
+        connections: dict[fr.schemas.Label, Port | Node] = {}
+        constants: dict[fr.schemas.Label, fr.schemas.JSONABLE] = {}
+        for k, v in kwargs.items():
+            if isinstance(v, Port | Node):
+                connections[k] = v
+            elif fr.tools.is_jsonable(v):
+                constants[k] = v
+            else:
+                raise TypeError(
+                    f"Cannot use {v!r} as the source for input {k!r} of "
+                    f"{self.lexical_path!r}: expected a {Port.__name__}, a "
+                    f"{Node.__name__}, or a JSONable constant."
+                )
+        with self._pending_state_restored_on_error():
+            self._pending_constants.update(constants)
+            self.connect_input(**connections)
+
+    def take_pending_constants(self) -> dict[fr.schemas.Label, fr.schemas.JSONABLE]:
+        """
+        Return a copy of the pending constants and clear them.
+
+        Unlike :meth:`use_pending_edges` this imposes no owner requirement; the caller
+        (a mutable graph realizing this node) is responsible for materializing them.
+        """
+        taken = dict(self._pending_constants)
+        self._pending_constants.clear()
+        return taken
+
+    def _reject_unknown_targets(self, labels: Iterable[fr.schemas.Label]) -> None:
+        """Raise for any label that is not currently one of this node's input ports."""
+        unknown = [label for label in labels if label not in self.inputs]
+        if unknown:
+            raise ValueError(
+                f"{self.lexical_path!r} has no input port(s) {unknown!r}. "
+                f"Available: {list(self.inputs.keys())}"
+            )
 
     def connect_input(self, **kwargs: Port | Node) -> None:
         """
@@ -278,14 +351,16 @@ class Node(
         If this node does not yet have an owner, caches these edges for later use with
         :meth:`apply_pending_connections`.
         """
+        self._reject_unknown_targets(kwargs.keys())
         connections: dict[str, Port] = {}
         for k, v in kwargs.items():
             connections[k] = coerce_to_port(v)
-        self._pending_connections.update(connections)
-        if isinstance(self._owner, MutableDag):
-            self._owner.add_edge(*self.use_pending_edges())
-        elif self._owner is not None:
-            raise self._mutable_owner_error()
+        with self._pending_state_restored_on_error():
+            self._pending_connections.update(connections)
+            if isinstance(self._owner, MutableDag):
+                self._owner.realize_pending(self)
+            elif self._owner is not None:
+                raise self._mutable_owner_error()
 
     def use_pending_edges(self) -> EdgeList:
         """
@@ -381,12 +456,13 @@ class StaticNode(Node[RecipeType, execution.ResultType], abc.ABC):
         recipe: RecipeType,
         label: fr.schemas.Label | None = None,
         /,
-        **connections: Port | Node,
+        **connections: Port | Node | fr.schemas.JSONABLE,
     ):
         self._label = label or self.__class__.__name__.lower()
         self._owner = None
         self._detached_root = None
         self._pending_connections = {}
+        self._pending_constants = {}
         self._recipe = recipe
         live_preview = self.generate_flowrep_live_node()
         self._inputs = self._build_inputs(live_preview)
@@ -394,7 +470,7 @@ class StaticNode(Node[RecipeType, execution.ResultType], abc.ABC):
 
         self.executor = None
         self.last_run = None
-        self.connect_input(**connections)
+        self.establish_sources(**connections)
 
     @property
     def inputs(self) -> PortMap[InputPort, Node]:
@@ -545,7 +621,7 @@ class StaticGraph(StaticNode[RecipeType, execution.ResultType], Graph, abc.ABC):
         recipe: RecipeType,
         label: fr.schemas.Label | None = None,
         /,
-        **connections: Port | Node,
+        **connections: Port | Node | fr.schemas.JSONABLE,
     ):
         super().__init__(recipe, label, **connections)
         self._nodes = self._build_nodes(recipe)
@@ -632,6 +708,13 @@ class MutableDag(Node[fr.schemas.WorkflowRecipe, fr.schemas.DagData], Graph, abc
 
     @abc.abstractmethod
     def add_node(self, *nodes: Node) -> None: ...
+
+    @abc.abstractmethod
+    def realize_pending(self, node: Node) -> None:
+        """
+        Materialize `node`'s pending constants as sibling nodes and draw down its
+        pending connections as edges.
+        """
 
     @abc.abstractmethod
     def remove_node(self, *nodes: Node | fr.schemas.Label) -> None: ...

--- a/src/pyiron_workflow/datatypes.py
+++ b/src/pyiron_workflow/datatypes.py
@@ -270,7 +270,7 @@ class Node(
         to_.executor = from_.executor
 
     def __call__(self, **kwargs: Port | Node | fr.schemas.JSONABLE) -> Self:
-        self.establish_sources(**kwargs)
+        self._establish_sources(**kwargs)
         return self
 
     @contextlib.contextmanager
@@ -298,9 +298,12 @@ class Node(
             self._pending_connections.update(connections)
             raise
 
-    def establish_sources(self, **kwargs: Port | Node | fr.schemas.JSONABLE) -> None:
+    def _establish_sources(self, **kwargs: Port | Node | fr.schemas.JSONABLE) -> None:
         """
         Register the sources feeding this node's inputs.
+
+        Used in a "python public" sense that it gets called from outside the object,
+        but part of the plumbing and not intended to be part of the public API.
 
         :class:`Port` and :class:`Node` values become edges; JSONable values become
         :class:`~pyiron_workflow.constant.Constant` sibling nodes. Both are deferred
@@ -322,11 +325,14 @@ class Node(
                 )
         with self._pending_state_restored_on_error():
             self._pending_constants.update(constants)
-            self.connect_input(**connections)
+            self._connect_input(**connections)
 
-    def take_pending_constants(self) -> dict[fr.schemas.Label, fr.schemas.JSONABLE]:
+    def _take_pending_constants(self) -> dict[fr.schemas.Label, fr.schemas.JSONABLE]:
         """
         Return a copy of the pending constants and clear them.
+
+        Used in a "python public" sense that it gets called from outside the object,
+        but part of the plumbing and not intended to be part of the public API.
 
         Unlike :meth:`use_pending_edges` this imposes no owner requirement; the caller
         (a mutable graph realizing this node) is responsible for materializing them.
@@ -344,9 +350,12 @@ class Node(
                 f"Available: {list(self.inputs.keys())}"
             )
 
-    def connect_input(self, **kwargs: Port | Node) -> None:
+    def _connect_input(self, **kwargs: Port | Node) -> None:
         """
         A syntactic shortcut for adding new edges feeding this node on the owning graph.
+
+        Used in a "python public" sense that it gets called from outside the object,
+        but part of the plumbing and not intended to be part of the public API.
 
         If this node does not yet have an owner, caches these edges for later use with
         :meth:`apply_pending_connections`.
@@ -358,14 +367,17 @@ class Node(
         with self._pending_state_restored_on_error():
             self._pending_connections.update(connections)
             if isinstance(self._owner, MutableDag):
-                self._owner.realize_pending(self)
+                self._owner._realize_pending(self)
             elif self._owner is not None:
                 raise self._mutable_owner_error()
 
-    def use_pending_edges(self) -> EdgeList:
+    def _use_pending_edges(self) -> EdgeList:
         """
         Converts the internal pending connections to a list of edges and clears the
         pending dictionary -- use 'em or lose 'em.
+
+        Used in a "python public" sense that it gets called from outside the object,
+        but part of the plumbing and not intended to be part of the public API.
 
         Raises instead if the current owner is not a mutable dag.
         """
@@ -380,10 +392,13 @@ class Node(
         else:
             raise self._mutable_owner_error()
 
-    def detach_pending_connections(self) -> dict[str, Port]:
+    def _detach_pending_connections(self) -> dict[str, Port]:
         """
         Return a copy of the pending input connections and clear them, *without*
         attempting to realize them as edges.
+
+        Used in a "python public" sense that it gets called from outside the object,
+        but part of the plumbing and not intended to be part of the public API.
 
         Unlike :meth:`use_pending_edges`, this neither requires a mutable owner nor
         resolves the connections against one. It is used when a node carrying pending
@@ -470,7 +485,7 @@ class StaticNode(Node[RecipeType, execution.ResultType], abc.ABC):
 
         self.executor = None
         self.last_run = None
-        self.establish_sources(**connections)
+        self._establish_sources(**connections)
 
     @property
     def inputs(self) -> PortMap[InputPort, Node]:
@@ -710,7 +725,7 @@ class MutableDag(Node[fr.schemas.WorkflowRecipe, fr.schemas.DagData], Graph, abc
     def add_node(self, *nodes: Node) -> None: ...
 
     @abc.abstractmethod
-    def realize_pending(self, node: Node) -> None:
+    def _realize_pending(self, node: Node) -> None:
         """
         Materialize `node`'s pending constants as sibling nodes and draw down its
         pending connections as edges.

--- a/src/pyiron_workflow/injection.py
+++ b/src/pyiron_workflow/injection.py
@@ -401,7 +401,19 @@ def _build_injection_graph(
             graph.add_node(source_node)
             negotiated_source_ports.append(source_port)
 
+            # `add_node` may have materialized pending constants as siblings feeding
+            # some of these inputs. Promoting those to graph inputs as well would put
+            # two sources on one target, so skip anything already fed.
+            already_fed = {
+                edge.target.port
+                for edge in graph.edges
+                if isinstance(edge.target, fr.schemas.TargetHandle)
+                and edge.target.node == source_node.label
+            }
+
             for iport_label, iport in source_node.inputs.items():
+                if iport_label in already_fed:
+                    continue
                 # Without an owner we always need to scope input ports by the (now
                 # forced-unique inside the new graph context) node label
                 port_label = f"{source_node.label}_{iport_label}"

--- a/src/pyiron_workflow/injection.py
+++ b/src/pyiron_workflow/injection.py
@@ -339,7 +339,7 @@ def _build_operation(
         else label
     )
     operation_node = Atomic(operation.flowrep_recipe, label)
-    operation_node.connect_input(
+    operation_node._connect_input(
         **{
             label: s._injection.port
             for label, s in zip(operation_node.inputs, sources, strict=False)
@@ -389,12 +389,12 @@ def _build_injection_graph(
                 )
                 seen.add(source_port)
             negotiated_source_ports.append(graph.inputs[port_label])
-            graph.connect_input(**{port_label: source_port})
+            graph._connect_input(**{port_label: source_port})
         elif source_node.owner is None:
             # Add the source node to the new graph and wire its inputs from graph inputs.
             # Capture any pending connections *before* add_node would try to realize them
             # against the wrong context, so they can be lifted onto the new graph.
-            lifted = source_node.detach_pending_connections()
+            lifted = source_node._detach_pending_connections()
             source_node.label = label_helpers.unique_suffix(
                 source_node.label, graph.nodes
             )
@@ -427,14 +427,14 @@ def _build_injection_graph(
                     # This input was fed from an outer context; re-register the edge as a
                     # pending connection on the new (still unparented) graph so it resolves
                     # when the new graph is finally attached to that context.
-                    graph.connect_input(**{port_label: lifted[iport_label]})
+                    graph._connect_input(**{port_label: lifted[iport_label]})
         else:  # pragma: no cover
             raise ValueError(
                 "Can't inject across graph contexts. Fallback exception; should not be "
                 "reachable."
             )
 
-    operation_node.connect_input(
+    operation_node._connect_input(
         **dict(zip(operation_node.inputs, negotiated_source_ports, strict=False))
     )
 

--- a/src/pyiron_workflow/validation.py
+++ b/src/pyiron_workflow/validation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import dataclasses
+import typing
 from typing import ClassVar
 
 import flowrep as fr
@@ -9,6 +10,7 @@ import semantikon
 
 from pyiron_workflow import (
     atomic_node,
+    constant,
     dag,
     datatypes,
     execution,
@@ -60,6 +62,32 @@ def validate_edge(
             f"({target_hint}) but the source provides none."
         )
     return edge
+
+
+def _constant_hint_is_uncheckable(
+    source_hint: type | None, target_hint: type | None
+) -> bool:
+    """
+    Whether a `Constant`-sourced edge's hints cannot meaningfully be compared.
+
+    A `Constant`'s annotation is `type(value)`, so a container literal arrives
+    unparameterised and can never satisfy a parameterised target of the same origin
+    (e.g. `[1, 2]` is hinted `list`, which is not as-or-more-specific-than `list[int]`).
+    Targets of a *different* origin (`list` -> `tuple[int]`) and non-generic targets
+    (`int` -> `float`) are still checked.
+    """
+    return typing.get_origin(target_hint) is source_hint
+
+
+def validate_constant_edge(
+    edge: datatypes.EdgeTuple,
+    owner: datatypes.StaticGraph | workflow_node.Workflow,
+) -> datatypes.EdgeTuple:
+    """As :func:`validate_edge`, but tolerant of an unparameterised container source."""
+    source_hint, target_hint = _resolve_edge_hints(edge, owner)
+    if _constant_hint_is_uncheckable(source_hint, target_hint):
+        return edge
+    return validate_edge(edge, owner)
 
 
 class NotParseable:
@@ -160,6 +188,12 @@ def _validate_graph(
 
     for edge in owner.edges:
         source_hint, target_hint = _resolve_edge_hints(edge, owner)
+        if (
+            edge.source.node is not None
+            and isinstance(owner.nodes[edge.source.node], constant.Constant)
+            and _constant_hint_is_uncheckable(source_hint, target_hint)
+        ):
+            source_hint = None
         if source_hint is not None and target_hint is not None:
             if not type_hinting.type_hint_is_as_or_more_specific_than(
                 source_hint, target_hint

--- a/src/pyiron_workflow/workflow_node.py
+++ b/src/pyiron_workflow/workflow_node.py
@@ -1,17 +1,28 @@
 from __future__ import annotations
 
 import collections
+import contextlib
 import dataclasses
 import functools
+import itertools
 import types
 from collections.abc import Callable, MutableMapping
 from typing import TYPE_CHECKING, Any, Self, cast
 
 import flowrep as fr
 import semantikon
+from flowrep.parsers import label_helpers
 from semantikon.metadata import Missing
 
-from pyiron_workflow import actions, constructors, dag, datatypes, execution, validation
+from pyiron_workflow import (
+    actions,
+    constant,
+    constructors,
+    dag,
+    datatypes,
+    execution,
+    validation,
+)
 
 if TYPE_CHECKING:
     import rdflib
@@ -166,13 +177,21 @@ class Workflow(datatypes.MutableDag):
         label: fr.schemas.Label | None = None,
         undo_limit: int = 10,
         /,
-        **connections: datatypes.Port | datatypes.Node,
+        **connections: datatypes.Port | datatypes.Node | fr.schemas.JSONABLE,
     ):
+        if connections:
+            raise TypeError(
+                f"A new {self.__class__.__name__} has no input ports, so it cannot "
+                f"accept the connection(s) {list(connections.keys())!r} at "
+                f"construction. Create the input(s) with `create_input` first, then "
+                f"feed them with `establish_sources`."
+            )
         # Add a super call later if needed
         self._label = label or self.__class__.__name__.lower()
         self._owner = None
         self._detached_root = None
         self._pending_connections = {}
+        self._pending_constants = {}
         self.executor = None
         self.last_run = None
         self._inputs = MutablePortMap[datatypes.InputPort](self)
@@ -182,7 +201,6 @@ class Workflow(datatypes.MutableDag):
         self._diff_accumulator: actions.GraphDiff | None = None
         self.undo_stack = collections.deque(maxlen=undo_limit)
         self.redo_stack = collections.deque(maxlen=undo_limit)
-        self.connect_input(**connections)
 
     def copy(
         self, new_label: fr.schemas.Label | None = None, _copy_to: Self | None = None
@@ -689,18 +707,63 @@ class Workflow(datatypes.MutableDag):
         return self.add_port_metadata(port, None)
 
     @_undoable
+    def realize_pending(self, node: datatypes.Node) -> None:
+        """
+        Materialize `node`'s pending constants as sibling nodes, then draw down its
+        pending connections as edges.
+
+        Each `Constant` must be `_add_node`'d before its own edge is validated, since
+        `validate_constant_edge` resolves the source hint through `owner.get_node(...)`.
+        The pending-connection edges have no such ordering constraint against the
+        constants -- `establish_sources` already routed every `Port`/`Node` value into
+        `_pending_connections`, so a constant can never appear as a pending-edge source.
+        """
+        node._reject_unknown_targets(
+            itertools.chain(node._pending_constants, node._pending_connections)
+        )
+        with node._pending_state_restored_on_error():
+            for port_label, value in node.take_pending_constants().items():
+                child = constant.Constant.from_value(
+                    value,
+                    label_helpers.unique_suffix(
+                        f"{node.label}_{port_label}_constant", self.nodes
+                    ),
+                )
+                self._add_node(child)
+                self._add_edge(
+                    validation.validate_constant_edge(
+                        datatypes.EdgeTuple(
+                            fr.schemas.SourceHandle(
+                                node=child.label,
+                                port=fr.schemas.ConstantRecipe.std_label,
+                            ),
+                            fr.schemas.TargetHandle(node=node.label, port=port_label),
+                        ),
+                        self,
+                    )
+                )
+            for edge in node.use_pending_edges():
+                self._add_edge(validation.validate_edge(edge, self))
+
+    @_undoable
     def add_node(self, *nodes: datatypes.Node) -> None:
-        for n in nodes:
-            self._add_node(n)
-            for edge in n.use_pending_edges():
-                self._add_edge(edge)
-            try:
-                n.lexical_root  # noqa: B018 -- brute-force cycle check
-            except RecursionError:
-                raise ValueError(
-                    f"Cannot add {n.label!r} to {self.label!r} because it "
-                    f"contains a cycle."
-                ) from None
+        with contextlib.ExitStack() as stack:
+            # Guard *every* node for the whole loop: a failure on a later node rolls
+            # the graph back past the earlier ones too, so their drained pending state
+            # has to come back with it.
+            for n in nodes:
+                stack.enter_context(n._pending_state_restored_on_error())
+            # Then perform the potentially rollback-requiring operations
+            for n in nodes:
+                self._add_node(n)
+                self.realize_pending(n)
+                try:
+                    n.lexical_root  # noqa: B018 -- brute-force cycle check
+                except RecursionError:
+                    raise ValueError(
+                        f"Cannot add {n.label!r} to {self.label!r} because it "
+                        f"contains a cycle."
+                    ) from None
 
     @_undoable
     def remove_node(self, *nodes: datatypes.Node | fr.schemas.Label) -> None:

--- a/src/pyiron_workflow/workflow_node.py
+++ b/src/pyiron_workflow/workflow_node.py
@@ -707,10 +707,13 @@ class Workflow(datatypes.MutableDag):
         return self.add_port_metadata(port, None)
 
     @_undoable
-    def realize_pending(self, node: datatypes.Node) -> None:
+    def _realize_pending(self, node: datatypes.Node) -> None:
         """
         Materialize `node`'s pending constants as sibling nodes, then draw down its
         pending connections as edges.
+
+        Used in a "python public" sense that it gets called from outside the object,
+        but part of the plumbing and not intended to be part of the public API.
 
         Each `Constant` must be `_add_node`'d before its own edge is validated, since
         `validate_constant_edge` resolves the source hint through `owner.get_node(...)`.
@@ -722,7 +725,7 @@ class Workflow(datatypes.MutableDag):
             itertools.chain(node._pending_constants, node._pending_connections)
         )
         with node._pending_state_restored_on_error():
-            for port_label, value in node.take_pending_constants().items():
+            for port_label, value in node._take_pending_constants().items():
                 child = constant.Constant.from_value(
                     value,
                     label_helpers.unique_suffix(
@@ -742,7 +745,7 @@ class Workflow(datatypes.MutableDag):
                         self,
                     )
                 )
-            for edge in node.use_pending_edges():
+            for edge in node._use_pending_edges():
                 self._add_edge(validation.validate_edge(edge, self))
 
     @_undoable
@@ -756,7 +759,7 @@ class Workflow(datatypes.MutableDag):
             # Then perform the potentially rollback-requiring operations
             for n in nodes:
                 self._add_node(n)
-                self.realize_pending(n)
+                self._realize_pending(n)
                 try:
                     n.lexical_root  # noqa: B018 -- brute-force cycle check
                 except RecursionError:

--- a/tests/unit/_fixtures.py
+++ b/tests/unit/_fixtures.py
@@ -83,6 +83,11 @@ def typed_float(x: float) -> float:
     return x + 0.0
 
 
+@fr.atomic
+def typed_list(x: list[int]) -> int:
+    return sum(x)
+
+
 # --------------------------------------------------------------------------- #
 # Macro recipes                                                               #
 # --------------------------------------------------------------------------- #
@@ -309,6 +314,11 @@ def typed_int_node(label: str = "typed_int"):
 def typed_float_node(label: str = "typed_float"):
     """Return a fresh `Atomic` wrapping `typed_float` (input/output hinted `float`)."""
     return wfms.tools.atomictype2node(typed_float, label)
+
+
+def typed_list_node(label: str = "typed_list"):
+    """Return a fresh `Atomic` wrapping `typed_list` (input hinted `list[int]`)."""
+    return wfms.tools.atomictype2node(typed_list, label)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_constructors.py
+++ b/tests/unit/test_constructors.py
@@ -289,6 +289,64 @@ class TestConnectionsAtConstruction(unittest.TestCase):
         )
 
 
+class TestConstantConnectionsAtConstruction(unittest.TestCase):
+    """JSONable connection values are stashed as pending constants by every route."""
+
+    def test_node_instance(self) -> None:
+        original = _fixtures.atomic_add_node("original")
+        copied = constructors.node(original, "copied", y=5)
+        self.assertEqual({"y": 5}, copied._pending_constants)
+        self.assertEqual(
+            {},
+            original._pending_constants,
+            msg="Constants belong to the copy, not the node we copied from",
+        )
+
+    def test_recipe(self) -> None:
+        n = constructors.node(_fixtures.add.flowrep_recipe, "added", x=1, y=2)
+        self.assertEqual({"x": 1, "y": 2}, n._pending_constants)
+
+    def test_flow_control_recipes(self) -> None:
+        for label, recipe, port_label in (
+            ("for_each", _fixtures.for_wf.flowrep_recipe.nodes["for_each_0"], "z"),
+            ("if", _if_recipe(), "x"),
+            ("try", _try_recipe(), "x"),
+            ("while", _while_recipe(), "x"),
+        ):
+            with self.subTest(label):
+                n = constructors.recipe2node(recipe, label, **{port_label: 3})
+                self.assertEqual({port_label: 3}, n._pending_constants)
+
+    def test_decorated_atomic_like(self) -> None:
+        n = constructors.node(_fixtures.add, "added", y=5)
+        self.assertEqual({"y": 5}, n._pending_constants)
+
+    def test_undecorated_atomic_like(self) -> None:
+        n = constructors.node(plain_add, "added", y=5)
+        self.assertEqual({"y": 5}, n._pending_constants)
+
+    def test_mixed_ports_and_constants(self) -> None:
+        src = _fixtures.atomic_add_node("src")
+        n = constructors.node(_fixtures.add, "added", x=src, y=5)
+        self.assertIs(n._pending_connections["x"], src.outputs["output_0"])
+        self.assertEqual({"y": 5}, n._pending_constants)
+
+    def test_constant_value_rejects_jsonable_connections(self) -> None:
+        with self.assertRaisesRegex(TypeError, "cannot take incoming connections"):
+            constructors.node(42, "forty_two", x=1)
+
+    def test_constant_recipe_rejects_jsonable_connections(self) -> None:
+        recipe = fr.schemas.ConstantRecipe(constant=42)
+        with self.assertRaisesRegex(TypeError, "cannot take incoming connections"):
+            constructors.recipe2node(recipe, "forty_two", x=1)
+
+    def test_workflow_copy_with_connections_still_works(self) -> None:
+        inner = workflow_node.Workflow("inner")
+        inner.create_input("x")
+        copied = constructors.node(inner, "copied", x=5)
+        self.assertEqual({"x": 5}, copied._pending_constants)
+
+
 # --------------------------------------------------------------------------- #
 # Tests for `function2node`                                                   #
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_datatypes.py
+++ b/tests/unit/test_datatypes.py
@@ -356,13 +356,106 @@ class TestConnectAtInit(unittest.TestCase):
 
     def test_connect_wrong_type_raises(self):
         with self.assertRaises(TypeError):
-            self._macro(x=42)
+            self._macro(x=(1, 2))  # tuples are not JSONable
 
     def test_connections_stay_pending_without_owner(self):
         src = _fixtures.atomic_add_node("src")
         m = self._macro(x=src.outputs["output_0"], y=src)
         self.assertIsNone(m.owner)
         self.assertEqual(set(m._pending_connections), {"x", "y"})
+
+
+class TestEstablishSources(unittest.TestCase):
+    def setUp(self) -> None:
+        self.src = _fixtures.atomic_add_node("src")
+        self.port = self.src.outputs["output_0"]
+
+    def test_splits_ports_from_constants(self) -> None:
+        n = _fixtures.atomic_add_node("n")
+        n.establish_sources(x=self.port, y="bar")
+        self.assertIs(n._pending_connections["x"], self.port)
+        self.assertEqual({"y": "bar"}, n._pending_constants)
+        self.assertNotIn("y", n._pending_connections)
+
+    def test_node_source_coerces_to_port(self) -> None:
+        n = _fixtures.atomic_add_node("n")
+        n.establish_sources(x=self.src)
+        self.assertIs(n._pending_connections["x"], self.port)
+        self.assertEqual({}, n._pending_constants)
+
+    def test_none_is_a_constant_not_an_absence(self) -> None:
+        n = _fixtures.atomic_add_node("n")
+        n.establish_sources(x=None)
+        self.assertEqual({"x": None}, n._pending_constants)
+
+    def test_container_literals_are_constants(self) -> None:
+        n = _fixtures.atomic_add_node("n")
+        n.establish_sources(x=[1, 2], y={"a": 1})
+        self.assertEqual({"x": [1, 2], "y": {"a": 1}}, n._pending_constants)
+
+    def test_non_jsonable_non_port_raises(self) -> None:
+        n = _fixtures.atomic_add_node("n")
+        with self.assertRaises(TypeError):
+            n.establish_sources(x=(1, 2))  # tuples are not JSONable
+
+    def test_call_dunder_routes_through_establish_sources(self) -> None:
+        n = _fixtures.atomic_add_node("n")
+        self.assertIs(n, n(y="bar"))
+        self.assertEqual({"y": "bar"}, n._pending_constants)
+
+    def test_take_pending_constants_drains(self) -> None:
+        n = _fixtures.atomic_add_node("n")
+        n.establish_sources(x=1, y=2)
+        self.assertEqual({"x": 1, "y": 2}, n.take_pending_constants())
+        self.assertEqual({}, n._pending_constants)
+
+    def test_copy_loses_pending_constants(self) -> None:
+        n = _fixtures.atomic_add_node("n")
+        n.establish_sources(y="bar")
+        self.assertEqual({}, n.copy("copied")._pending_constants)
+
+    def test_failed_connection_strands_no_constant(self) -> None:
+        # The constant is stashed before `connect_input` can reject the port, so a
+        # failure must roll the stash back rather than leave it to materialize later.
+        n = _fixtures.atomic_add_node("n")
+        multi = _fixtures.macro_node("multi")  # outputs `a` and `s`
+        with self.assertRaises(ValueError):
+            n.establish_sources(x=multi, y=5)
+        self.assertEqual({}, n._pending_constants)
+        self.assertEqual({}, n._pending_connections)
+
+    def test_failed_connection_preserves_pre_existing_stores(self) -> None:
+        # Only the failed call's partial stash is rolled back; earlier state survives.
+        n = _fixtures.atomic_add_node("n")
+        n.establish_sources(x=1)
+        multi = _fixtures.macro_node("multi")
+        with self.assertRaises(ValueError):
+            n.establish_sources(y=2, x=multi)
+        self.assertEqual({"x": 1}, n._pending_constants)
+        self.assertEqual({}, n._pending_connections)
+
+
+class TestUnknownTargetGuard(unittest.TestCase):
+    def test_constant_to_unknown_port_raises_eagerly(self) -> None:
+        n = _fixtures.atomic_add_node("n")
+        with self.assertRaises(ValueError) as ctx:
+            n.establish_sources(typo=1)
+        self.assertIn("typo", str(ctx.exception))
+        self.assertIn("x", str(ctx.exception))
+
+    def test_port_to_unknown_port_raises_eagerly(self) -> None:
+        n = _fixtures.atomic_add_node("n")
+        src = _fixtures.atomic_add_node("src")
+        with self.assertRaises(ValueError) as ctx:
+            n.establish_sources(typo=src.outputs["output_0"])
+        self.assertIn("typo", str(ctx.exception))
+
+    def test_nothing_is_stashed_when_the_guard_fires(self) -> None:
+        n = _fixtures.atomic_add_node("n")
+        with self.assertRaises(ValueError):
+            n.establish_sources(typo=1)
+        self.assertEqual({}, n._pending_constants)
+        self.assertEqual({}, n._pending_connections)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_datatypes.py
+++ b/tests/unit/test_datatypes.py
@@ -372,31 +372,31 @@ class TestEstablishSources(unittest.TestCase):
 
     def test_splits_ports_from_constants(self) -> None:
         n = _fixtures.atomic_add_node("n")
-        n.establish_sources(x=self.port, y="bar")
+        n._establish_sources(x=self.port, y="bar")
         self.assertIs(n._pending_connections["x"], self.port)
         self.assertEqual({"y": "bar"}, n._pending_constants)
         self.assertNotIn("y", n._pending_connections)
 
     def test_node_source_coerces_to_port(self) -> None:
         n = _fixtures.atomic_add_node("n")
-        n.establish_sources(x=self.src)
+        n._establish_sources(x=self.src)
         self.assertIs(n._pending_connections["x"], self.port)
         self.assertEqual({}, n._pending_constants)
 
     def test_none_is_a_constant_not_an_absence(self) -> None:
         n = _fixtures.atomic_add_node("n")
-        n.establish_sources(x=None)
+        n._establish_sources(x=None)
         self.assertEqual({"x": None}, n._pending_constants)
 
     def test_container_literals_are_constants(self) -> None:
         n = _fixtures.atomic_add_node("n")
-        n.establish_sources(x=[1, 2], y={"a": 1})
+        n._establish_sources(x=[1, 2], y={"a": 1})
         self.assertEqual({"x": [1, 2], "y": {"a": 1}}, n._pending_constants)
 
     def test_non_jsonable_non_port_raises(self) -> None:
         n = _fixtures.atomic_add_node("n")
         with self.assertRaises(TypeError):
-            n.establish_sources(x=(1, 2))  # tuples are not JSONable
+            n._establish_sources(x=(1, 2))  # tuples are not JSONable
 
     def test_call_dunder_routes_through_establish_sources(self) -> None:
         n = _fixtures.atomic_add_node("n")
@@ -405,13 +405,13 @@ class TestEstablishSources(unittest.TestCase):
 
     def test_take_pending_constants_drains(self) -> None:
         n = _fixtures.atomic_add_node("n")
-        n.establish_sources(x=1, y=2)
-        self.assertEqual({"x": 1, "y": 2}, n.take_pending_constants())
+        n._establish_sources(x=1, y=2)
+        self.assertEqual({"x": 1, "y": 2}, n._take_pending_constants())
         self.assertEqual({}, n._pending_constants)
 
     def test_copy_loses_pending_constants(self) -> None:
         n = _fixtures.atomic_add_node("n")
-        n.establish_sources(y="bar")
+        n._establish_sources(y="bar")
         self.assertEqual({}, n.copy("copied")._pending_constants)
 
     def test_failed_connection_strands_no_constant(self) -> None:
@@ -420,17 +420,17 @@ class TestEstablishSources(unittest.TestCase):
         n = _fixtures.atomic_add_node("n")
         multi = _fixtures.macro_node("multi")  # outputs `a` and `s`
         with self.assertRaises(ValueError):
-            n.establish_sources(x=multi, y=5)
+            n._establish_sources(x=multi, y=5)
         self.assertEqual({}, n._pending_constants)
         self.assertEqual({}, n._pending_connections)
 
     def test_failed_connection_preserves_pre_existing_stores(self) -> None:
         # Only the failed call's partial stash is rolled back; earlier state survives.
         n = _fixtures.atomic_add_node("n")
-        n.establish_sources(x=1)
+        n._establish_sources(x=1)
         multi = _fixtures.macro_node("multi")
         with self.assertRaises(ValueError):
-            n.establish_sources(y=2, x=multi)
+            n._establish_sources(y=2, x=multi)
         self.assertEqual({"x": 1}, n._pending_constants)
         self.assertEqual({}, n._pending_connections)
 
@@ -439,7 +439,7 @@ class TestUnknownTargetGuard(unittest.TestCase):
     def test_constant_to_unknown_port_raises_eagerly(self) -> None:
         n = _fixtures.atomic_add_node("n")
         with self.assertRaises(ValueError) as ctx:
-            n.establish_sources(typo=1)
+            n._establish_sources(typo=1)
         self.assertIn("typo", str(ctx.exception))
         self.assertIn("x", str(ctx.exception))
 
@@ -447,13 +447,13 @@ class TestUnknownTargetGuard(unittest.TestCase):
         n = _fixtures.atomic_add_node("n")
         src = _fixtures.atomic_add_node("src")
         with self.assertRaises(ValueError) as ctx:
-            n.establish_sources(typo=src.outputs["output_0"])
+            n._establish_sources(typo=src.outputs["output_0"])
         self.assertIn("typo", str(ctx.exception))
 
     def test_nothing_is_stashed_when_the_guard_fires(self) -> None:
         n = _fixtures.atomic_add_node("n")
         with self.assertRaises(ValueError):
-            n.establish_sources(typo=1)
+            n._establish_sources(typo=1)
         self.assertEqual({}, n._pending_constants)
         self.assertEqual({}, n._pending_connections)
 

--- a/tests/unit/test_injection.py
+++ b/tests/unit/test_injection.py
@@ -503,5 +503,37 @@ class TestConstantInjection(unittest.TestCase):
             (2,) * wf.inputs.a
 
 
+class TestPendingConstantAbsorption(unittest.TestCase):
+    # NOTE: `label_helpers.unique_suffix` always appends a numeric suffix, even
+    # absent a collision (see the existing "plain_increment_0_x" comment above),
+    # so the absorbed unparented node "f" is renamed "f_0" once it lands in the
+    # injection graph.
+    def test_constant_is_adopted_into_the_injection_graph(self) -> None:
+        n = constructors.node(_fixtures.add, "f", y=3) + 2
+        self.assertIsInstance(n, workflow_node.Workflow)
+        self.assertIn("f_0_y_constant_0", n.nodes)
+
+    def test_constant_fed_port_is_not_promoted(self) -> None:
+        n = constructors.node(_fixtures.add, "f", y=3) + 2
+        self.assertNotIn("f_0_y", n.inputs)
+        self.assertIn("f_0_x", n.inputs, msg="Unfed inputs are still promoted")
+
+    def test_no_target_is_double_fed(self) -> None:
+        n = constructors.node(_fixtures.add, "f", y=3) + 2
+        targets = [e.target for e in n.edges]
+        self.assertEqual(
+            len(targets), len(set(targets)), msg=f"Duplicate target in {n.edges}"
+        )
+
+    def test_absorbed_constant_runs(self) -> None:
+        outer = workflow_node.Workflow("outer")
+        outer.create_input("x")
+        outer.create_output("out")
+        outer.n = constructors.node(_fixtures.add, "f", y=3) + 2
+        outer.connect(outer.inputs.x, outer.n.inputs.f_0_x)
+        outer.connect(outer.n, outer.outputs.out)
+        self.assertEqual(15, outer.run(x=10).outputs.out)  # (10 + 3) + 2
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -16,6 +16,7 @@ import rdflib
 from unit import _fixtures
 
 from pyiron_workflow import (
+    constant,
     dag,
     datatypes,
     execution,
@@ -564,6 +565,74 @@ class TestValidatePlanOntology(unittest.TestCase):
         report = validation.validate_plan(_fixtures.clothes_correct_macro_node())
         self.assertIsInstance(repr(report), str)
         self.assertTrue(repr(report))
+
+
+class TestConstantHintCarveOut(unittest.TestCase):
+    def test_predicate_truth_table(self) -> None:
+        for source, target, expected in (
+            (list, list[int], True),
+            (dict, dict[str, int], True),
+            (tuple, tuple[int, str], True),
+            (int, int, False),
+            (int, float, False),
+            (list, list, False),
+            (type(None), int | None, False),
+            (list, int | None, False),
+            (list, tuple[int], False),
+        ):
+            with self.subTest(f"{source} -> {target}"):
+                self.assertEqual(
+                    expected,
+                    validation._constant_hint_is_uncheckable(source, target),
+                )
+
+    def test_container_constant_passes_unchecked(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.add_node(_fixtures.typed_list_node("consumer"))
+        wf.add_node(constant.Constant.from_value([1, 2], "c"))
+        edge = datatypes.EdgeTuple(
+            fr.schemas.SourceHandle(node="c", port="constant"),
+            fr.schemas.TargetHandle(node="consumer", port="x"),
+        )
+        self.assertIs(edge, validation.validate_constant_edge(edge, wf))
+
+    def test_mismatched_scalar_constant_still_raises(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.add_node(_fixtures.typed_int_node("consumer"))
+        wf.add_node(constant.Constant.from_value("nope", "c"))
+        edge = datatypes.EdgeTuple(
+            fr.schemas.SourceHandle(node="c", port="constant"),
+            fr.schemas.TargetHandle(node="consumer", port="x"),
+        )
+        with self.assertRaises(TypeError):
+            validation.validate_constant_edge(edge, wf)
+
+    def test_matching_scalar_constant_passes(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.add_node(_fixtures.typed_int_node("consumer"))
+        wf.add_node(constant.Constant.from_value(7, "c"))
+        edge = datatypes.EdgeTuple(
+            fr.schemas.SourceHandle(node="c", port="constant"),
+            fr.schemas.TargetHandle(node="consumer", port="x"),
+        )
+        self.assertIs(edge, validation.validate_constant_edge(edge, wf))
+
+    def test_validate_types_reports_carved_edge_as_unfulfilled(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.add_node(_fixtures.typed_list_node("consumer"))
+        wf.add_node(constant.Constant.from_value([1, 2], "c"))
+        wf.add_edge(
+            datatypes.EdgeTuple(
+                fr.schemas.SourceHandle(node="c", port="constant"),
+                fr.schemas.TargetHandle(node="consumer", port="x"),
+            ),
+            type_validate=False,
+        )
+        report = validation.validate_types(wf)
+        self.assertEqual([], report.invalid_edges)
+        self.assertEqual(1, len(report.unfulfilled_edges))
+        self.assertTrue(report.valid)
+        self.assertFalse(report.complete)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -14,10 +14,12 @@ from unit import _fixtures
 from pyiron_workflow import (
     actions,
     atomic_node,
+    constant,
     constructors,
     dag,
     datatypes,
     execution,
+    validation,
     workflow_node,
 )
 
@@ -2665,47 +2667,6 @@ class TestWorkflowFromRecipe(unittest.TestCase):
         self.assertEqual(len(rebuilt.edges), 0)
 
 
-class TestWorkflowConnectAtInit(unittest.TestCase):
-    """`Workflow` connection sugar at construction.
-
-    A freshly-built workflow has no owner, so every connection takes the
-    'pending' route rather than being applied as an edge immediately.
-    """
-
-    def test_connect_port_is_pending(self) -> None:
-        src = _fixtures.atomic_add_node("src")
-        port = src.outputs["output_0"]
-        wf = workflow_node.Workflow("wf", x=port)
-        self.assertIs(wf._pending_connections["x"], port)
-
-    def test_connect_single_output_node_coerces_to_its_port(self) -> None:
-        src = _fixtures.atomic_add_node("src")
-        wf = workflow_node.Workflow("wf", y=src)
-        self.assertIs(wf._pending_connections["y"], src.outputs["output_0"])
-
-    def test_connect_multi_output_node_raises(self) -> None:
-        multi = _fixtures.macro_node("multi")  # outputs `a` and `s`
-        with self.assertRaises(ValueError):
-            workflow_node.Workflow("wf", x=multi)
-
-    def test_connect_wrong_type_raises(self) -> None:
-        with self.assertRaises(TypeError):
-            workflow_node.Workflow("wf", x=42)
-
-    def test_connections_stay_pending_without_owner(self) -> None:
-        src = _fixtures.atomic_add_node("src")
-        wf = workflow_node.Workflow("wf", x=src.outputs["output_0"])
-        self.assertIsNone(wf.owner)
-        self.assertEqual(wf.edges, [])
-        self.assertIn("x", wf._pending_connections)
-
-    def test_undo_limit_and_connections_coexist(self) -> None:
-        src = _fixtures.atomic_add_node("src")
-        wf = workflow_node.Workflow("wf", 5, x=src.outputs["output_0"])
-        self.assertEqual(wf.undo_limit, 5)
-        self.assertIn("x", wf._pending_connections)
-
-
 class TestWorkflowData(unittest.TestCase):
     def test_annotations_propagate_from_wfms_to_data(self):
         wf = workflow_node.Workflow.from_recipe(
@@ -2770,6 +2731,239 @@ class TestWorkflowCopy(unittest.TestCase):
         self.assertIsNone(copy.owner)
         self.assertIs(copied_child.owner, copy)
         self.assertIs(wf.nodes["add_0"].owner, wf)
+
+
+class TestWorkflowInitRejectsConnections(unittest.TestCase):
+    def test_port_connection_raises(self) -> None:
+        src = _fixtures.atomic_add_node("src")
+        with self.assertRaises(TypeError) as ctx:
+            workflow_node.Workflow("wf", x=src.outputs["output_0"])
+        self.assertIn("create_input", str(ctx.exception))
+
+    def test_constant_connection_raises(self) -> None:
+        with self.assertRaises(TypeError) as ctx:
+            workflow_node.Workflow("wf", x=5)
+        self.assertIn("create_input", str(ctx.exception))
+
+    def test_plain_construction_still_works(self) -> None:
+        self.assertEqual("wf", workflow_node.Workflow("wf").label)
+        self.assertEqual(5, workflow_node.Workflow("wf", 5).undo_stack.maxlen)
+
+    def test_connections_are_fine_once_io_exists(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.create_input("x")
+        wf.establish_sources(x=5)
+        self.assertEqual({"x": 5}, wf._pending_constants)
+
+    def test_establishing_before_io_exists_raises(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        with self.assertRaises(ValueError) as ctx:
+            wf.establish_sources(x=5)
+        self.assertIn("x", str(ctx.exception))
+
+
+class TestRealizePendingConstants(unittest.TestCase):
+    def test_deferred_use_case(self) -> None:
+        # Deferred: the constant materializes when the node is parented by assignment.
+        wf = workflow_node.Workflow("wf")
+        wf.create_input("x")
+        wf.create_output("out")
+        wf.foo = constructors.node(_fixtures.add, "foo", x=wf.inputs.x, y=5)
+        wf.connect(wf.foo, wf.outputs.out)
+        self.assertIn("foo_y_constant_0", wf.nodes)
+        self.assertEqual(12, wf.run(x=7).outputs.out)
+
+    def test_post_hoc_use_case(self) -> None:
+        # Post-hoc: the node is already owned, so the constant materializes immediately.
+        wf = workflow_node.Workflow("wf")
+        wf.create_input("x")
+        wf.create_output("out")
+        wf.add_node(_fixtures.atomic_add_node("foo"))
+        wf.connect(wf.inputs.x, wf.foo.inputs.x)
+        wf.connect(wf.foo, wf.outputs.out)
+        wf.foo(y=5)
+        self.assertIn("foo_y_constant_0", wf.nodes)
+        self.assertEqual(12, wf.run(x=7).outputs.out)
+
+    def test_constant_edge_is_wired_to_the_right_target(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.foo = constructors.node(_fixtures.add, "foo", y=5)
+        self.assertIn(
+            datatypes.EdgeTuple(
+                fr.schemas.SourceHandle(node="foo_y_constant_0", port="constant"),
+                fr.schemas.TargetHandle(node="foo", port="y"),
+            ),
+            wf.edges,
+        )
+
+    def test_two_constants_on_one_node_get_distinct_labels(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.foo = constructors.node(_fixtures.add, "foo", x=1, y=2)
+        self.assertIn("foo_x_constant_0", wf.nodes)
+        self.assertIn("foo_y_constant_0", wf.nodes)
+
+    def test_label_collision_is_suffixed(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.add_node(constant.Constant.from_value(99, "foo_y_constant_0"))
+        wf.foo = constructors.node(_fixtures.add, "foo", y=5)
+        self.assertIn("foo_y_constant_1", wf.nodes)
+        self.assertEqual(99, wf.nodes["foo_y_constant_0"].recipe.constant)
+
+    def test_distinct_consumers_get_distinct_constants(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.foo = constructors.node(_fixtures.add, "foo", y=5)
+        wf.baz = constructors.node(_fixtures.add, "baz", y=5)
+        self.assertIn("foo_y_constant_0", wf.nodes)
+        self.assertIn("baz_y_constant_0", wf.nodes)
+
+
+class TestRealizePendingAtomicity(unittest.TestCase):
+    def test_deferred_case_is_one_undo_entry(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        before = len(wf.undo_stack)
+        wf.foo = constructors.node(_fixtures.add, "foo", y=5)
+        self.assertEqual(before + 1, len(wf.undo_stack))
+
+    def test_undo_removes_both_node_and_constant(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.foo = constructors.node(_fixtures.add, "foo", y=5)
+        wf.undo()
+        self.assertNotIn("foo", wf.nodes)
+        self.assertNotIn("foo_y_constant_0", wf.nodes)
+        self.assertEqual([], wf.edges)
+
+    def test_post_hoc_case_is_one_undo_entry(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.add_node(_fixtures.atomic_add_node("foo"))
+        before = len(wf.undo_stack)
+        wf.foo(y=5)
+        self.assertEqual(before + 1, len(wf.undo_stack))
+
+    def test_undo_of_post_hoc_case_removes_only_the_constant(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.add_node(_fixtures.atomic_add_node("foo"))
+        wf.foo(y=5)
+        wf.undo()
+        self.assertIn("foo", wf.nodes)
+        self.assertNotIn("foo_y_constant_0", wf.nodes)
+        self.assertEqual([], wf.edges)
+
+    def test_undo_of_two_constants_removes_both(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.foo = constructors.node(_fixtures.add, "foo", x=1, y=2)
+        wf.undo()
+        self.assertNotIn("foo", wf.nodes)
+        self.assertNotIn("foo_x_constant_0", wf.nodes)
+        self.assertNotIn("foo_y_constant_0", wf.nodes)
+        self.assertEqual([], wf.edges)
+
+    def test_redo_after_undo_restores_nodes_edges_and_owners(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.foo = constructors.node(_fixtures.add, "foo", y=5)
+        wf.undo()
+        wf.redo()
+        self.assertIn("foo", wf.nodes)
+        self.assertIn("foo_y_constant_0", wf.nodes)
+        self.assertIs(wf.nodes["foo"].owner, wf)
+        self.assertIs(wf.nodes["foo_y_constant_0"].owner, wf)
+        self.assertIn(
+            datatypes.EdgeTuple(
+                fr.schemas.SourceHandle(node="foo_y_constant_0", port="constant"),
+                fr.schemas.TargetHandle(node="foo", port="y"),
+            ),
+            wf.edges,
+        )
+
+
+class TestRealizePendingValidation(unittest.TestCase):
+    def test_ill_typed_constant_raises(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        with self.assertRaises(TypeError):
+            wf.foo = constructors.node(_fixtures.typed_int, "foo", x="not an int")
+
+    def test_ill_typed_constant_leaves_graph_clean(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        with self.assertRaises(TypeError):
+            wf.foo = constructors.node(_fixtures.typed_int, "foo", x="not an int")
+        self.assertEqual({}, dict(wf.nodes))
+        self.assertEqual([], wf.edges)
+
+    def test_failed_realization_leaves_node_reusable(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        node = constructors.node(_fixtures.typed_int, "foo", x="not an int")
+        with self.assertRaises(TypeError):
+            wf.add_node(node)
+        self.assertEqual({"x": "not an int"}, node._pending_constants)
+        self.assertIsNone(node.owner)
+
+        # Re-establish a well-typed constant and confirm the node still works.
+        node.establish_sources(x=7)
+        other = workflow_node.Workflow("other")
+        other.create_output("out")
+        other.add_node(node)
+        other.connect(node, other.outputs.out)
+        self.assertIn("foo_x_constant_0", other.nodes)
+        self.assertEqual(7, other.run().outputs.out)
+
+    def test_container_constant_is_admitted(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.foo = constructors.node(_fixtures.typed_list, "foo", x=[1, 2, 3])
+        self.assertIn("foo_x_constant_0", wf.nodes)
+        report = validation.validate_types(wf)
+        self.assertEqual([], report.invalid_edges)
+
+    def test_well_typed_constant_is_admitted(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.foo = constructors.node(_fixtures.typed_int, "foo", x=7)
+        self.assertIn("foo_x_constant_0", wf.nodes)
+
+    def test_batch_add_failure_leaves_earlier_nodes_constant_driven(self) -> None:
+        # `add_node(a, b)` drains `a` before `b` fails; `_undoable` then unparents `a`.
+        # Without a node-level rollback `a` comes back unowned *and* de-constanted, so
+        # re-adding it silently computes with defaults instead of its constant.
+        wf = workflow_node.Workflow("wf")
+        a = constructors.node(_fixtures.multiply_with_defaults, "a", x=10)
+        b = constructors.node(_fixtures.typed_int, "b", x="not an int")
+        with self.assertRaises(TypeError):
+            wf.add_node(a, b)
+        self.assertEqual({"x": 10}, a._pending_constants)
+
+        other = workflow_node.Workflow("other")
+        other.create_output("out")
+        other.add_node(a)
+        other.connect(a, other.outputs.out)
+        self.assertEqual(20, other.run().outputs.out)  # 10 * 2, not the default 1 * 2
+
+    def test_failed_realization_on_owned_node_is_not_sticky(self) -> None:
+        # The owned branch writes the pending stores before realization can fail; a
+        # failure must not poison the node against every subsequent call.
+        wf = workflow_node.Workflow("wf")
+        wf.add_node(_fixtures.typed_int_node("t"))
+        with self.assertRaises(TypeError):
+            wf.t(x="not an int")
+        self.assertEqual({}, wf.t._pending_constants)
+        self.assertEqual({}, wf.t._pending_connections)
+        wf.t()  # Must not re-raise the earlier failure
+
+    def test_realize_time_backstop_covers_pending_connections(self) -> None:
+        parent = workflow_node.Workflow("parent")
+        parent.add_node(_fixtures.atomic_add_node("src"))
+        child = workflow_node.Workflow("child")
+        child.create_input("x")
+        child.establish_sources(x=parent.src.outputs["output_0"])
+        child.remove_input("x")
+        with self.assertRaises(ValueError) as ctx:
+            parent.add_node(child)
+        self.assertIn("no input port", str(ctx.exception))
+        self.assertIn("x", str(ctx.exception))
+
+    def test_pending_port_edges_are_now_validated_too(self) -> None:
+        wf = workflow_node.Workflow("wf")
+        wf.add_node(_fixtures.typed_float_node("src"))
+        with self.assertRaises(TypeError):
+            wf.foo = constructors.node(
+                _fixtures.typed_int, "foo", x=wf.src.outputs["output_0"]
+            )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -2752,13 +2752,13 @@ class TestWorkflowInitRejectsConnections(unittest.TestCase):
     def test_connections_are_fine_once_io_exists(self) -> None:
         wf = workflow_node.Workflow("wf")
         wf.create_input("x")
-        wf.establish_sources(x=5)
+        wf._establish_sources(x=5)
         self.assertEqual({"x": 5}, wf._pending_constants)
 
     def test_establishing_before_io_exists_raises(self) -> None:
         wf = workflow_node.Workflow("wf")
         with self.assertRaises(ValueError) as ctx:
-            wf.establish_sources(x=5)
+            wf._establish_sources(x=5)
         self.assertIn("x", str(ctx.exception))
 
 
@@ -2897,7 +2897,7 @@ class TestRealizePendingValidation(unittest.TestCase):
         self.assertIsNone(node.owner)
 
         # Re-establish a well-typed constant and confirm the node still works.
-        node.establish_sources(x=7)
+        node._establish_sources(x=7)
         other = workflow_node.Workflow("other")
         other.create_output("out")
         other.add_node(node)
@@ -2950,7 +2950,7 @@ class TestRealizePendingValidation(unittest.TestCase):
         parent.add_node(_fixtures.atomic_add_node("src"))
         child = workflow_node.Workflow("child")
         child.create_input("x")
-        child.establish_sources(x=parent.src.outputs["output_0"])
+        child._establish_sources(x=parent.src.outputs["output_0"])
         child.remove_input("x")
         with self.assertRaises(ValueError) as ctx:
             parent.add_node(child)


### PR DESCRIPTION
The main functional change here is that the `pyiron_workflow.Node` objects extend what they can digest as new connections from `**connections: Port | Node` to `Port | Node | fr.JSONABLE`. This is accomplished by having a `Node._pending_constants` alongside the existing `_pending_edges`, which are realized as injected constant nodes when the node-holding-pending stuff gets parented. If it's _already_ parented, they get injected right away. I.e. both of these now work:

```python
# 1. Deferred: label comes from the assignment; constant materializes on parenting.
wf.foo = pwf.node(foo_func, x=wf.inputs.x, y="bar")

# 2. Post-hoc: node already owned, so the constant materializes immediately.
wf.foo(y="bar")
```

Some of the rollbacks (restoring state during a `Workflow` mutation when an error is encountered) have also been made a bit more robust.

I also break compatibility here by making some formerly public methods private: `Node.connect_input/use_pending_edges/detatch_pending_connections`. These and some of the new methods that manage the plumbing of constant and edge deferred injection are public in the pythonic sense that they are accessed from outside their owning object, but they are private plumbing that I don't want to expose to the public API. Keeping the API clean takes precedence here.