### PR TITLE
Don't pin python in the env yamls

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -10,5 +10,6 @@ dependencies:
 - rdflib =7.6.0
 - semantikon =1.4.2
 - typeguard =4.5.2
+- python =3.14
 - python-workflow-definition =0.1.5
 - fleche =0.21.1

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -7,7 +7,6 @@ dependencies:
 - hatch-vcs =0.5.0
 - pint =0.25.3
 - pyiron_snippets =1.4.0
-- python >=3.11,<3.15
 - rdflib =7.6.0
 - semantikon =1.4.2
 - typeguard =4.5.2

--- a/.ci_support/environment-notebook.yml
+++ b/.ci_support/environment-notebook.yml
@@ -1,4 +1,5 @@
 channels:
 - conda-forge
 dependencies:
+- python =3.14
 - python-workflow-definition =0.1.5

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -7,7 +7,6 @@ dependencies:
 - hatch-vcs =0.5.0
 - pint =0.25.3
 - pyiron_snippets =1.4.0
-- python >=3.11,<3.15
 - rdflib =7.6.0
 - semantikon =1.4.2
 - typeguard =4.5.2

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -16,5 +16,6 @@ dependencies:
 - rdflib =7.6.0
 - semantikon =1.4.2
 - typeguard =4.5.2
+- python =3.14
 - python-workflow-definition =0.1.5
 - fleche =0.21.1

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -13,7 +13,6 @@ dependencies:
 - hatch-vcs =0.5.0
 - pint =0.25.3
 - pyiron_snippets =1.4.0
-- python >=3.11,<3.15
 - rdflib =7.6.0
 - semantikon =1.4.2
 - typeguard =4.5.2


### PR DESCRIPTION
Mybinder is hung up on it, and the pyproject.toml and conda feedstock manage pinning python versions for us.