### PR TITLE
Patch for-loops for zero- and one-length inputs

### DIFF
--- a/src/pyiron_workflow/flowcontrollers/forflow.py
+++ b/src/pyiron_workflow/flowcontrollers/forflow.py
@@ -77,8 +77,16 @@ class ForEach(datatypes.StaticGraph[fr.schemas.ForEachRecipe, fr.schemas.ForEach
         )
         iterated_length_map = {**nested_length_map, **zipped_length_map}
 
+        total_steps = self._calculate_total_steps(nested_length_map, zipped_length_map)
+
+        # An empty iterated port means zero body steps. Scatter nodes would then
+        # need zero outputs, which no atomic recipe can express -- and nothing
+        # would consume them anyway -- so only the aggregators get built, and
+        # they collect nothing into empty lists.
+        scattered_length_map = iterated_length_map if total_steps > 0 else {}
+
         # Scatter nodes
-        for label, length in iterated_length_map.items():
+        for label, length in scattered_length_map.items():
             result_scatter_label = self._scatter_label(label)
             scatter_node = transformers.Transform1toN(length).node(result_scatter_label)
             runtime_map[result_scatter_label] = scatter_node
@@ -86,7 +94,6 @@ class ForEach(datatypes.StaticGraph[fr.schemas.ForEachRecipe, fr.schemas.ForEach
                 scatter_node.generate_flowrep_live_node()
             )
 
-        total_steps = self._calculate_total_steps(nested_length_map, zipped_length_map)
         # Body nodes
         for i in range(total_steps):
             result_body_label = self._body_label(body_label, i)
@@ -113,23 +120,13 @@ class ForEach(datatypes.StaticGraph[fr.schemas.ForEachRecipe, fr.schemas.ForEach
         )
 
         input_edges = {
-            # parent to nested
+            # parent to scatters (nested and zipped alike)
             fr.schemas.TargetHandle(
                 node=self._scatter_label(parent_port),
                 port=transformers.Transform1toN.input_label,
             ): fr.schemas.InputSource(port=parent_port)
-            for child_port, parent_port in nested_label_map.items()
+            for parent_port in scattered_length_map
         }
-        input_edges.update(
-            # parent to zipped
-            {
-                fr.schemas.TargetHandle(
-                    node=self._scatter_label(parent_port),
-                    port=transformers.Transform1toN.input_label,
-                ): fr.schemas.InputSource(port=parent_port)
-                for child_port, parent_port in zipped_label_map.items()
-            }
-        )
         input_edges.update(
             # broadcast input to bodies
             {
@@ -310,6 +307,9 @@ class ForEach(datatypes.StaticGraph[fr.schemas.ForEachRecipe, fr.schemas.ForEach
         zipped ports occupy the innermost dimension (stride 1) and are not
         represented here.
         """
+        if total_steps == 0:
+            return {}  # No body indices exist, so there is nothing to decompose
+
         strides: dict[fr.schemas.Label, int] = {}
         running = total_steps
         for parent_label, length in nested_length_map.items():

--- a/src/pyiron_workflow/transformers.py
+++ b/src/pyiron_workflow/transformers.py
@@ -1,4 +1,5 @@
-from typing import ClassVar
+from collections.abc import Callable
+from typing import Any, ClassVar
 
 import flowrep as fr
 from pyiron_snippets import versions
@@ -17,14 +18,28 @@ class Transform1toN:
     def iterable_to_outputs(items, /):
         return tuple(items)
 
+    @staticmethod
+    def iterable_to_output(items, /):
+        return items[0]
+
     def __init__(self, n: int):
+        if n < 1:
+            raise ValueError(f"Cannot scatter into {n} outputs; need at least 1.")
         self.n = n
+
+    @property
+    def _function(self) -> Callable[[Any], Any]:
+        """
+        A recipe declaring exactly one output receives the whole return value,
+        so a 1-wide scatter must return the element rather than a 1-tuple.
+        """
+        return self.iterable_to_output if self.n == 1 else self.iterable_to_outputs
 
     @property
     def recipe(self) -> fr.schemas.AtomicRecipe:
         return fr.schemas.AtomicRecipe(
             reference=fr.schemas.PythonReference(
-                info=versions.VersionInfo.of(self.iterable_to_outputs),
+                info=versions.VersionInfo.of(self._function),
                 restricted_input_kinds={
                     self.input_label: fr.schemas.RestrictedParamKind.POSITIONAL_ONLY
                 },

--- a/tests/unit/test_foreach.py
+++ b/tests/unit/test_foreach.py
@@ -5,7 +5,7 @@ import unittest
 import flowrep as fr
 from unit import _fixtures
 
-from pyiron_workflow import execution, transformers
+from pyiron_workflow import datatypes, execution, transformers
 from pyiron_workflow.flowcontrollers import forflow
 
 
@@ -204,6 +204,88 @@ class TestBuildRuntimeDagNestedOnly(unittest.TestCase):
             fr.schemas.SourceHandle(
                 node="aggregate_sums",
                 port=transformers.TransformNto1.output_label,
+            ),
+        )
+
+
+class TestBuildRuntimeDagEmptyIteration(unittest.TestCase):
+    """
+    An empty iterated port means zero body steps: no scatters and no bodies are
+    built, and the aggregators collect nothing into empty lists.
+    """
+
+    def setUp(self) -> None:
+        self.cases: dict[str, execution.Run[fr.schemas.ForEachData]] = {}
+        self.nodes: dict[str, datatypes.NodeMap] = {}
+        for name, recipe, inputs in (
+            ("nested", _build_nested_only_recipe(), {"xs": [], "y": 100}),
+            ("zipped", _build_zipped_only_recipe(), {"xs": [], "ys": []}),
+        ):
+            fe = forflow.ForEach(recipe, "fe")
+            dag_run = _prepare_run(fe, inputs)
+            self.cases[name] = dag_run
+            self.nodes[name] = fe._build_runtime_dag(dag_run)
+
+    def test_no_body_or_scatter_nodes(self) -> None:
+        for name, nodes in self.nodes.items():
+            with self.subTest(name):
+                self.assertEqual(
+                    [
+                        label
+                        for label in nodes
+                        if label.startswith(("body_", "scatter_"))
+                    ],
+                    [],
+                )
+
+    def test_aggregator_collects_nothing(self) -> None:
+        for name, nodes in self.nodes.items():
+            with self.subTest(name):
+                self.assertEqual(nodes["aggregate_sums"].recipe.inputs, [])
+
+    def test_no_edges(self) -> None:
+        for name, dag_run in self.cases.items():
+            with self.subTest(name):
+                self.assertEqual(dict(dag_run.result.edges), {})
+                self.assertEqual(dict(dag_run.result.input_edges), {})
+
+    def test_output_still_wired_to_aggregator(self) -> None:
+        for name, dag_run in self.cases.items():
+            with self.subTest(name):
+                self.assertEqual(
+                    dag_run.result.output_edges[fr.schemas.OutputTarget(port="sums")],
+                    fr.schemas.SourceHandle(
+                        node="aggregate_sums",
+                        port=transformers.TransformNto1.output_label,
+                    ),
+                )
+
+
+class TestBuildRuntimeDagSingleNested(unittest.TestCase):
+    """A 1-long iterable still gets a scatter node, so graph shape is uniform."""
+
+    def setUp(self) -> None:
+        self.recipe = _build_nested_only_recipe()
+        self.fe = forflow.ForEach(self.recipe, "fe")
+        self.dag_run = _prepare_run(self.fe, {"xs": [1], "y": 100})
+        self.nodes = self.fe._build_runtime_dag(self.dag_run)
+
+    def test_single_body_node(self) -> None:
+        body_labels = [label for label in self.nodes if label.startswith("body_")]
+        self.assertEqual(body_labels, ["body_0"])
+
+    def test_scatter_declares_one_output(self) -> None:
+        self.assertEqual(self.nodes["scatter_xs"].recipe.outputs, ["output_0"])
+
+    def test_scatter_to_body(self) -> None:
+        src = self.dag_run.result.edges[
+            fr.schemas.TargetHandle(node="body_0", port="x")
+        ]
+        self.assertEqual(
+            src,
+            fr.schemas.SourceHandle(
+                node="scatter_xs",
+                port=transformers.Transform1toN.output_label(0),
             ),
         )
 
@@ -435,6 +517,11 @@ class TestNestedStrides(unittest.TestCase):
     def test_empty(self) -> None:
         self.assertEqual(forflow.ForEach._nested_strides(1, {}), {})
 
+    def test_zero_total_steps(self) -> None:
+        # No body indices exist, so there is nothing to decompose -- and the
+        # naive stride arithmetic would divide by the zero-length port.
+        self.assertEqual(forflow.ForEach._nested_strides(0, {"a": 0, "b": 3}), {})
+
     def test_single_nested(self) -> None:
         self.assertEqual(forflow.ForEach._nested_strides(3, {"a": 3}), {"a": 1})
 
@@ -518,6 +605,75 @@ class TestTransferLabelMap(unittest.TestCase):
 
     def test_empty(self) -> None:
         self.assertEqual(forflow.ForEach._transfer_label_map({}), {})
+
+
+class TestNestedExecutionAcrossLengths(unittest.TestCase):
+    """
+    End-to-end over the degenerate and ordinary length combinations.
+
+    `for_wf(xs, ys, z)` is a doubly-nested loop over `macro`, so it exercises
+    captured outputs (`sums`), transfer outputs (`x_used`, `y_used`) and a
+    broadcast input (`z`) at once.
+    """
+
+    def _run(self, xs: list[int], ys: list[int]) -> dict[str, object]:
+        node = _fixtures.for_wf_node()
+        return dict(execution.run(node, xs=xs, ys=ys, z=1).outputs)
+
+    def test_both_empty(self) -> None:
+        self.assertEqual(self._run([], []), {"x_used": [], "y_used": [], "sums": []})
+
+    def test_empty_inner(self) -> None:
+        self.assertEqual(self._run([10], []), {"x_used": [], "y_used": [], "sums": []})
+
+    def test_empty_outer(self) -> None:
+        self.assertEqual(self._run([], [20]), {"x_used": [], "y_used": [], "sums": []})
+
+    def test_both_singletons(self) -> None:
+        # macro(x, y, z) -> s = (x + y) - z
+        self.assertEqual(
+            self._run([10], [20]),
+            {"x_used": [10], "y_used": [20], "sums": [29]},
+        )
+
+    def test_singleton_outer_multi_inner(self) -> None:
+        self.assertEqual(
+            self._run([10], [20, 30]),
+            {"x_used": [10, 10], "y_used": [20, 30], "sums": [29, 39]},
+        )
+
+    def test_multi_outer_singleton_inner(self) -> None:
+        self.assertEqual(
+            self._run([10, 40], [20]),
+            {"x_used": [10, 40], "y_used": [20, 20], "sums": [29, 59]},
+        )
+
+    def test_both_multi(self) -> None:
+        self.assertEqual(
+            self._run([10, 40], [20, 30]),
+            {
+                "x_used": [10, 10, 40, 40],
+                "y_used": [20, 30, 20, 30],
+                "sums": [29, 39, 59, 69],
+            },
+        )
+
+
+class TestZippedExecutionAcrossLengths(unittest.TestCase):
+    """The same length sweep on the zip axis, where both ports advance together."""
+
+    def _run(self, xs: list[int], ys: list[int]) -> list[int]:
+        fe = forflow.ForEach(_build_zipped_only_recipe(), "fe")
+        return execution.run(fe, xs=xs, ys=ys).outputs.sums
+
+    def test_empty(self) -> None:
+        self.assertEqual(self._run([], []), [])
+
+    def test_singleton(self) -> None:
+        self.assertEqual(self._run([1], [2]), [3])
+
+    def test_multi(self) -> None:
+        self.assertEqual(self._run([1, 2, 3], [10, 20, 30]), [11, 22, 33])
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_transformers.py
+++ b/tests/unit/test_transformers.py
@@ -7,7 +7,7 @@ import unittest
 import flowrep as fr
 from unit import _fixtures
 
-from pyiron_workflow import atomic_node, transformers
+from pyiron_workflow import atomic_node, execution, transformers
 
 
 class TestTransform1toN(unittest.TestCase):
@@ -25,6 +25,9 @@ class TestTransform1toN(unittest.TestCase):
             transformers.Transform1toN.iterable_to_outputs([1, 2, 3]),
             (1, 2, 3),
         )
+
+    def test_iterable_to_output_returns_the_element(self) -> None:
+        self.assertEqual(transformers.Transform1toN.iterable_to_output([7]), 7)
 
     def test_recipe_inputs(self) -> None:
         recipe = transformers.Transform1toN(3).recipe
@@ -48,6 +51,30 @@ class TestTransform1toN(unittest.TestCase):
         self.assertEqual(node.label, "lbl")
         self.assertEqual(node.recipe.inputs, ["items"])
         self.assertEqual(node.recipe.outputs, ["output_0", "output_1", "output_2"])
+
+    def test_single_output_recipe_declares_one_port(self) -> None:
+        self.assertEqual(transformers.Transform1toN(1).recipe.outputs, ["output_0"])
+
+    def test_single_output_does_not_wrap_the_element(self) -> None:
+        """
+        A recipe declaring exactly one output receives the whole return value,
+        so a 1-wide scatter must return the element itself, not a 1-tuple.
+        """
+        node = transformers.Transform1toN(1).node("scatter")
+        self.assertEqual(
+            dict(execution.run(node, items=[42]).outputs), {"output_0": 42}
+        )
+
+    def test_multi_output_still_unpacks(self) -> None:
+        node = transformers.Transform1toN(2).node("scatter")
+        self.assertEqual(
+            dict(execution.run(node, items=[1, 2]).outputs),
+            {"output_0": 1, "output_1": 2},
+        )
+
+    def test_zero_outputs_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "at least 1"):
+            transformers.Transform1toN(0)
 
 
 class TestTransformNto1(unittest.TestCase):


### PR DESCRIPTION
Solves the problem of tuple-like results in length-1 iterables by patching the returns from transformers; handling zero-length input is patched in the for-loop construction of the runtime dag directly.

Closes #915 