### PR TITLE
Extend api

### DIFF
--- a/src/pyiron_workflow/__init__.py
+++ b/src/pyiron_workflow/__init__.py
@@ -8,13 +8,13 @@ except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0+unknown"
 
 # Public API
-from pyiron_workflow.api import schemas as schemas
-from pyiron_workflow.api import tools as tools
-from pyiron_workflow.api.schemas import (
+from pyiron_workflow.api import (
     ExecutorInstructions as ExecutorInstructions,
 )
-from pyiron_workflow.api.schemas import ProgressHook as ProgressHook
-from pyiron_workflow.api.schemas import RunConfig as RunConfig
-from pyiron_workflow.api.schemas import Workflow as Workflow
-from pyiron_workflow.api.tools import node as node
-from pyiron_workflow.api.tools import run as run
+from pyiron_workflow.api import ProgressHook as ProgressHook
+from pyiron_workflow.api import RunConfig as RunConfig
+from pyiron_workflow.api import Workflow as Workflow
+from pyiron_workflow.api import node as node
+from pyiron_workflow.api import run as run
+from pyiron_workflow.api import schemas as schemas
+from pyiron_workflow.api import tools as tools

--- a/src/pyiron_workflow/api/__init__.py
+++ b/src/pyiron_workflow/api/__init__.py
@@ -7,3 +7,4 @@ from pyiron_workflow.api.schemas import ProgressHook as ProgressHook
 from pyiron_workflow.api.schemas import RunConfig as RunConfig
 from pyiron_workflow.api.schemas import Workflow as Workflow
 from pyiron_workflow.api.tools import node as node
+from pyiron_workflow.api.tools import run as run

--- a/src/pyiron_workflow/api/schemas.py
+++ b/src/pyiron_workflow/api/schemas.py
@@ -1,4 +1,5 @@
 from pyiron_workflow.atomic_node import Atomic as Atomic
+from pyiron_workflow.constant import Constant as Constant
 from pyiron_workflow.dag import Macro as Macro
 from pyiron_workflow.datatypes import EdgeTuple as EdgeTuple
 from pyiron_workflow.execution import ExecutorInstructions as ExecutorInstructions


### PR DESCRIPTION
Module root imports come just from the api module, and `Constant` is added to the schema alongside the other node classes.